### PR TITLE
VK-133  Add tag skeleton

### DIFF
--- a/frontend/src/components/design-system/containers/TagComponent.vue
+++ b/frontend/src/components/design-system/containers/TagComponent.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import LabelText from '@/components/design-system/typography/LabelText.vue';
+</script>
+
+<template>
+  <LabelText>
+    <slot />
+  </LabelText>
+</template>


### PR DESCRIPTION
Vycházím z toho, že se secondary tag a tag s ikonkou (z Figmy) nikde nepoužívá. Tak nejsou přidané props.