### PR TITLE
VK-201: Make question and response ids stable

### DIFF
--- a/data/kalkulacka/calculators.json
+++ b/data/kalkulacka/calculators.json
@@ -3,230 +3,234 @@
     {
       "id": "senatni-2022",
       "key": "senatni-2022",
-      "name": "senatni-2022",
-      "description": "senatni-2022"
+      "name": "Senátní volby 2022",
+      "description": "Volí se třetina senátních obvodů.",
+      "from": "2022-09-23 14:00",
+      "to": "2022-09-24 14:00"
     },
     {
       "id": "komunalni-2022",
       "key": "komunalni-2022",
-      "name": "komunalni-2022",
-      "description": "komunalni-2022"
+      "name": "Komunální volby 2022",
+      "description": "K dispozici je 35 kalkulaček pro největší města.",
+      "from": "2022-09-23 14:00",
+      "to": "2022-09-24 14:00"
     }
   ],
   "calculators": [
     {
       "election_id": "senatni-2022",
       "district_code": "1",
-      "name": "1",
-      "description": "1 - DESCRIPTION",
+      "name": "Karlovy Vary",
+      "description": "Karlovy Vary",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "4",
-      "name": "4",
-      "description": "4 - DESCRIPTION",
+      "name": "Most",
+      "description": "Most",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "7",
-      "name": "7",
-      "description": "7 - DESCRIPTION",
+      "name": "Plzeň-město",
+      "description": "Plzeň-město",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "10",
-      "name": "10",
-      "description": "10 - DESCRIPTION",
+      "name": "",
+      "description": "",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "13",
-      "name": "13",
-      "description": "13 - DESCRIPTION",
+      "name": "Tábor",
+      "description": "Tábor",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "16",
-      "name": "16",
-      "description": "16 - DESCRIPTION",
+      "name": "Beroun",
+      "description": "Beroun",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "19",
-      "name": "19",
-      "description": "19 - DESCRIPTION",
+      "name": "Praha 11",
+      "description": "Praha 11",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "22",
-      "name": "22",
-      "description": "22 - DESCRIPTION",
+      "name": "Praha 10",
+      "description": "Praha 10",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "25",
-      "name": "25",
-      "description": "25 - DESCRIPTION",
+      "name": "Praha 6",
+      "description": "Praha 6",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "28",
-      "name": "28",
-      "description": "28 - DESCRIPTION",
+      "name": "Mělník",
+      "description": "Mělník",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "31",
-      "name": "31",
-      "description": "31 - DESCRIPTION",
+      "name": "Ústí nad Labem",
+      "description": "Ústí nad Labem",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "34",
-      "name": "34",
-      "description": "34 - DESCRIPTION",
+      "name": "Liberec",
+      "description": "Liberec",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "37",
-      "name": "37",
-      "description": "37 - DESCRIPTION",
+      "name": "Jičín",
+      "description": "Jičín",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "40",
-      "name": "40",
-      "description": "40 - DESCRIPTION",
+      "name": "Kutná Hora",
+      "description": "Kutná Hora",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "43",
-      "name": "43",
-      "description": "43 - DESCRIPTION",
+      "name": "Pardubice",
+      "description": "Pardubice",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "46",
-      "name": "46",
-      "description": "46 - DESCRIPTION",
+      "name": "Ústí nad Orlicí",
+      "description": "Ústí nad Orlicí",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "49",
-      "name": "49",
-      "description": "49 - DESCRIPTION",
+      "name": "Blansko",
+      "description": "Blansko",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "52",
-      "name": "52",
-      "description": "52 - DESCRIPTION",
+      "name": "Jihlava",
+      "description": "Jihlava",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "55",
-      "name": "55",
-      "description": "55 - DESCRIPTION",
+      "name": "Brno-město (55)",
+      "description": "Brno-město (55)",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "58",
-      "name": "58",
-      "description": "58 - DESCRIPTION",
+      "name": "Brno-město (58)",
+      "description": "Brno-město (58)",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "61",
-      "name": "61",
-      "description": "61 - DESCRIPTION",
+      "name": "Olomouc",
+      "description": "Olomouc",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "64",
-      "name": "64",
-      "description": "64 - DESCRIPTION",
+      "name": "Bruntál",
+      "description": "Bruntál",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "67",
-      "name": "67",
-      "description": "67 - DESCRIPTION",
+      "name": "Nový Jičín",
+      "description": "Nový Jičín",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "70",
-      "name": "70",
-      "description": "70 - DESCRIPTION",
+      "name": "Ostrava-město",
+      "description": "Ostrava-město",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "73",
-      "name": "73",
-      "description": "73 - DESCRIPTION",
+      "name": "Frýdek-Místek",
+      "description": "Frýdek-Místek",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "76",
-      "name": "76",
-      "description": "76 - DESCRIPTION",
+      "name": "Kroměříž",
+      "description": "Kroměříž",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
     {
       "election_id": "senatni-2022",
       "district_code": "79",
-      "name": "79",
-      "description": "79 - DESCRIPTION",
+      "name": "Hodonín",
+      "description": "Hodonín",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -234,7 +238,7 @@
       "election_id": "komunalni-2022",
       "district_code": "554782",
       "name": "Praha hl. m.",
-      "description": "Praha hl. m. - DESCRIPTION",
+      "description": "Praha hl. m.",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -242,7 +246,7 @@
       "election_id": "komunalni-2022",
       "district_code": "582786",
       "name": "Brno",
-      "description": "Brno - DESCRIPTION",
+      "description": "Brno",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -250,7 +254,7 @@
       "election_id": "komunalni-2022",
       "district_code": "554821",
       "name": "Ostrava",
-      "description": "Ostrava - DESCRIPTION",
+      "description": "Ostrava",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -258,7 +262,7 @@
       "election_id": "komunalni-2022",
       "district_code": "554791",
       "name": "Plzeň",
-      "description": "Plzeň - DESCRIPTION",
+      "description": "Plzeň",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -266,7 +270,7 @@
       "election_id": "komunalni-2022",
       "district_code": "563889",
       "name": "Liberec",
-      "description": "Liberec - DESCRIPTION",
+      "description": "Liberec",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -274,7 +278,7 @@
       "election_id": "komunalni-2022",
       "district_code": "500496",
       "name": "Olomouc",
-      "description": "Olomouc - DESCRIPTION",
+      "description": "Olomouc",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -282,7 +286,7 @@
       "election_id": "komunalni-2022",
       "district_code": "544256",
       "name": "České Budějovice",
-      "description": "České Budějovice - DESCRIPTION",
+      "description": "České Budějovice",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -290,7 +294,7 @@
       "election_id": "komunalni-2022",
       "district_code": "569810",
       "name": "Hradec Králové",
-      "description": "Hradec Králové - DESCRIPTION",
+      "description": "Hradec Králové",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -298,7 +302,7 @@
       "election_id": "komunalni-2022",
       "district_code": "554804",
       "name": "Ústí nad Labem",
-      "description": "Ústí nad Labem - DESCRIPTION",
+      "description": "Ústí nad Labem",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -306,7 +310,7 @@
       "election_id": "komunalni-2022",
       "district_code": "555134",
       "name": "Pardubice",
-      "description": "Pardubice - DESCRIPTION",
+      "description": "Pardubice",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -314,7 +318,7 @@
       "election_id": "komunalni-2022",
       "district_code": "585068",
       "name": "Zlín",
-      "description": "Zlín - DESCRIPTION",
+      "description": "Zlín",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -322,7 +326,7 @@
       "election_id": "komunalni-2022",
       "district_code": "555088",
       "name": "Havířov",
-      "description": "Havířov - DESCRIPTION",
+      "description": "Havířov",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -330,7 +334,7 @@
       "election_id": "komunalni-2022",
       "district_code": "532053",
       "name": "Kladno",
-      "description": "Kladno - DESCRIPTION",
+      "description": "Kladno",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -338,7 +342,7 @@
       "election_id": "komunalni-2022",
       "district_code": "567027",
       "name": "Most",
-      "description": "Most - DESCRIPTION",
+      "description": "Most",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -346,7 +350,7 @@
       "election_id": "komunalni-2022",
       "district_code": "505927",
       "name": "Opava",
-      "description": "Opava - DESCRIPTION",
+      "description": "Opava",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -354,7 +358,7 @@
       "election_id": "komunalni-2022",
       "district_code": "598003",
       "name": "Frýdek-Místek",
-      "description": "Frýdek-Místek - DESCRIPTION",
+      "description": "Frýdek-Místek",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -362,7 +366,7 @@
       "election_id": "komunalni-2022",
       "district_code": "586846",
       "name": "Jihlava",
-      "description": "Jihlava - DESCRIPTION",
+      "description": "Jihlava",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -370,7 +374,7 @@
       "election_id": "komunalni-2022",
       "district_code": "598917",
       "name": "Karviná",
-      "description": "Karviná - DESCRIPTION",
+      "description": "Karviná",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -378,7 +382,7 @@
       "election_id": "komunalni-2022",
       "district_code": "567442",
       "name": "Teplice",
-      "description": "Teplice - DESCRIPTION",
+      "description": "Teplice",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -386,7 +390,7 @@
       "election_id": "komunalni-2022",
       "district_code": "562971",
       "name": "Chomutov",
-      "description": "Chomutov - DESCRIPTION",
+      "description": "Chomutov",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -394,7 +398,7 @@
       "election_id": "komunalni-2022",
       "district_code": "554961",
       "name": "Karlovy Vary",
-      "description": "Karlovy Vary - DESCRIPTION",
+      "description": "Karlovy Vary",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -402,7 +406,7 @@
       "election_id": "komunalni-2022",
       "district_code": "562335",
       "name": "Děčín",
-      "description": "Děčín - DESCRIPTION",
+      "description": "Děčín",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -410,7 +414,7 @@
       "election_id": "komunalni-2022",
       "district_code": "563510",
       "name": "Jablonec nad Nisou",
-      "description": "Jablonec nad Nisou - DESCRIPTION",
+      "description": "Jablonec nad Nisou",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -418,7 +422,7 @@
       "election_id": "komunalni-2022",
       "district_code": "535419",
       "name": "Mladá Boleslav",
-      "description": "Mladá Boleslav - DESCRIPTION",
+      "description": "Mladá Boleslav",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -426,7 +430,7 @@
       "election_id": "komunalni-2022",
       "district_code": "589250",
       "name": "Prostějov",
-      "description": "Prostějov - DESCRIPTION",
+      "description": "Prostějov",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -434,7 +438,7 @@
       "election_id": "komunalni-2022",
       "district_code": "511382",
       "name": "Přerov",
-      "description": "Přerov - DESCRIPTION",
+      "description": "Přerov",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -442,7 +446,7 @@
       "election_id": "komunalni-2022",
       "district_code": "561380",
       "name": "Česká Lípa",
-      "description": "Česká Lípa - DESCRIPTION",
+      "description": "Česká Lípa",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -450,7 +454,7 @@
       "election_id": "komunalni-2022",
       "district_code": "590266",
       "name": "Třebíč",
-      "description": "Třebíč - DESCRIPTION",
+      "description": "Třebíč",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -458,7 +462,7 @@
       "election_id": "komunalni-2022",
       "district_code": "598810",
       "name": "Třinec",
-      "description": "Třinec - DESCRIPTION",
+      "description": "Třinec",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -466,7 +470,7 @@
       "election_id": "komunalni-2022",
       "district_code": "552046",
       "name": "Tábor",
-      "description": "Tábor - DESCRIPTION",
+      "description": "Tábor",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -474,7 +478,7 @@
       "election_id": "komunalni-2022",
       "district_code": "593711",
       "name": "Znojmo",
-      "description": "Znojmo - DESCRIPTION",
+      "description": "Znojmo",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -482,7 +486,7 @@
       "election_id": "komunalni-2022",
       "district_code": "533165",
       "name": "Kolín",
-      "description": "Kolín - DESCRIPTION",
+      "description": "Kolín",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -490,7 +494,7 @@
       "election_id": "komunalni-2022",
       "district_code": "539911",
       "name": "Příbram",
-      "description": "Příbram - DESCRIPTION",
+      "description": "Příbram",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -498,7 +502,7 @@
       "election_id": "komunalni-2022",
       "district_code": "554481",
       "name": "Cheb",
-      "description": "Cheb - DESCRIPTION",
+      "description": "Cheb",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     },
@@ -506,7 +510,7 @@
       "election_id": "komunalni-2022",
       "district_code": "549240",
       "name": "Písek",
-      "description": "Písek - DESCRIPTION",
+      "description": "Písek",
       "on_hp_from": "2021-01-01",
       "on_hp_to": "2031-01-01"
     }

--- a/data/kalkulacka/komunalni-2022/500496.json
+++ b/data/kalkulacka/komunalni-2022/500496.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-500496",
   "name": "Olomouc",
-  "description": "Olomouc - DESCRIPTION",
+  "description": "Olomouc",
   "district_code": "500496",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-500496-question-1",
+      "id": "komunalni-2022-500496-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-2",
+      "id": "komunalni-2022-500496-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-3",
+      "id": "komunalni-2022-500496-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-4",
+      "id": "komunalni-2022-500496-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-5",
+      "id": "komunalni-2022-500496-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-6",
+      "id": "komunalni-2022-500496-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-7",
+      "id": "komunalni-2022-500496-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-8",
+      "id": "komunalni-2022-500496-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-9",
+      "id": "komunalni-2022-500496-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-10",
+      "id": "komunalni-2022-500496-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-11",
+      "id": "komunalni-2022-500496-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-12",
+      "id": "komunalni-2022-500496-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-13",
+      "id": "komunalni-2022-500496-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-14",
+      "id": "komunalni-2022-500496-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-15",
+      "id": "komunalni-2022-500496-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-16",
+      "id": "komunalni-2022-500496-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-17",
+      "id": "komunalni-2022-500496-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-18",
+      "id": "komunalni-2022-500496-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-19",
+      "id": "komunalni-2022-500496-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-20",
+      "id": "komunalni-2022-500496-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-21",
+      "id": "komunalni-2022-500496-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-22",
+      "id": "komunalni-2022-500496-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-23",
+      "id": "komunalni-2022-500496-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-24",
+      "id": "komunalni-2022-500496-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-25",
+      "id": "komunalni-2022-500496-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-26",
+      "id": "komunalni-2022-500496-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-27",
+      "id": "komunalni-2022-500496-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-28",
+      "id": "komunalni-2022-500496-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-29",
+      "id": "komunalni-2022-500496-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-30",
+      "id": "komunalni-2022-500496-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-31",
+      "id": "komunalni-2022-500496-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-32",
+      "id": "komunalni-2022-500496-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-33",
+      "id": "komunalni-2022-500496-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-34",
+      "id": "komunalni-2022-500496-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-35",
+      "id": "komunalni-2022-500496-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-36",
+      "id": "komunalni-2022-500496-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-37",
+      "id": "komunalni-2022-500496-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-38",
+      "id": "komunalni-2022-500496-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-39",
+      "id": "komunalni-2022-500496-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-40",
+      "id": "komunalni-2022-500496-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-41",
+      "id": "komunalni-2022-500496-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-42",
+      "id": "komunalni-2022-500496-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-43",
+      "id": "komunalni-2022-500496-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-44",
+      "id": "komunalni-2022-500496-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-45",
+      "id": "komunalni-2022-500496-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-46",
+      "id": "komunalni-2022-500496-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-47",
+      "id": "komunalni-2022-500496-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-48",
+      "id": "komunalni-2022-500496-q-48",
       "name": "Investice do chodníků",
       "title": "Podporuji vyšší investice do obnovy chodníků a dalších místních komunikací.",
       "gist": "",
@@ -395,7 +397,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-49",
+      "id": "komunalni-2022-500496-q-49",
       "name": "Městský architekt",
       "title": "Olomouc má mít svého městského architekta na částečný úvazek",
       "gist": "Pozice městského architekta není obsazena už mnoho let. Kritici namítají, že město místo něj hledá jen úředníka s omezenými pravomocemi. Útvar hlavního architekta má podle nich být plnohodnotné a samostatné koncepční pracoviště v přímém partnerství rady nebo primátora.",
@@ -403,7 +405,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-50",
+      "id": "komunalni-2022-500496-q-50",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -411,7 +413,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-51",
+      "id": "komunalni-2022-500496-q-51",
       "name": "Pomoc se sociálními dávkami",
       "title": "Olomouc má zřídit kontaktní místo pro bydlení",
       "gist": "Zastánci říkají, že mají dostat všechny potřebné informace i ti, kteří nevyužívají sociální služby. Například senioři často nečerpají dávky navázané na bydlení, protože o nich nevědí. Kritici to považují za zbytečné.",
@@ -419,7 +421,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-52",
+      "id": "komunalni-2022-500496-q-52",
       "name": "Další cyklostezky",
       "title": "Město má vystavět cyklostezky do Topolan a Chomoutova",
       "gist": "",
@@ -427,7 +429,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-53",
+      "id": "komunalni-2022-500496-q-53",
       "name": "Online portál města",
       "title": "Městský online portál by měl fungovat jako e-shop.",
       "gist": "Občané a občanky musí mít možnost vyřídit maximum záležitostí online, nikoli trávit čas obíháním úřadů.",
@@ -435,7 +437,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-54",
+      "id": "komunalni-2022-500496-q-54",
       "name": "Druhá ledová plocha",
       "title": "Podporuji vybudování druhého kluziště dostupného pro veřejnost.",
       "gist": "",
@@ -443,7 +445,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-55",
+      "id": "komunalni-2022-500496-q-55",
       "name": "Multifunkční sportovní hala",
       "title": "Město by mělo mít novou multifunkční sportovní halu.",
       "gist": "",
@@ -451,7 +453,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-500496-question-56",
+      "id": "komunalni-2022-500496-q-56",
       "name": "Demontáž laviček",
       "title": "Souhlasím s tím, aby město demontovalo lavičky obsazované lidmi bez domova.",
       "gist": "",
@@ -461,10 +463,11 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-500496-candidate-742711",
+      "id": "komunalni-2022-500496-c-742711",
       "name": "SDRUŽENÍ PRO REPUBLIKU - REPUBLIKÁNSKÁ STRANA ČECH, MORAVY A SLEZSKA",
       "type": "party",
       "description": "SDRUŽENÍ PRO REPUBLIKU - REPUBLIKÁNSKÁ STRANA ČECH, MORAVY A SLEZSKA - DESCRIPTION",
+      "img_url": "spr-rsčms",
       "contacts": {
         "web": [
           {
@@ -475,7 +478,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-500496-742711-party",
+          "id": "komunalni-2022-500496-c-742711-p",
           "name": "SDRUŽENÍ PRO REPUBLIKU - REPUBLIKÁNSKÁ STRANA ČECH, MORAVY A SLEZSKA",
           "description": "SDRUŽENÍ PRO REPUBLIKU - REPUBLIKÁNSKÁ STRANA ČECH, MORAVY A SLEZSKA - DESCRIPTION",
           "contacts": {
@@ -491,10 +494,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-500496-candidate-527249",
+      "id": "komunalni-2022-500496-c-527249",
       "name": "STAN, ZELENÍ A NEZÁVISLÉ OLOMOUCKÉ OSOBNOSTI",
       "type": "party",
       "description": "STAN, ZELENÍ A NEZÁVISLÉ OLOMOUCKÉ OSOBNOSTI - DESCRIPTION",
+      "img_url": "zelení-stan",
       "contacts": {
         "web": [
           {
@@ -505,7 +509,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-500496-527249-party",
+          "id": "komunalni-2022-500496-c-527249-p",
           "name": "STAN, ZELENÍ A NEZÁVISLÉ OLOMOUCKÉ OSOBNOSTI",
           "description": "STAN, ZELENÍ A NEZÁVISLÉ OLOMOUCKÉ OSOBNOSTI - DESCRIPTION",
           "contacts": {
@@ -521,16 +525,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-500496-candidate-918243",
+      "id": "komunalni-2022-500496-c-918243",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-500496-918243-party",
+          "id": "komunalni-2022-500496-c-918243-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -541,10 +546,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-500496-candidate-412729",
+      "id": "komunalni-2022-500496-c-412729",
       "name": "spOLečně",
       "type": "party",
       "description": "spOLečně - DESCRIPTION",
+      "img_url": "spol",
       "contacts": {
         "web": [
           {
@@ -555,7 +561,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-500496-412729-party",
+          "id": "komunalni-2022-500496-c-412729-p",
           "name": "spOLečně",
           "description": "spOLečně - DESCRIPTION",
           "contacts": {
@@ -571,10 +577,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-500496-candidate-588378",
+      "id": "komunalni-2022-500496-c-588378",
       "name": "ProOlomouc a Piráti",
       "type": "party",
       "description": "ProOlomouc a Piráti - DESCRIPTION",
+      "img_url": "piráti-prool",
       "contacts": {
         "web": [
           {
@@ -585,7 +592,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-500496-588378-party",
+          "id": "komunalni-2022-500496-c-588378-p",
           "name": "ProOlomouc a Piráti",
           "description": "ProOlomouc a Piráti - DESCRIPTION",
           "contacts": {
@@ -601,10 +608,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-500496-candidate-704728",
+      "id": "komunalni-2022-500496-c-704728",
       "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
       "type": "party",
       "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
+      "img_url": "přísaha",
       "contacts": {
         "web": [
           {
@@ -615,7 +623,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-500496-704728-party",
+          "id": "komunalni-2022-500496-c-704728-p",
           "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
           "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
           "contacts": {
@@ -631,16 +639,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-500496-candidate-538203",
+      "id": "komunalni-2022-500496-c-538203",
       "name": "Olomoučané",
       "type": "party",
       "description": "Olomoučané - DESCRIPTION",
+      "img_url": "čssd-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-500496-538203-party",
+          "id": "komunalni-2022-500496-c-538203-p",
           "name": "Olomoučané",
           "description": "Olomoučané - DESCRIPTION",
           "contacts": {
@@ -651,16 +660,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-500496-candidate-906275",
+      "id": "komunalni-2022-500496-c-906275",
       "name": "Svobodní, Soukromníci, Koruna Česká, Konzervativní strana",
       "type": "party",
       "description": "Svobodní, Soukromníci, Koruna Česká, Konzervativní strana - DESCRIPTION",
+      "img_url": "konsmonsvobsouk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-500496-906275-party",
+          "id": "komunalni-2022-500496-c-906275-p",
           "name": "Svobodní, Soukromníci, Koruna Česká, Konzervativní strana",
           "description": "Svobodní, Soukromníci, Koruna Česká, Konzervativní strana - DESCRIPTION",
           "contacts": {
@@ -671,10 +681,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-500496-candidate-120992",
+      "id": "komunalni-2022-500496-c-120992",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": [
           {
@@ -685,7 +696,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-500496-120992-party",
+          "id": "komunalni-2022-500496-c-120992-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -701,10 +712,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-500496-candidate-241472",
+      "id": "komunalni-2022-500496-c-241472",
       "name": "SPOLU",
       "type": "party",
       "description": "SPOLU - DESCRIPTION",
+      "img_url": "kdu-ods-top 09",
       "contacts": {
         "web": [
           {
@@ -720,7 +732,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-500496-241472-party",
+          "id": "komunalni-2022-500496-c-241472-p",
           "name": "SPOLU",
           "description": "SPOLU - DESCRIPTION",
           "contacts": {
@@ -741,16 +753,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-500496-candidate-389711",
+      "id": "komunalni-2022-500496-c-389711",
       "name": "SPD a Trikolora",
       "type": "party",
       "description": "SPD a Trikolora - DESCRIPTION",
+      "img_url": "spd-trikolora",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-500496-389711-party",
+          "id": "komunalni-2022-500496-c-389711-p",
           "name": "SPD a Trikolora",
           "description": "SPD a Trikolora - DESCRIPTION",
           "contacts": {
@@ -763,681 +776,681 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-500496-answer-120992-1",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-1",
+      "id": "komunalni-2022-500496-a-4",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-2",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-2",
+      "id": "komunalni-2022-500496-a-7",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-2",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-3",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-3",
+      "id": "komunalni-2022-500496-a-10",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-4",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-4",
+      "id": "komunalni-2022-500496-a-13",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-5",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-5",
+      "id": "komunalni-2022-500496-a-16",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-6",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-6",
+      "id": "komunalni-2022-500496-a-19",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-7",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-7",
+      "id": "komunalni-2022-500496-a-22",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-8",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-8",
+      "id": "komunalni-2022-500496-a-25",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-8",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-9",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-9",
+      "id": "komunalni-2022-500496-a-28",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-10",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-10",
+      "id": "komunalni-2022-500496-a-31",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-11",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-11",
+      "id": "komunalni-2022-500496-a-34",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-12",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-12",
+      "id": "komunalni-2022-500496-a-37",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-13",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-13",
+      "id": "komunalni-2022-500496-a-40",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-14",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-14",
+      "id": "komunalni-2022-500496-a-43",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-15",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-15",
+      "id": "komunalni-2022-500496-a-46",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-15",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-16",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-16",
+      "id": "komunalni-2022-500496-a-49",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-16",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-17",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-17",
+      "id": "komunalni-2022-500496-a-52",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-18",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-18",
+      "id": "komunalni-2022-500496-a-55",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-19",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-19",
+      "id": "komunalni-2022-500496-a-58",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-20",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-20",
+      "id": "komunalni-2022-500496-a-61",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-21",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-21",
+      "id": "komunalni-2022-500496-a-64",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-22",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-22",
+      "id": "komunalni-2022-500496-a-67",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-22",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-23",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-23"
+      "id": "komunalni-2022-500496-a-70",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-23"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-24",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-24",
+      "id": "komunalni-2022-500496-a-73",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-25",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-25",
+      "id": "komunalni-2022-500496-a-76",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-26",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-26",
+      "id": "komunalni-2022-500496-a-79",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-27",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-27",
+      "id": "komunalni-2022-500496-a-82",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-28",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-28",
+      "id": "komunalni-2022-500496-a-85",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-28",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-29",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-29",
+      "id": "komunalni-2022-500496-a-88",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-30",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-30"
+      "id": "komunalni-2022-500496-a-91",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-30"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-31",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-31",
+      "id": "komunalni-2022-500496-a-94",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-32",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-32",
+      "id": "komunalni-2022-500496-a-97",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-33",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-33",
+      "id": "komunalni-2022-500496-a-100",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-34",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-34",
+      "id": "komunalni-2022-500496-a-103",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-35",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-35"
+      "id": "komunalni-2022-500496-a-106",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-35"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-36",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-36"
+      "id": "komunalni-2022-500496-a-109",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-36"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-37",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-37",
+      "id": "komunalni-2022-500496-a-112",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-38",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-38",
+      "id": "komunalni-2022-500496-a-115",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-39",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-39"
+      "id": "komunalni-2022-500496-a-118",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-39"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-40",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-40",
+      "id": "komunalni-2022-500496-a-121",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-41",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-41",
+      "id": "komunalni-2022-500496-a-124",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-42",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-42",
+      "id": "komunalni-2022-500496-a-127",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-43",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-43"
+      "id": "komunalni-2022-500496-a-130",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-43"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-44",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-44",
+      "id": "komunalni-2022-500496-a-133",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-44",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-45",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-45",
+      "id": "komunalni-2022-500496-a-136",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-46",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-46",
+      "id": "komunalni-2022-500496-a-139",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-47",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-47",
+      "id": "komunalni-2022-500496-a-142",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-47",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-48",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-48",
+      "id": "komunalni-2022-500496-a-145",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-49",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-49",
+      "id": "komunalni-2022-500496-a-148",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-49",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-50",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-50",
+      "id": "komunalni-2022-500496-a-151",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-50",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-51",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-51"
+      "id": "komunalni-2022-500496-a-154",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-51"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-52",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-52",
+      "id": "komunalni-2022-500496-a-157",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-52",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-53",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-53"
+      "id": "komunalni-2022-500496-a-160",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-53"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-54",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-54",
+      "id": "komunalni-2022-500496-a-163",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-54",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-55",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-55"
+      "id": "komunalni-2022-500496-a-166",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-55"
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-56",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-56",
+      "id": "komunalni-2022-500496-a-169",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-56",
       "answer": "no",
       "comment": "Je potřeba najít jiné řešení."
     },
     {
-      "id": "komunalni-2022-500496-answer-120992-57",
-      "candidate_id": "komunalni-2022-500496-candidate-120992",
-      "question_id": "komunalni-2022-500496-question-57"
+      "id": "komunalni-2022-500496-a-172",
+      "candidate_id": "komunalni-2022-500496-c-120992",
+      "question_id": "komunalni-2022-500496-q-57"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-1",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-1"
+      "id": "komunalni-2022-500496-a-4",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-1"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-2",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-2",
+      "id": "komunalni-2022-500496-a-7",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-2",
       "answer": "yes",
       "comment": "Ne nutně stejným způsobem jako dnes."
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-3",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-3",
+      "id": "komunalni-2022-500496-a-10",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-4",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-4",
+      "id": "komunalni-2022-500496-a-13",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-5",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-5",
+      "id": "komunalni-2022-500496-a-16",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-6",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-6",
+      "id": "komunalni-2022-500496-a-19",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-6",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-7",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-7",
+      "id": "komunalni-2022-500496-a-22",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-7",
       "answer": "no",
       "comment": "Pro město jde o významný zdroj příjmů."
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-8",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-8",
+      "id": "komunalni-2022-500496-a-25",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-8",
       "answer": "no",
       "comment": "Bylo by to krásné, ale z finančních důvodů není možné."
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-9",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-9",
+      "id": "komunalni-2022-500496-a-28",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-10",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-10",
+      "id": "komunalni-2022-500496-a-31",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-11",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-11",
+      "id": "komunalni-2022-500496-a-34",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-12",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-12",
+      "id": "komunalni-2022-500496-a-37",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-12",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-13",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-13",
+      "id": "komunalni-2022-500496-a-40",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-14",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-14",
+      "id": "komunalni-2022-500496-a-43",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-15",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-15",
+      "id": "komunalni-2022-500496-a-46",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-15",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-16",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-16",
+      "id": "komunalni-2022-500496-a-49",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-17",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-17",
+      "id": "komunalni-2022-500496-a-52",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-18",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-18",
+      "id": "komunalni-2022-500496-a-55",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-19",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-19",
+      "id": "komunalni-2022-500496-a-58",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-20",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-20",
+      "id": "komunalni-2022-500496-a-61",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-21",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-21"
+      "id": "komunalni-2022-500496-a-64",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-21"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-22",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-22",
+      "id": "komunalni-2022-500496-a-67",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-22",
       "answer": "yes",
       "comment": "Na základě jasných kritérií."
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-23",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-23",
+      "id": "komunalni-2022-500496-a-70",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-23",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-24",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-24",
+      "id": "komunalni-2022-500496-a-73",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-25",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-25",
+      "id": "komunalni-2022-500496-a-76",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-26",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-26",
+      "id": "komunalni-2022-500496-a-79",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-27",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-27",
+      "id": "komunalni-2022-500496-a-82",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-27",
       "answer": "yes",
       "comment": "Všechny druhy dopravy by měly být rovnoprávné."
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-28",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-28",
+      "id": "komunalni-2022-500496-a-85",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-29",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-29",
+      "id": "komunalni-2022-500496-a-88",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-29",
       "answer": "yes",
       "comment": "Je nutné, aby developer vybudoval i občanskou vybavenost."
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-30",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-30",
+      "id": "komunalni-2022-500496-a-91",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-31",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-31",
+      "id": "komunalni-2022-500496-a-94",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-32",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-32",
+      "id": "komunalni-2022-500496-a-97",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-33",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-33",
+      "id": "komunalni-2022-500496-a-100",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-34",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-34",
+      "id": "komunalni-2022-500496-a-103",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-35",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-35",
+      "id": "komunalni-2022-500496-a-106",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-36",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-36"
+      "id": "komunalni-2022-500496-a-109",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-36"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-37",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-37",
+      "id": "komunalni-2022-500496-a-112",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-38",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-38",
+      "id": "komunalni-2022-500496-a-115",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-39",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-39",
+      "id": "komunalni-2022-500496-a-118",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-40",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-40",
+      "id": "komunalni-2022-500496-a-121",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-40",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-41",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-41",
+      "id": "komunalni-2022-500496-a-124",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-42",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-42",
+      "id": "komunalni-2022-500496-a-127",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-43",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-43"
+      "id": "komunalni-2022-500496-a-130",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-43"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-44",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-44",
+      "id": "komunalni-2022-500496-a-133",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-45",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-45",
+      "id": "komunalni-2022-500496-a-136",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-45",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-46",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-46",
+      "id": "komunalni-2022-500496-a-139",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-47",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-47",
+      "id": "komunalni-2022-500496-a-142",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-48",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-48",
+      "id": "komunalni-2022-500496-a-145",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-49",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-49",
+      "id": "komunalni-2022-500496-a-148",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-49",
       "answer": "yes",
       "comment": "Městský architekt by měl být na plný úvazek."
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-50",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-50",
+      "id": "komunalni-2022-500496-a-151",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-50",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-51",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-51",
+      "id": "komunalni-2022-500496-a-154",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-51",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-52",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-52",
+      "id": "komunalni-2022-500496-a-157",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-52",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-53",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-53",
+      "id": "komunalni-2022-500496-a-160",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-53",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-54",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-54",
+      "id": "komunalni-2022-500496-a-163",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-54",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-55",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-55",
+      "id": "komunalni-2022-500496-a-166",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-55",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-56",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-56",
+      "id": "komunalni-2022-500496-a-169",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-56",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-500496-answer-588378-57",
-      "candidate_id": "komunalni-2022-500496-candidate-588378",
-      "question_id": "komunalni-2022-500496-question-57"
+      "id": "komunalni-2022-500496-a-172",
+      "candidate_id": "komunalni-2022-500496-c-588378",
+      "question_id": "komunalni-2022-500496-q-57"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/505927.json
+++ b/data/kalkulacka/komunalni-2022/505927.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-505927",
   "name": "Opava",
-  "description": "Opava - DESCRIPTION",
+  "description": "Opava",
   "district_code": "505927",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-505927-question-1",
+      "id": "komunalni-2022-505927-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-2",
+      "id": "komunalni-2022-505927-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-3",
+      "id": "komunalni-2022-505927-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-4",
+      "id": "komunalni-2022-505927-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-5",
+      "id": "komunalni-2022-505927-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-6",
+      "id": "komunalni-2022-505927-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-7",
+      "id": "komunalni-2022-505927-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-8",
+      "id": "komunalni-2022-505927-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-9",
+      "id": "komunalni-2022-505927-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-10",
+      "id": "komunalni-2022-505927-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-11",
+      "id": "komunalni-2022-505927-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-12",
+      "id": "komunalni-2022-505927-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-13",
+      "id": "komunalni-2022-505927-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-14",
+      "id": "komunalni-2022-505927-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-15",
+      "id": "komunalni-2022-505927-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-16",
+      "id": "komunalni-2022-505927-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-17",
+      "id": "komunalni-2022-505927-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-18",
+      "id": "komunalni-2022-505927-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-19",
+      "id": "komunalni-2022-505927-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-20",
+      "id": "komunalni-2022-505927-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-21",
+      "id": "komunalni-2022-505927-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-22",
+      "id": "komunalni-2022-505927-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-23",
+      "id": "komunalni-2022-505927-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-24",
+      "id": "komunalni-2022-505927-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-25",
+      "id": "komunalni-2022-505927-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-26",
+      "id": "komunalni-2022-505927-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-27",
+      "id": "komunalni-2022-505927-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-28",
+      "id": "komunalni-2022-505927-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-29",
+      "id": "komunalni-2022-505927-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-30",
+      "id": "komunalni-2022-505927-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-31",
+      "id": "komunalni-2022-505927-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-32",
+      "id": "komunalni-2022-505927-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-33",
+      "id": "komunalni-2022-505927-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-34",
+      "id": "komunalni-2022-505927-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-35",
+      "id": "komunalni-2022-505927-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-36",
+      "id": "komunalni-2022-505927-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-37",
+      "id": "komunalni-2022-505927-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-38",
+      "id": "komunalni-2022-505927-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-39",
+      "id": "komunalni-2022-505927-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-40",
+      "id": "komunalni-2022-505927-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-41",
+      "id": "komunalni-2022-505927-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-42",
+      "id": "komunalni-2022-505927-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-43",
+      "id": "komunalni-2022-505927-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-44",
+      "id": "komunalni-2022-505927-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-45",
+      "id": "komunalni-2022-505927-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-46",
+      "id": "komunalni-2022-505927-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-47",
+      "id": "komunalni-2022-505927-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-505927-question-48",
+      "id": "komunalni-2022-505927-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,17 +399,18 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-505927-candidate-724202",
+      "id": "komunalni-2022-505927-c-724202",
       "name": "Občané městských částí Opavy",
       "type": "party",
       "description": "Občané městských částí Opavy - DESCRIPTION",
+      "img_url": "omčo",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/obcaneopavy"
       },
       "parties": [
         {
-          "id": "komunalni-2022-505927-724202-party",
+          "id": "komunalni-2022-505927-c-724202-p",
           "name": "Občané městských částí Opavy",
           "description": "Občané městských částí Opavy - DESCRIPTION",
           "contacts": {
@@ -419,16 +422,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-505927-candidate-583572",
+      "id": "komunalni-2022-505927-c-583572",
       "name": "Demokratická strana zelených – ZA PRÁVA ZVÍŘAT — sdružení DSZ – ZA PRÁVA ZVÍŘAT a NK",
       "type": "party",
       "description": "Demokratická strana zelených – ZA PRÁVA ZVÍŘAT — sdružení DSZ – ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+      "img_url": "dsz-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-505927-583572-party",
+          "id": "komunalni-2022-505927-c-583572-p",
           "name": "Demokratická strana zelených – ZA PRÁVA ZVÍŘAT — sdružení DSZ – ZA PRÁVA ZVÍŘAT a NK",
           "description": "Demokratická strana zelených – ZA PRÁVA ZVÍŘAT — sdružení DSZ – ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
           "contacts": {
@@ -439,16 +443,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-505927-candidate-306338",
+      "id": "komunalni-2022-505927-c-306338",
       "name": "Česká strana sociálně demokratická",
       "type": "party",
       "description": "Česká strana sociálně demokratická - DESCRIPTION",
+      "img_url": "čssd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-505927-306338-party",
+          "id": "komunalni-2022-505927-c-306338-p",
           "name": "Česká strana sociálně demokratická",
           "description": "Česká strana sociálně demokratická - DESCRIPTION",
           "contacts": {
@@ -459,17 +464,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-505927-candidate-922382",
+      "id": "komunalni-2022-505927-c-922382",
       "name": "Společně pro Opavu (ODS, TOP 09)",
       "type": "party",
       "description": "Společně pro Opavu (ODS, TOP 09) - DESCRIPTION",
+      "img_url": "ods-top 09",
       "contacts": {
         "web": [],
         "instagram": "https://instagram.com/spolecneproopavu?igshid=YmMyMTA2M2Y="
       },
       "parties": [
         {
-          "id": "komunalni-2022-505927-922382-party",
+          "id": "komunalni-2022-505927-c-922382-p",
           "name": "Společně pro Opavu (ODS, TOP 09)",
           "description": "Společně pro Opavu (ODS, TOP 09) - DESCRIPTION",
           "contacts": {
@@ -481,16 +487,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-505927-candidate-466013",
+      "id": "komunalni-2022-505927-c-466013",
       "name": "Změna pro Opavu",
       "type": "party",
       "description": "Změna pro Opavu - DESCRIPTION",
+      "img_url": "změna-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-505927-466013-party",
+          "id": "komunalni-2022-505927-c-466013-p",
           "name": "Změna pro Opavu",
           "description": "Změna pro Opavu - DESCRIPTION",
           "contacts": {
@@ -501,16 +508,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-505927-candidate-898202",
+      "id": "komunalni-2022-505927-c-898202",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-505927-898202-party",
+          "id": "komunalni-2022-505927-c-898202-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -521,16 +529,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-505927-candidate-110955",
+      "id": "komunalni-2022-505927-c-110955",
       "name": "KDU-ČSL",
       "type": "party",
       "description": "KDU-ČSL - DESCRIPTION",
+      "img_url": "kdu-čsl",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-505927-110955-party",
+          "id": "komunalni-2022-505927-c-110955-p",
           "name": "KDU-ČSL",
           "description": "KDU-ČSL - DESCRIPTION",
           "contacts": {
@@ -541,16 +550,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-505927-candidate-319917",
+      "id": "komunalni-2022-505927-c-319917",
       "name": "Trikolora",
       "type": "party",
       "description": "Trikolora - DESCRIPTION",
+      "img_url": "trikolora",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-505927-319917-party",
+          "id": "komunalni-2022-505927-c-319917-p",
           "name": "Trikolora",
           "description": "Trikolora - DESCRIPTION",
           "contacts": {
@@ -561,16 +571,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-505927-candidate-736919",
+      "id": "komunalni-2022-505927-c-736919",
       "name": "Piráti & Opavané",
       "type": "party",
       "description": "Piráti & Opavané - DESCRIPTION",
+      "img_url": "piráti-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-505927-736919-party",
+          "id": "komunalni-2022-505927-c-736919-p",
           "name": "Piráti & Opavané",
           "description": "Piráti & Opavané - DESCRIPTION",
           "contacts": {
@@ -581,10 +592,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-505927-candidate-496785",
+      "id": "komunalni-2022-505927-c-496785",
       "name": "Zelená pro Opavu",
       "type": "party",
       "description": "Zelená pro Opavu - DESCRIPTION",
+      "img_url": "zelení-nk",
       "contacts": {
         "web": [
           {
@@ -599,7 +611,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-505927-496785-party",
+          "id": "komunalni-2022-505927-c-496785-p",
           "name": "Zelená pro Opavu",
           "description": "Zelená pro Opavu - DESCRIPTION",
           "contacts": {
@@ -619,16 +631,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-505927-candidate-890740",
+      "id": "komunalni-2022-505927-c-890740",
       "name": "NEZÁVISLÍ pro OPAVU",
       "type": "party",
       "description": "NEZÁVISLÍ pro OPAVU - DESCRIPTION",
+      "img_url": "nez-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-505927-890740-party",
+          "id": "komunalni-2022-505927-c-890740-p",
           "name": "NEZÁVISLÍ pro OPAVU",
           "description": "NEZÁVISLÍ pro OPAVU - DESCRIPTION",
           "contacts": {
@@ -639,16 +652,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-505927-candidate-723812",
+      "id": "komunalni-2022-505927-c-723812",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-505927-723812-party",
+          "id": "komunalni-2022-505927-c-723812-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -659,16 +673,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-505927-candidate-316973",
+      "id": "komunalni-2022-505927-c-316973",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-505927-316973-party",
+          "id": "komunalni-2022-505927-c-316973-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -679,16 +694,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-505927-candidate-262054",
+      "id": "komunalni-2022-505927-c-262054",
       "name": "VOLNÝ blok",
       "type": "party",
       "description": "VOLNÝ blok - DESCRIPTION",
+      "img_url": "volný blok",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-505927-262054-party",
+          "id": "komunalni-2022-505927-c-262054-p",
           "name": "VOLNÝ blok",
           "description": "VOLNÝ blok - DESCRIPTION",
           "contacts": {
@@ -701,329 +717,329 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-505927-answer-466013-1",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-1",
+      "id": "komunalni-2022-505927-a-4",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-1",
       "answer": "no",
       "comment": "Nevidím důvod v to aby někde bydleli bohatí a jinde chudí. Navíc v Opavě pro to není ani prostředí ani důvod."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-2",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-2",
+      "id": "komunalni-2022-505927-a-7",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-2",
       "answer": "yes",
       "comment": "Poplatek za svoz odpadu je jedna z mála daní, jež město vybírá. Nespravedlivost vzniká u těch, kteří poctivě třídí, (mají tedy menší objem komunálního nevytříděného odpadu) a přitom je výše jejich poplatku stejná jako u těch kdo na třídění ani nepomyslí. S tímto je nutné co nejrychleji něco udělat a poctivé třídiče zvýhodnit a ty ostatní tak motivovat ke změně chování.  "
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-3",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-3",
+      "id": "komunalni-2022-505927-a-10",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-3",
       "answer": "no",
       "comment": "Je nutná regulace v jednotlivých bytech, aby jediná obrana před přetopeným bytem nebylo otevřené okno. Částečná regulace formou snížení teploty v celkovém objemu však je formou jak omezit ztráty, při zachování stejného teplotního komfortu."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-4",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-4",
+      "id": "komunalni-2022-505927-a-13",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-4",
       "answer": "yes",
       "comment": "Je to obecný trend, který (např. ve Vídni) ukazuje, že je ulice po zavedení rychlosti 30, mnohem přehlednější a bezpečnější. Sníží se hlučnost a prašnost. Zóny 30 zavedené v obytných zónách by už měly být naprosto normální a ocení je všichni. Zpoždění při popojíždění v těchto ulicích je navíc naprosto minimální."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-5",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-5",
+      "id": "komunalni-2022-505927-a-16",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-5",
       "answer": "yes",
       "comment": "Řada lidí se dostala do této situace nechtěně, nebo byla donucena okolnostmi. V rámci milostivého léta by zaplatili svůj dluh bez úroků a mohlo by jim to pomoci v jejich sociální situaci. V současné době přicházející drahoty a sociální nejistoty je nutné snížit na minimum dopady podobných hříchů z minulosti, tak aby se dále neprohlubovaly."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-6",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-6",
+      "id": "komunalni-2022-505927-a-19",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-6",
       "answer": "yes",
       "comment": "Musí však být naprosto vyloučena možnost jejich zneužívání. Anonymizovaná data pomáhají v řízení města, stejně jako mohou získaná data sloužit jako prevence kriminality."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-7",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-7",
+      "id": "komunalni-2022-505927-a-22",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-7",
       "answer": "no",
       "comment": "Obecně se hazard přesunul z větší části do on-line prostoru a do samotných heren po všech restrikcích chodí už jen malá část hráčů. Navíc v Opavě byla v posledním roce vymezena jen velmi malá část města, kde mohou být herny provozovány a tak jsou sociální a další dopady samotných heren minimalizovány."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-8",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-8",
+      "id": "komunalni-2022-505927-a-25",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-8",
       "answer": "no",
       "comment": "Věci zadarmo většinou nejsou praktické, protože si jich lidé neváží a navíc josu využívány i těmi kdo by jinak městskou hromadnou dopravou nejezdili. jsme pro levnou městskou hromadnou dopravu, protože dokáže snížit procento automobilů v městském provozu. Je to jen otázka nastavení a sejmutí jakési známky toho, že MHD se nejezdí, když mám auto."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-9",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-9",
+      "id": "komunalni-2022-505927-a-28",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-10",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-10",
+      "id": "komunalni-2022-505927-a-31",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-10",
       "answer": "yes",
       "comment": "Každý zastupitel by si měl případně zodpovědět proč v té které věci hlasoval jak hlasoval."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-11",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-11",
+      "id": "komunalni-2022-505927-a-34",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-11",
       "answer": "yes",
       "comment": "Je to stejné jako u zastupitelstva."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-12",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-12",
+      "id": "komunalni-2022-505927-a-37",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-13",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-13"
+      "id": "komunalni-2022-505927-a-40",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-13"
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-14",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-14",
+      "id": "komunalni-2022-505927-a-43",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-14",
       "answer": "yes",
       "comment": "Je to naprosto postradatelné."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-15",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-15",
+      "id": "komunalni-2022-505927-a-46",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-15",
       "answer": "yes",
       "comment": "Míra osvětlení měst je často přehnaná. není nutno mít přesvětlené ulice. Samozřejmě nelze mít zhasnuto aby lidé chodili s baterkami, ale redukce osvětlení je možná a žádoucí."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-16",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-16",
+      "id": "komunalni-2022-505927-a-49",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-17",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-17",
+      "id": "komunalni-2022-505927-a-52",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-17",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-18",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-18",
+      "id": "komunalni-2022-505927-a-55",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-18",
       "answer": "yes",
       "comment": "Město pracuje s veřejnými financemi a ty mají být pod veřejnou kontrolou."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-19",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-19",
+      "id": "komunalni-2022-505927-a-58",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-20",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-20",
+      "id": "komunalni-2022-505927-a-61",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-20",
       "answer": "yes",
       "comment": "Je to jedna z forem pomoci mladým rodinám i sociaálně znevýhodněným. "
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-21",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-21",
+      "id": "komunalni-2022-505927-a-64",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-21",
       "answer": "yes",
       "comment": "Jendá se o postradatelnou věc. "
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-22",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-22",
+      "id": "komunalni-2022-505927-a-67",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-22",
       "answer": "no",
       "comment": "Věci zdarma většinou nekončí jak by měly. Obědy zdarma by měly dostávat maximálně sociálně znevýhodněné děti, jejichž zákonní zástupci prokazatelně nemají na placení obědů."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-23",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-23",
+      "id": "komunalni-2022-505927-a-70",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-24",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-24",
+      "id": "komunalni-2022-505927-a-73",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-24",
       "answer": "no",
       "comment": "Parkování pro všechny všude není v současné situaci možné a jako takové musí být regulováno. Má-li člověk na provoz automobilu měl by částečně přispívat i do plochy kde automobil parkuje."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-25",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-25",
+      "id": "komunalni-2022-505927-a-76",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-26",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-26",
+      "id": "komunalni-2022-505927-a-79",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-26",
       "answer": "yes",
       "comment": "Developerské projekty josu často zdrojem zvýšených nákladů pro municipality, ty by tak měly podředu říct jak minimalizovat tyto náklady a co by developer měl do svého projektu zakomponovat a zařídit."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-27",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-27",
+      "id": "komunalni-2022-505927-a-82",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-27",
       "answer": "yes",
       "comment": "Městské prostředí se v posledních letech soustředí jen na automobily, kde by mohly zaparkovat, kudy by mohly přijet. zabírají vměstském prostředí více a více místa a pro lidi je čím dál tím méně místa. Pěší a cyklisté nevypouští do ovzduší exhalace a nevíří prach. Musí se vdy najít nějaký kompromis, ale preference pěších a acyklistů bych přirovnal k pudu sebezáchovy městského prostředí jako takového."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-28",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-28",
+      "id": "komunalni-2022-505927-a-85",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-28",
       "answer": "no",
       "comment": "Je věcí vlastníka, jak nakládá se svým majetkem. nesouhlasíme s přeměňováním bytů na kanceláře, ale když se vlastník rozhodne nevyužívat bytové prostory vůbec, je to jeho věc, byť by městu každý fungující byt jen prospěl."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-29",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-29",
+      "id": "komunalni-2022-505927-a-88",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-30",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-30",
+      "id": "komunalni-2022-505927-a-91",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-30",
       "answer": "yes",
       "comment": "Elektromobilita je jednou forem dopravy a budování její infrasturktury umožňuje lepší prostředí ve městech. Rozhodně by ale neměly být elektroauta zvýhodňovány nějak více nad rámec. Za elektřinu platit v plném rozsahu stejně jako za parkovné. "
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-31",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-31",
+      "id": "komunalni-2022-505927-a-94",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-31",
       "answer": "yes",
       "comment": "V sooučasné ekonomické situaci josu tyto formy společného budování bydlení jednou z mála forem jak dosáhnout na vlastní bydlení i pro méně majetné lidi."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-32",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-32",
+      "id": "komunalni-2022-505927-a-97",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-33",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-33",
+      "id": "komunalni-2022-505927-a-100",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-33",
       "answer": "yes",
       "comment": "Minimálně neblokovat výstavbu fotovoltaických panelů předpisy a regulativy, s výjimou památkově chráněných území, kde mohou fotovoltaické panely znehodnotit průhledy a pohledy na cené části města."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-34",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-34",
+      "id": "komunalni-2022-505927-a-103",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-34",
       "answer": "yes",
       "comment": "Jedná se o podporu vnímání kulturní a sportovní infrastruktury jako přirozenou součást života. Je to služba pro občany "
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-35",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-35",
+      "id": "komunalni-2022-505927-a-106",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-36",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-36",
+      "id": "komunalni-2022-505927-a-109",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-37",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-37",
+      "id": "komunalni-2022-505927-a-112",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-37",
       "answer": "yes",
       "comment": "Většina budov by tak mohla dojít k zajímavým úsporám. "
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-38",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-38",
+      "id": "komunalni-2022-505927-a-115",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-39",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-39",
+      "id": "komunalni-2022-505927-a-118",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-39",
       "answer": "yes",
       "comment": "Integrace těch kdo už tady je je důležitá pro budoucí soužití a porozumění mezi všemi. Ponechání volného vývoje b yk ničemu dobrému nevedlo. "
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-40",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-40",
+      "id": "komunalni-2022-505927-a-121",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-40",
       "answer": "no",
       "comment": "měli by být strážníci pro jednotlivé části města, které by člověk znal a s důvěrou se na ně mohl obrátit."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-41",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-41",
+      "id": "komunalni-2022-505927-a-124",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-41",
       "answer": "yes",
       "comment": "Tak kde to dává smysl, čím méně vody bude odtékat do kanalizace tím lépe. Navíc fungování zelených střech v parných dnech také není nezanedbatelné."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-42",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-42",
+      "id": "komunalni-2022-505927-a-127",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-42",
       "answer": "yes",
       "comment": "Uvolnilo by to provoz v ranní a odpolední špičce. navíc je Opava natolik velkým městem, že je cyklodoprava takřka rychlejší než automobilová , bez negativních vlivů do životního prostředí."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-43",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-43",
+      "id": "komunalni-2022-505927-a-130",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-43",
       "answer": "no",
       "comment": "Město má podporovat sportující mládež a amaterské soutěže. Profesionální sport je formou podnikání a municipalita jako taková by neměla mít podíl v profesionálních klubech. Podporovat je finančně formou správy stadionu a výchovy mládeže, ale nikoliv na samotný profesionální klub."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-44",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-44",
+      "id": "komunalni-2022-505927-a-133",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-45",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-45",
+      "id": "komunalni-2022-505927-a-136",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-45",
       "answer": "yes",
       "comment": "Minimálně formou osvěty a pomoci. Sociální systém v ČR je ve velké míře dostatečně robusní. Pomoc v nesnázi je všk povinností každé municipality a má k tomu své nástroje a zdroje."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-46",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-46",
+      "id": "komunalni-2022-505927-a-139",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-47",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-47",
+      "id": "komunalni-2022-505927-a-142",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-47",
       "answer": "yes",
       "comment": "V rámci většího kolektivu se lépe daří integrace, byť v některých případech je to nemožné. Nicméně posílání dětí na školy jen podle jejich rasy nebo původu odsuzujeme a nebudeme podporovat."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-48",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-48",
+      "id": "komunalni-2022-505927-a-145",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-48",
       "answer": "yes",
       "comment": "Současný ekonomický trend často neumožňuje rodičům setrvávat na metřekých déle než dva roky. Budování nových kapacit je tak naprostou nutností."
     },
     {
-      "id": "komunalni-2022-505927-answer-466013-49",
-      "candidate_id": "komunalni-2022-505927-candidate-466013",
-      "question_id": "komunalni-2022-505927-question-49",
+      "id": "komunalni-2022-505927-a-148",
+      "candidate_id": "komunalni-2022-505927-c-466013",
+      "question_id": "komunalni-2022-505927-q-49",
       "comment": "Nechápu otázku 49-63 :)"
     }
   ]

--- a/data/kalkulacka/komunalni-2022/511382.json
+++ b/data/kalkulacka/komunalni-2022/511382.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-511382",
   "name": "Přerov",
-  "description": "Přerov - DESCRIPTION",
+  "description": "Přerov",
   "district_code": "511382",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-511382-question-1",
+      "id": "komunalni-2022-511382-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-2",
+      "id": "komunalni-2022-511382-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-3",
+      "id": "komunalni-2022-511382-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-4",
+      "id": "komunalni-2022-511382-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-5",
+      "id": "komunalni-2022-511382-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-6",
+      "id": "komunalni-2022-511382-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-7",
+      "id": "komunalni-2022-511382-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-8",
+      "id": "komunalni-2022-511382-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-9",
+      "id": "komunalni-2022-511382-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-10",
+      "id": "komunalni-2022-511382-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-11",
+      "id": "komunalni-2022-511382-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-12",
+      "id": "komunalni-2022-511382-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-13",
+      "id": "komunalni-2022-511382-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-14",
+      "id": "komunalni-2022-511382-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-15",
+      "id": "komunalni-2022-511382-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-16",
+      "id": "komunalni-2022-511382-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-17",
+      "id": "komunalni-2022-511382-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-18",
+      "id": "komunalni-2022-511382-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-19",
+      "id": "komunalni-2022-511382-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-20",
+      "id": "komunalni-2022-511382-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-21",
+      "id": "komunalni-2022-511382-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-22",
+      "id": "komunalni-2022-511382-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-23",
+      "id": "komunalni-2022-511382-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-24",
+      "id": "komunalni-2022-511382-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-25",
+      "id": "komunalni-2022-511382-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-26",
+      "id": "komunalni-2022-511382-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-27",
+      "id": "komunalni-2022-511382-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-28",
+      "id": "komunalni-2022-511382-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-29",
+      "id": "komunalni-2022-511382-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-30",
+      "id": "komunalni-2022-511382-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-31",
+      "id": "komunalni-2022-511382-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-32",
+      "id": "komunalni-2022-511382-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-33",
+      "id": "komunalni-2022-511382-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-34",
+      "id": "komunalni-2022-511382-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-35",
+      "id": "komunalni-2022-511382-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-36",
+      "id": "komunalni-2022-511382-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-37",
+      "id": "komunalni-2022-511382-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-38",
+      "id": "komunalni-2022-511382-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-39",
+      "id": "komunalni-2022-511382-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-40",
+      "id": "komunalni-2022-511382-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-41",
+      "id": "komunalni-2022-511382-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-42",
+      "id": "komunalni-2022-511382-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-43",
+      "id": "komunalni-2022-511382-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-44",
+      "id": "komunalni-2022-511382-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-45",
+      "id": "komunalni-2022-511382-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-46",
+      "id": "komunalni-2022-511382-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-47",
+      "id": "komunalni-2022-511382-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-511382-question-48",
+      "id": "komunalni-2022-511382-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,16 +399,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-511382-candidate-336509",
+      "id": "komunalni-2022-511382-c-336509",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-511382-336509-party",
+          "id": "komunalni-2022-511382-c-336509-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -417,16 +420,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-511382-candidate-228551",
+      "id": "komunalni-2022-511382-c-228551",
       "name": "Společně pro Přerov - koalice politického hnutí Změna a NEZÁVISLÉ VOLBY",
       "type": "party",
       "description": "Společně pro Přerov - koalice politického hnutí Změna a NEZÁVISLÉ VOLBY - DESCRIPTION",
+      "img_url": "nv-změna",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-511382-228551-party",
+          "id": "komunalni-2022-511382-c-228551-p",
           "name": "Společně pro Přerov - koalice politického hnutí Změna a NEZÁVISLÉ VOLBY",
           "description": "Společně pro Přerov - koalice politického hnutí Změna a NEZÁVISLÉ VOLBY - DESCRIPTION",
           "contacts": {
@@ -437,16 +441,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-511382-candidate-715671",
+      "id": "komunalni-2022-511382-c-715671",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
       "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "img_url": "stan",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-511382-715671-party",
+          "id": "komunalni-2022-511382-c-715671-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
           "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
           "contacts": {
@@ -457,16 +462,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-511382-candidate-481448",
+      "id": "komunalni-2022-511382-c-481448",
       "name": "Česká strana sociálně demokratická",
       "type": "party",
       "description": "Česká strana sociálně demokratická - DESCRIPTION",
+      "img_url": "čssd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-511382-481448-party",
+          "id": "komunalni-2022-511382-c-481448-p",
           "name": "Česká strana sociálně demokratická",
           "description": "Česká strana sociálně demokratická - DESCRIPTION",
           "contacts": {
@@ -477,16 +483,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-511382-candidate-138684",
+      "id": "komunalni-2022-511382-c-138684",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-511382-138684-party",
+          "id": "komunalni-2022-511382-c-138684-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -497,16 +504,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-511382-candidate-516200",
+      "id": "komunalni-2022-511382-c-516200",
       "name": "Za prosperitu města Přerova a jeho místních částí",
       "type": "party",
       "description": "Za prosperitu města Přerova a jeho místních částí - DESCRIPTION",
+      "img_url": "nez-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-511382-516200-party",
+          "id": "komunalni-2022-511382-c-516200-p",
           "name": "Za prosperitu města Přerova a jeho místních částí",
           "description": "Za prosperitu města Přerova a jeho místních částí - DESCRIPTION",
           "contacts": {
@@ -517,16 +525,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-511382-candidate-608981",
+      "id": "komunalni-2022-511382-c-608981",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-511382-608981-party",
+          "id": "komunalni-2022-511382-c-608981-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -537,16 +546,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-511382-candidate-995169",
+      "id": "komunalni-2022-511382-c-995169",
       "name": "Pomáháme městu - ODS a nezávislé osobnosti",
       "type": "party",
       "description": "Pomáháme městu - ODS a nezávislé osobnosti - DESCRIPTION",
+      "img_url": "ods-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-511382-995169-party",
+          "id": "komunalni-2022-511382-c-995169-p",
           "name": "Pomáháme městu - ODS a nezávislé osobnosti",
           "description": "Pomáháme městu - ODS a nezávislé osobnosti - DESCRIPTION",
           "contacts": {
@@ -557,16 +567,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-511382-candidate-636621",
+      "id": "komunalni-2022-511382-c-636621",
       "name": "Srdce Přerova",
       "type": "party",
       "description": "Srdce Přerova - DESCRIPTION",
+      "img_url": "bcoufal@onyx.cz",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-511382-636621-party",
+          "id": "komunalni-2022-511382-c-636621-p",
           "name": "Srdce Přerova",
           "description": "Srdce Přerova - DESCRIPTION",
           "contacts": {
@@ -577,10 +588,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-511382-candidate-757784",
+      "id": "komunalni-2022-511382-c-757784",
       "name": "Piráti - ODVAHA ZMĚNIT PŘEROV",
       "type": "party",
       "description": "Piráti - ODVAHA ZMĚNIT PŘEROV - DESCRIPTION",
+      "img_url": "piráti-nk",
       "contacts": {
         "web": [
           {
@@ -592,7 +604,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-511382-757784-party",
+          "id": "komunalni-2022-511382-c-757784-p",
           "name": "Piráti - ODVAHA ZMĚNIT PŘEROV",
           "description": "Piráti - ODVAHA ZMĚNIT PŘEROV - DESCRIPTION",
           "contacts": {
@@ -609,16 +621,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-511382-candidate-512870",
+      "id": "komunalni-2022-511382-c-512870",
       "name": "KDU-ČSL a TOP 09",
       "type": "party",
       "description": "KDU-ČSL a TOP 09 - DESCRIPTION",
+      "img_url": "kdu-čsl-top 09",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-511382-512870-party",
+          "id": "komunalni-2022-511382-c-512870-p",
           "name": "KDU-ČSL a TOP 09",
           "description": "KDU-ČSL a TOP 09 - DESCRIPTION",
           "contacts": {
@@ -631,901 +644,1496 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-511382-answer-608981-1",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-1",
+      "id": "komunalni-2022-511382-a-4",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-1",
       "answer": "no",
       "comment": "Nárok by měli mít všichni občané a každá lokalita by měla být přístupná bez rozdílu všem lidem"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-2",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-2",
+      "id": "komunalni-2022-511382-a-7",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-3",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-3",
+      "id": "komunalni-2022-511382-a-10",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-3",
       "answer": "no",
       "comment": "To určitě v žádném případě, mohlo by to ohrozit jejich zdraví i život"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-4",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-4",
+      "id": "komunalni-2022-511382-a-13",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-5",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-5",
+      "id": "komunalni-2022-511382-a-16",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-5",
       "answer": "yes",
       "comment": "Je potřeba se s nimi spojit, nabídnout pomoc se současnými dluhy a vysvětlit, jak v budoucnosti dluhy nedělat"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-6",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-6",
+      "id": "komunalni-2022-511382-a-19",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-6",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-7",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-7",
+      "id": "komunalni-2022-511382-a-22",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-7",
       "answer": "yes",
       "comment": "Hazardní hry často hrají lidé nezaměstnaní, používají na ně dávky od státu. Ale ty mají být na živobytí rodiny."
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-8",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-8",
+      "id": "komunalni-2022-511382-a-25",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-8",
       "answer": "yes",
       "comment": "Bylo by možno tím omezit množství aut ve městě."
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-9",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-9",
+      "id": "komunalni-2022-511382-a-28",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-10",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-10",
+      "id": "komunalni-2022-511382-a-31",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-10",
       "answer": "yes",
       "comment": "Každý z nás by měl hlasovat jmenovitě a za svůj názor se nestydět."
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-11",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-11",
+      "id": "komunalni-2022-511382-a-34",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-11",
       "answer": "yes",
       "comment": "Každý je zodpovědný za svůj názor."
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-12",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-12"
+      "id": "komunalni-2022-511382-a-37",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-12"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-13",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-13",
+      "id": "komunalni-2022-511382-a-40",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-13",
       "answer": "yes",
       "comment": "Velmi vhodné"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-14",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-14",
+      "id": "komunalni-2022-511382-a-43",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-14",
       "answer": "yes",
       "comment": "Úspory jsou potřeba."
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-15",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-15",
+      "id": "komunalni-2022-511382-a-46",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-15",
       "answer": "yes",
       "comment": "Hlavně nesvítit ve dne,"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-16",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-16",
+      "id": "komunalni-2022-511382-a-49",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-16",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-17",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-17",
+      "id": "komunalni-2022-511382-a-52",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-17",
       "answer": "yes",
       "comment": "Nemůžeme pustit děti do života s dluhem."
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-18",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-18"
+      "id": "komunalni-2022-511382-a-55",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-18"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-19",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-19"
+      "id": "komunalni-2022-511382-a-58",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-19"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-20",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-20",
+      "id": "komunalni-2022-511382-a-61",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-21",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-21",
+      "id": "komunalni-2022-511382-a-64",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-22",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-22",
+      "id": "komunalni-2022-511382-a-67",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-22",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-23",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-23"
+      "id": "komunalni-2022-511382-a-70",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-23"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-24",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-24"
+      "id": "komunalni-2022-511382-a-73",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-24"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-25",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-25"
+      "id": "komunalni-2022-511382-a-76",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-25"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-26",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-26",
+      "id": "komunalni-2022-511382-a-79",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-27",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-27",
+      "id": "komunalni-2022-511382-a-82",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-28",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-28"
+      "id": "komunalni-2022-511382-a-85",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-28"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-29",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-29",
+      "id": "komunalni-2022-511382-a-88",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-30",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-30"
+      "id": "komunalni-2022-511382-a-91",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-30"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-31",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-31",
+      "id": "komunalni-2022-511382-a-94",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-32",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-32",
+      "id": "komunalni-2022-511382-a-97",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-33",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-33",
+      "id": "komunalni-2022-511382-a-100",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-34",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-34",
+      "id": "komunalni-2022-511382-a-103",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-35",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-35"
+      "id": "komunalni-2022-511382-a-106",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-35"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-36",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-36"
+      "id": "komunalni-2022-511382-a-109",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-36"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-37",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-37",
+      "id": "komunalni-2022-511382-a-112",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-38",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-38",
+      "id": "komunalni-2022-511382-a-115",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-39",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-39"
+      "id": "komunalni-2022-511382-a-118",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-39"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-40",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-40",
+      "id": "komunalni-2022-511382-a-121",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-40",
       "answer": "yes",
       "comment": "Pro bezpečnost občanů zvláště v některých lokalitách."
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-41",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-41",
+      "id": "komunalni-2022-511382-a-124",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-42",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-42",
+      "id": "komunalni-2022-511382-a-127",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-43",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-43",
+      "id": "komunalni-2022-511382-a-130",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-44",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-44",
+      "id": "komunalni-2022-511382-a-133",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-44",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-45",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-45",
+      "id": "komunalni-2022-511382-a-136",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-45",
       "answer": "yes",
       "comment": "Ale s kontrolou, na co jsou finanční prostředky použity."
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-46",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-46",
+      "id": "komunalni-2022-511382-a-139",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-47",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-47"
+      "id": "komunalni-2022-511382-a-142",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-47"
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-48",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-48",
+      "id": "komunalni-2022-511382-a-145",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-48",
       "answer": "yes",
       "comment": "Pomoci ženám s návratem do zaměstnání a budování kariéry."
     },
     {
-      "id": "komunalni-2022-511382-answer-608981-49",
-      "candidate_id": "komunalni-2022-511382-candidate-608981",
-      "question_id": "komunalni-2022-511382-question-49",
+      "id": "komunalni-2022-511382-a-148",
+      "candidate_id": "komunalni-2022-511382-c-608981",
+      "question_id": "komunalni-2022-511382-q-49",
       "comment": "Máme pro vás řešení: teď a tady."
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-1",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-1"
+      "id": "komunalni-2022-511382-a-4",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-1"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-2",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-2",
+      "id": "komunalni-2022-511382-a-7",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-3",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-3",
+      "id": "komunalni-2022-511382-a-10",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-4",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-4",
+      "id": "komunalni-2022-511382-a-13",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-5",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-5",
+      "id": "komunalni-2022-511382-a-16",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-6",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-6",
+      "id": "komunalni-2022-511382-a-19",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-7",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-7",
+      "id": "komunalni-2022-511382-a-22",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-8",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-8",
+      "id": "komunalni-2022-511382-a-25",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-9",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-9",
+      "id": "komunalni-2022-511382-a-28",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-10",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-10",
+      "id": "komunalni-2022-511382-a-31",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-11",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-11",
+      "id": "komunalni-2022-511382-a-34",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-11",
       "answer": "yes",
       "comment": "Sami jsme to takto zavedli"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-12",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-12"
+      "id": "komunalni-2022-511382-a-37",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-12"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-13",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-13",
+      "id": "komunalni-2022-511382-a-40",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-14",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-14",
+      "id": "komunalni-2022-511382-a-43",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-15",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-15",
+      "id": "komunalni-2022-511382-a-46",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-15",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-16",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-16",
+      "id": "komunalni-2022-511382-a-49",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-17",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-17",
+      "id": "komunalni-2022-511382-a-52",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-18",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-18",
+      "id": "komunalni-2022-511382-a-55",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-18",
       "answer": "yes",
       "comment": "Sami jsme toto zavedli."
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-19",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-19",
+      "id": "komunalni-2022-511382-a-58",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-19",
       "answer": "yes",
       "comment": "Sami jsme toto prosazovali."
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-20",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-20",
+      "id": "komunalni-2022-511382-a-61",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-21",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-21",
+      "id": "komunalni-2022-511382-a-64",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-22",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-22",
+      "id": "komunalni-2022-511382-a-67",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-22",
       "answer": "no",
       "comment": "Obědy zdarma však mají být poskytnuty těm nejpotřebnějším. Usilujeme o cílenou, nikoli plošnou podporu."
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-23",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-23",
+      "id": "komunalni-2022-511382-a-70",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-23",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-24",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-24",
+      "id": "komunalni-2022-511382-a-73",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-25",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-25",
+      "id": "komunalni-2022-511382-a-76",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-26",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-26",
+      "id": "komunalni-2022-511382-a-79",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-27",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-27",
+      "id": "komunalni-2022-511382-a-82",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-28",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-28",
+      "id": "komunalni-2022-511382-a-85",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-28",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-29",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-29",
+      "id": "komunalni-2022-511382-a-88",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-29",
       "answer": "yes",
       "comment": "V současné době se v Přerově blíží nule."
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-30",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-30"
+      "id": "komunalni-2022-511382-a-91",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-30"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-31",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-31",
+      "id": "komunalni-2022-511382-a-94",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-32",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-32"
+      "id": "komunalni-2022-511382-a-97",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-32"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-33",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-33",
+      "id": "komunalni-2022-511382-a-100",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-33",
       "answer": "yes",
       "comment": "Anebo městská společnost"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-34",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-34",
+      "id": "komunalni-2022-511382-a-103",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-35",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-35"
+      "id": "komunalni-2022-511382-a-106",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-35"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-36",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-36"
+      "id": "komunalni-2022-511382-a-109",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-36"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-37",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-37",
+      "id": "komunalni-2022-511382-a-112",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-37",
       "answer": "yes",
       "comment": "Jako součást zvyšování energetické nezávislosti města."
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-38",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-38",
+      "id": "komunalni-2022-511382-a-115",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-38",
       "answer": "yes",
       "comment": "Ano, protože šetří místem."
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-39",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-39",
+      "id": "komunalni-2022-511382-a-118",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-39",
       "answer": "yes",
       "comment": "Ano, segregace totiž povede ke známým problémům a navíc segregací často plýtváme jejich potenciálem pro společnost."
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-40",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-40",
+      "id": "komunalni-2022-511382-a-121",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-41",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-41",
+      "id": "komunalni-2022-511382-a-124",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-42",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-42",
+      "id": "komunalni-2022-511382-a-127",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-43",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-43",
+      "id": "komunalni-2022-511382-a-130",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-43",
       "answer": "yes",
       "comment": "Ano, ale pouze omezeně a podle předem jasných pravidel."
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-44",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-44",
+      "id": "komunalni-2022-511382-a-133",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-45",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-45",
+      "id": "komunalni-2022-511382-a-136",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-45",
       "answer": "yes",
       "comment": "V současné době ano, stát není dostatečně akční. Obecně spíše nikoli."
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-46",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-46",
+      "id": "komunalni-2022-511382-a-139",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-47",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-47",
+      "id": "komunalni-2022-511382-a-142",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-48",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-48",
+      "id": "komunalni-2022-511382-a-145",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-228551-49",
-      "candidate_id": "komunalni-2022-511382-candidate-228551",
-      "question_id": "komunalni-2022-511382-question-49"
+      "id": "komunalni-2022-511382-a-148",
+      "candidate_id": "komunalni-2022-511382-c-228551",
+      "question_id": "komunalni-2022-511382-q-49"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-1",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-1",
+      "id": "komunalni-2022-511382-a-4",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-2",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-2",
+      "id": "komunalni-2022-511382-a-7",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-2",
       "answer": "yes",
       "comment": "ano, ale systém by měl být motivační. Čím více třídíš, tím méně platíš."
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-3",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-3",
+      "id": "komunalni-2022-511382-a-10",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-4",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-4",
+      "id": "komunalni-2022-511382-a-13",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-5",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-5",
+      "id": "komunalni-2022-511382-a-16",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-6",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-6",
+      "id": "komunalni-2022-511382-a-19",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-6",
       "answer": "no",
       "comment": "Bezpečnost je naše priorita, strážnici však patří do ulic, nikoliv do kanceláří. "
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-7",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-7",
+      "id": "komunalni-2022-511382-a-22",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-7",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-8",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-8",
+      "id": "komunalni-2022-511382-a-25",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-8",
       "answer": "no",
       "comment": "MHD v Přerově je za skvělé ceny. Naopak chceme zvýšit frekvenci spojů"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-9",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-9",
+      "id": "komunalni-2022-511382-a-28",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-10",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-10",
+      "id": "komunalni-2022-511382-a-31",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-11",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-11",
+      "id": "komunalni-2022-511382-a-34",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-12",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-12",
+      "id": "komunalni-2022-511382-a-37",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-13",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-13",
+      "id": "komunalni-2022-511382-a-40",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-14",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-14",
+      "id": "komunalni-2022-511382-a-43",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-15",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-15",
+      "id": "komunalni-2022-511382-a-46",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-15",
       "comment": "Spíše se vydat cestou chytrého osvětlení"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-16",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-16",
+      "id": "komunalni-2022-511382-a-49",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-16",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-17",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-17",
+      "id": "komunalni-2022-511382-a-52",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-17",
       "answer": "yes",
       "comment": "ano, dětské exekuce jsou ostudou našeho právního řádu"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-18",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-18",
+      "id": "komunalni-2022-511382-a-55",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-19",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-19",
+      "id": "komunalni-2022-511382-a-58",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-20",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-20",
+      "id": "komunalni-2022-511382-a-61",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-21",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-21",
+      "id": "komunalni-2022-511382-a-64",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-22",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-22",
+      "id": "komunalni-2022-511382-a-67",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-22",
       "answer": "no",
       "comment": "Ano, jen podpořit spíše chudší rodiny."
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-23",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-23",
+      "id": "komunalni-2022-511382-a-70",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-23",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-24",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-24",
+      "id": "komunalni-2022-511382-a-73",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-24",
       "answer": "yes",
       "comment": "Na sidlištích chceme parkování řešit pomocí patrových parkovišť nikoliv zavádět parkovací zóny."
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-25",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-25",
+      "id": "komunalni-2022-511382-a-76",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-26",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-26",
+      "id": "komunalni-2022-511382-a-79",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-27",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-27",
+      "id": "komunalni-2022-511382-a-82",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-27",
       "answer": "no",
       "comment": "V centru města ano."
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-28",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-28",
+      "id": "komunalni-2022-511382-a-85",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-29",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-29",
+      "id": "komunalni-2022-511382-a-88",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-30",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-30",
+      "id": "komunalni-2022-511382-a-91",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-31",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-31",
+      "id": "komunalni-2022-511382-a-94",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-32",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-32",
+      "id": "komunalni-2022-511382-a-97",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-33",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-33",
+      "id": "komunalni-2022-511382-a-100",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-34",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-34",
+      "id": "komunalni-2022-511382-a-103",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-35",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-35",
+      "id": "komunalni-2022-511382-a-106",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-36",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-36",
+      "id": "komunalni-2022-511382-a-109",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-36",
       "answer": "yes",
       "comment": "ano, na vládní úrovni je třeba snížit jejich DPH z 21% na nižší"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-37",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-37",
+      "id": "komunalni-2022-511382-a-112",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-38",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-38",
+      "id": "komunalni-2022-511382-a-115",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-38",
       "comment": "Spíše sdílená kola."
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-39",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-39",
+      "id": "komunalni-2022-511382-a-118",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-40",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-40",
+      "id": "komunalni-2022-511382-a-121",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-41",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-41",
+      "id": "komunalni-2022-511382-a-124",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-42",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-42",
+      "id": "komunalni-2022-511382-a-127",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-43",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-43",
+      "id": "komunalni-2022-511382-a-130",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-44",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-44",
+      "id": "komunalni-2022-511382-a-133",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-45",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-45",
+      "id": "komunalni-2022-511382-a-136",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-45",
       "answer": "no",
       "comment": "ano i ne, podpora spíše zřízením poradenského místa, či zřízením sociálního fondu na překlenutí např. jednoho měsíce, kdy rodina není schopná uhradit nájem."
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-46",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-46",
+      "id": "komunalni-2022-511382-a-139",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-46",
       "answer": "yes",
       "comment": "Chceme opravit Strojař a získat zde nové bytové jednotky."
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-47",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-47",
+      "id": "komunalni-2022-511382-a-142",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-48",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-48",
+      "id": "komunalni-2022-511382-a-145",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-511382-answer-757784-49",
-      "candidate_id": "komunalni-2022-511382-candidate-757784",
-      "question_id": "komunalni-2022-511382-question-49"
+      "id": "komunalni-2022-511382-a-148",
+      "candidate_id": "komunalni-2022-511382-c-757784",
+      "question_id": "komunalni-2022-511382-q-49"
+    },
+    {
+      "id": "komunalni-2022-511382-a-4",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-1",
+      "answer": "no",
+      "comment": "Nechceme, aby se bydlení v určitých částech města stalo nedostupným běžným občanům. Nechceme ani vylidněné části města."
+    },
+    {
+      "id": "komunalni-2022-511382-a-7",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-2",
+      "answer": "yes",
+      "comment": "Měl by být v rozumné výši, dotovaný pro určité skupiny občanů (např. pro děti do určitého věku, seniory)."
+    },
+    {
+      "id": "komunalni-2022-511382-a-10",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-3",
+      "answer": "no",
+      "comment": "Vytápění lze v případě nouze omezovat v jiných prostorách města. Senioři nesmějí být vystaveni ohrožení svého zdraví."
+    },
+    {
+      "id": "komunalni-2022-511382-a-13",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-4",
+      "comment": "O snížení maximální rychlosti by bylo možné uvažovat v sídlištních lokalitách."
+    },
+    {
+      "id": "komunalni-2022-511382-a-16",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-5",
+      "comment": "Je to možné, záleží na počtu dlužníků města."
+    },
+    {
+      "id": "komunalni-2022-511382-a-19",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-6",
+      "comment": "Naše strana je v opozici, nemáme přesný přehled o aktuálním počtu umístěných kamer ve městě."
+    },
+    {
+      "id": "komunalni-2022-511382-a-22",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-7"
+    },
+    {
+      "id": "komunalni-2022-511382-a-25",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-8",
+      "answer": "no",
+      "comment": "Chtěli bychom ale udržet stávající ceny jízdného v MHD."
+    },
+    {
+      "id": "komunalni-2022-511382-a-28",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-31",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-34",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-11",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-511382-a-37",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-12",
+      "comment": "Měla by ale existovat určitá regulace zábavní pyrotechniky, aby nedocházelo k rušení např. nočního klidu."
+    },
+    {
+      "id": "komunalni-2022-511382-a-40",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-13",
+      "comment": "V tuto chvíli nikdo neví, jak se bude vyvíjet situace a jaká bude topná sezóna."
+    },
+    {
+      "id": "komunalni-2022-511382-a-43",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-14",
+      "comment": "V případě nouze je to možné udělat."
+    },
+    {
+      "id": "komunalni-2022-511382-a-46",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-15",
+      "comment": "V případě nouze je to možné udělat."
+    },
+    {
+      "id": "komunalni-2022-511382-a-49",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-16",
+      "comment": "V případě nouze je to možné udělat."
+    },
+    {
+      "id": "komunalni-2022-511382-a-52",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-55",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-58",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-19",
+      "comment": "Je možné mít participativní rozpočet, ale se smysluplnými akcemi."
+    },
+    {
+      "id": "komunalni-2022-511382-a-61",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-20",
+      "answer": "yes",
+      "comment": "Je to nutnost vzhledem k zhoršující se ekonomické situaci v České republice. Ne každý občan bude mít finance na vlastní soukromé bydlení. Nájemní bydlení by mělo být alternativou vlastního bydlení."
+    },
+    {
+      "id": "komunalni-2022-511382-a-64",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-21",
+      "comment": "V případě nouze je to možné udělat."
+    },
+    {
+      "id": "komunalni-2022-511382-a-67",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-22",
+      "answer": "no",
+      "comment": "Pokusíme se ale udržet stávající ceny obědů ve školních jídelnách."
+    },
+    {
+      "id": "komunalni-2022-511382-a-70",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-23"
+    },
+    {
+      "id": "komunalni-2022-511382-a-73",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-24"
+    },
+    {
+      "id": "komunalni-2022-511382-a-76",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-511382-a-79",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-82",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-85",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-28"
+    },
+    {
+      "id": "komunalni-2022-511382-a-88",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-91",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-30"
+    },
+    {
+      "id": "komunalni-2022-511382-a-94",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-97",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-32",
+      "answer": "no",
+      "comment": "Chtěli bychom ale udržet stávající ceny jízdného v MHD."
+    },
+    {
+      "id": "komunalni-2022-511382-a-100",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-33"
+    },
+    {
+      "id": "komunalni-2022-511382-a-103",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-106",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-511382-a-109",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-511382-a-112",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-37",
+      "comment": "Pokud to bude pro město ekonomicky výhodné, tak ano."
+    },
+    {
+      "id": "komunalni-2022-511382-a-115",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-38"
+    },
+    {
+      "id": "komunalni-2022-511382-a-118",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-121",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-124",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-41"
+    },
+    {
+      "id": "komunalni-2022-511382-a-127",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-42",
+      "answer": "yes",
+      "comment": "Musí k tomu být ale i podmínky (např. cyklostezky, úložné prostory pro kola)."
+    },
+    {
+      "id": "komunalni-2022-511382-a-130",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-133",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-511382-a-136",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-139",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-142",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-47"
+    },
+    {
+      "id": "komunalni-2022-511382-a-145",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-148",
+      "candidate_id": "komunalni-2022-511382-c-481448",
+      "question_id": "komunalni-2022-511382-q-49"
+    },
+    {
+      "id": "komunalni-2022-511382-a-4",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-1",
+      "answer": "yes",
+      "comment": "jak někdo může udržitelně bydlet v místě, či nemovitosti, když nemá na úhradu nákladů? \n"
+    },
+    {
+      "id": "komunalni-2022-511382-a-7",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-2",
+      "answer": "yes",
+      "comment": "ale záleží na velikosti obce a jejích potřebách investovat. V malé obci, nebo městě si dovedu představit, že může radnice poskytnout tuto službu pro obyvatele zdarma."
+    },
+    {
+      "id": "komunalni-2022-511382-a-10",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-3",
+      "answer": "no",
+      "comment": "to by byl hazard."
+    },
+    {
+      "id": "komunalni-2022-511382-a-13",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-4",
+      "answer": "no",
+      "comment": "omezení rychlosti někde má smysl, jinde ne. Záleží to na konkrétní situaci. Navíc bych to rozlišil i časově."
+    },
+    {
+      "id": "komunalni-2022-511382-a-16",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-5",
+      "answer": "yes",
+      "comment": "řada dotčených by se jinak o akci nedověděla."
+    },
+    {
+      "id": "komunalni-2022-511382-a-19",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-6",
+      "answer": "no",
+      "comment": "pouze pro krizová dopravní místa. Jinak je toho šmírování občanů až příliš."
+    },
+    {
+      "id": "komunalni-2022-511382-a-22",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-7",
+      "comment": "určitě by hazard neměl být v centrech měst, u škol apod. "
+    },
+    {
+      "id": "komunalni-2022-511382-a-25",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-8",
+      "answer": "no",
+      "comment": "třeba v Praze by městu chyběly obrovské finance na investice a provoz MHD. I tak je MHD masivně dotována. V malých městech by to mohli radní udělat jako službu občanům."
+    },
+    {
+      "id": "komunalni-2022-511382-a-28",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-9",
+      "answer": "yes",
+      "comment": "populace stárne a průchodnost města pro postižené je důležitý prvek humanity"
+    },
+    {
+      "id": "komunalni-2022-511382-a-31",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-34",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-11"
+    },
+    {
+      "id": "komunalni-2022-511382-a-37",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-511382-a-40",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-13",
+      "answer": "no",
+      "comment": "to snad ne. Tak zlé to tady nebude."
+    },
+    {
+      "id": "komunalni-2022-511382-a-43",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-14"
+    },
+    {
+      "id": "komunalni-2022-511382-a-46",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-15",
+      "answer": "no",
+      "comment": "narostla by kriminalita"
+    },
+    {
+      "id": "komunalni-2022-511382-a-49",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-511382-a-52",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-55",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-58",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-19"
+    },
+    {
+      "id": "komunalni-2022-511382-a-61",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-20",
+      "answer": "no",
+      "comment": "to zase bude komunální socialismus. Každý by měl, pokud tto ekonomická situace dovolí, vlastnit svoje bydlení. "
+    },
+    {
+      "id": "komunalni-2022-511382-a-64",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-511382-a-67",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-511382-a-70",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-23"
+    },
+    {
+      "id": "komunalni-2022-511382-a-73",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-24",
+      "comment": "záleží na konkrétní situaci a koncepci zón."
+    },
+    {
+      "id": "komunalni-2022-511382-a-76",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-25",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-79",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-82",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-511382-a-85",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-28",
+      "answer": "no",
+      "comment": "každý má právo nakládat se svým soukromým majetkem podle vlastního uvážení. "
+    },
+    {
+      "id": "komunalni-2022-511382-a-88",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-91",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-30",
+      "answer": "yes",
+      "comment": "pokud to dává smysl"
+    },
+    {
+      "id": "komunalni-2022-511382-a-94",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-31",
+      "answer": "no",
+      "comment": "jsem skeptický, jak by to v Česku dopadlo.\n"
+    },
+    {
+      "id": "komunalni-2022-511382-a-97",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-511382-a-100",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-511382-a-103",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-106",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-511382-a-109",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-511382-a-112",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-115",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-38"
+    },
+    {
+      "id": "komunalni-2022-511382-a-118",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-39",
+      "comment": "spíš asimilaci, než integraci. Jsem toho názoru, že když se cizinec chce někde usadit, měl by respektovat kulturu a zvyklosti svého nového bydliště. "
+    },
+    {
+      "id": "komunalni-2022-511382-a-121",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-40",
+      "comment": "jak kde. "
+    },
+    {
+      "id": "komunalni-2022-511382-a-124",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-127",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-42"
+    },
+    {
+      "id": "komunalni-2022-511382-a-130",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-43",
+      "answer": "no",
+      "comment": "od toho jsou jiné instituce, než město."
+    },
+    {
+      "id": "komunalni-2022-511382-a-133",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-44",
+      "answer": "yes",
+      "comment": "proč trestat lidi, kteří se starají ve prospěch těch, co se nestarají. "
+    },
+    {
+      "id": "komunalni-2022-511382-a-136",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-45",
+      "comment": "finance použít na vyřešení jejich situace, nikoli na dotování jejich chudoby."
+    },
+    {
+      "id": "komunalni-2022-511382-a-139",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-46",
+      "answer": "yes",
+      "comment": "pouze pro sociální a krizové účely."
+    },
+    {
+      "id": "komunalni-2022-511382-a-142",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-47"
+    },
+    {
+      "id": "komunalni-2022-511382-a-145",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-511382-a-148",
+      "candidate_id": "komunalni-2022-511382-c-636621",
+      "question_id": "komunalni-2022-511382-q-49"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/532053.json
+++ b/data/kalkulacka/komunalni-2022/532053.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-532053",
   "name": "Kladno",
-  "description": "Kladno - DESCRIPTION",
+  "description": "Kladno",
   "district_code": "532053",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-532053-question-1",
+      "id": "komunalni-2022-532053-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-2",
+      "id": "komunalni-2022-532053-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-3",
+      "id": "komunalni-2022-532053-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-4",
+      "id": "komunalni-2022-532053-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-5",
+      "id": "komunalni-2022-532053-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-6",
+      "id": "komunalni-2022-532053-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-7",
+      "id": "komunalni-2022-532053-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-8",
+      "id": "komunalni-2022-532053-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-9",
+      "id": "komunalni-2022-532053-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-10",
+      "id": "komunalni-2022-532053-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-11",
+      "id": "komunalni-2022-532053-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-12",
+      "id": "komunalni-2022-532053-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-13",
+      "id": "komunalni-2022-532053-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-14",
+      "id": "komunalni-2022-532053-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-15",
+      "id": "komunalni-2022-532053-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-16",
+      "id": "komunalni-2022-532053-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-17",
+      "id": "komunalni-2022-532053-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-18",
+      "id": "komunalni-2022-532053-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-19",
+      "id": "komunalni-2022-532053-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-20",
+      "id": "komunalni-2022-532053-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-21",
+      "id": "komunalni-2022-532053-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-22",
+      "id": "komunalni-2022-532053-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-23",
+      "id": "komunalni-2022-532053-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-24",
+      "id": "komunalni-2022-532053-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-25",
+      "id": "komunalni-2022-532053-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-26",
+      "id": "komunalni-2022-532053-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-27",
+      "id": "komunalni-2022-532053-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-28",
+      "id": "komunalni-2022-532053-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-29",
+      "id": "komunalni-2022-532053-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-30",
+      "id": "komunalni-2022-532053-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-31",
+      "id": "komunalni-2022-532053-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-32",
+      "id": "komunalni-2022-532053-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-33",
+      "id": "komunalni-2022-532053-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-34",
+      "id": "komunalni-2022-532053-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-35",
+      "id": "komunalni-2022-532053-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-36",
+      "id": "komunalni-2022-532053-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-37",
+      "id": "komunalni-2022-532053-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-38",
+      "id": "komunalni-2022-532053-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-39",
+      "id": "komunalni-2022-532053-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-40",
+      "id": "komunalni-2022-532053-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-41",
+      "id": "komunalni-2022-532053-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-42",
+      "id": "komunalni-2022-532053-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-43",
+      "id": "komunalni-2022-532053-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-44",
+      "id": "komunalni-2022-532053-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-45",
+      "id": "komunalni-2022-532053-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-46",
+      "id": "komunalni-2022-532053-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-47",
+      "id": "komunalni-2022-532053-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-532053-question-48",
+      "id": "komunalni-2022-532053-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,10 +399,11 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-532053-candidate-937609",
+      "id": "komunalni-2022-532053-c-937609",
       "name": "Občanská demokratická strana",
       "type": "party",
       "description": "Občanská demokratická strana - DESCRIPTION",
+      "img_url": "ods",
       "contacts": {
         "web": [
           {
@@ -417,7 +420,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-532053-937609-party",
+          "id": "komunalni-2022-532053-c-937609-p",
           "name": "Občanská demokratická strana",
           "description": "Občanská demokratická strana - DESCRIPTION",
           "contacts": {
@@ -439,10 +442,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-532053-candidate-786086",
+      "id": "komunalni-2022-532053-c-786086",
       "name": "VOLBA PRO KLADNO",
       "type": "party",
       "description": "VOLBA PRO KLADNO - DESCRIPTION",
+      "img_url": "vpk",
       "contacts": {
         "web": [
           {
@@ -454,7 +458,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-532053-786086-party",
+          "id": "komunalni-2022-532053-c-786086-p",
           "name": "VOLBA PRO KLADNO",
           "description": "VOLBA PRO KLADNO - DESCRIPTION",
           "contacts": {
@@ -471,16 +475,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-532053-candidate-773113",
+      "id": "komunalni-2022-532053-c-773113",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-532053-773113-party",
+          "id": "komunalni-2022-532053-c-773113-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -491,16 +496,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-532053-candidate-133748",
+      "id": "komunalni-2022-532053-c-133748",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-532053-133748-party",
+          "id": "komunalni-2022-532053-c-133748-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -511,10 +517,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-532053-candidate-358217",
+      "id": "komunalni-2022-532053-c-358217",
       "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
       "type": "party",
       "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
+      "img_url": "přísaha",
       "contacts": {
         "web": [
           {
@@ -526,7 +533,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-532053-358217-party",
+          "id": "komunalni-2022-532053-c-358217-p",
           "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
           "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
           "contacts": {
@@ -543,16 +550,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-532053-candidate-897710",
+      "id": "komunalni-2022-532053-c-897710",
       "name": "SPOLEČNĚ pro Kladno (koalice TOP 09 a KDU-ČSL)",
       "type": "party",
       "description": "SPOLEČNĚ pro Kladno (koalice TOP 09 a KDU-ČSL) - DESCRIPTION",
+      "img_url": "kdu-čsl-top 09",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-532053-897710-party",
+          "id": "komunalni-2022-532053-c-897710-p",
           "name": "SPOLEČNĚ pro Kladno (koalice TOP 09 a KDU-ČSL)",
           "description": "SPOLEČNĚ pro Kladno (koalice TOP 09 a KDU-ČSL) - DESCRIPTION",
           "contacts": {
@@ -563,10 +571,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-532053-candidate-646539",
+      "id": "komunalni-2022-532053-c-646539",
       "name": "OPRAVÍME KLADNO - PIRÁTI A STAROSTOVÉ",
       "type": "party",
       "description": "OPRAVÍME KLADNO - PIRÁTI A STAROSTOVÉ - DESCRIPTION",
+      "img_url": "stan-piráti",
       "contacts": {
         "web": [
           {
@@ -583,7 +592,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-532053-646539-party",
+          "id": "komunalni-2022-532053-c-646539-p",
           "name": "OPRAVÍME KLADNO - PIRÁTI A STAROSTOVÉ",
           "description": "OPRAVÍME KLADNO - PIRÁTI A STAROSTOVÉ - DESCRIPTION",
           "contacts": {
@@ -605,16 +614,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-532053-candidate-682005",
+      "id": "komunalni-2022-532053-c-682005",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-532053-682005-party",
+          "id": "komunalni-2022-532053-c-682005-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -625,10 +635,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-532053-candidate-830763",
+      "id": "komunalni-2022-532053-c-830763",
       "name": "Koalice pro Kladno (ČSSD a Zelení)",
       "type": "party",
       "description": "Koalice pro Kladno (ČSSD a Zelení) - DESCRIPTION",
+      "img_url": "zelení-čssd",
       "contacts": {
         "web": [
           {
@@ -639,7 +650,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-532053-830763-party",
+          "id": "komunalni-2022-532053-c-830763-p",
           "name": "Koalice pro Kladno (ČSSD a Zelení)",
           "description": "Koalice pro Kladno (ČSSD a Zelení) - DESCRIPTION",
           "contacts": {
@@ -657,306 +668,606 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-532053-answer-646539-1",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-1",
+      "id": "komunalni-2022-532053-a-4",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-2",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-2",
+      "id": "komunalni-2022-532053-a-7",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-3",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-3",
+      "id": "komunalni-2022-532053-a-10",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-4",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-4",
+      "id": "komunalni-2022-532053-a-13",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-5",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-5",
+      "id": "komunalni-2022-532053-a-16",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-6",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-6",
+      "id": "komunalni-2022-532053-a-19",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-6",
       "answer": "yes",
       "comment": "Je ovšem třeba instalovat kamery nikoli bezhlavě, ale s ohledem na jejich skutečný přínos."
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-7",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-7",
+      "id": "komunalni-2022-532053-a-22",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-8",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-8",
+      "id": "komunalni-2022-532053-a-25",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-8",
       "answer": "no",
       "comment": "Vzhledem ke specifikům Kladna a stávající kvalitě veřejné dopravy by zrušení jízdného pravděpodobně nepřineslo kýžený efekt, tj. přesednutí části lidí z aut do veřejné dopravy. Poměrně velká skupina cestujících má navíc MHD zdarma nebo za symbolickou cenu už teď. Jsme ochotní jednat o zavedení MHD zdarma v čase stávající krize."
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-9",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-9",
+      "id": "komunalni-2022-532053-a-28",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-10",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-10",
+      "id": "komunalni-2022-532053-a-31",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-11",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-11",
+      "id": "komunalni-2022-532053-a-34",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-12",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-12",
+      "id": "komunalni-2022-532053-a-37",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-13",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-13",
+      "id": "komunalni-2022-532053-a-40",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-13",
       "comment": "Záleží na tom, jak skutečně bude situace vypadat."
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-14",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-14",
+      "id": "komunalni-2022-532053-a-43",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-15",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-15",
+      "id": "komunalni-2022-532053-a-46",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-15",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-16",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-16",
+      "id": "komunalni-2022-532053-a-49",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-17",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-17",
+      "id": "komunalni-2022-532053-a-52",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-18",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-18",
+      "id": "komunalni-2022-532053-a-55",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-18",
       "answer": "yes",
       "comment": "Ve smyslu transparentního účetnictví, v programu máme zveřejňování všech faktur a kontrola využití městských financí je pro nás důležitá... Nemyslíme si ale, že by město mělo mít transparentní účty v bance."
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-19",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-19",
+      "id": "komunalni-2022-532053-a-58",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-19",
       "answer": "yes",
       "comment": "Chceme, aby občané měli podíl na rozdělování části prostředků prostřednictvím osadních výborů. Participativní rozpočet naopak nepovažujeme za vhodný nástroj, již jednou se na Kladně neosvědčil."
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-20",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-20",
+      "id": "komunalni-2022-532053-a-61",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-21",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-21",
+      "id": "komunalni-2022-532053-a-64",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-22",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-22",
+      "id": "komunalni-2022-532053-a-67",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-22",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-23",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-23",
+      "id": "komunalni-2022-532053-a-70",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-23",
       "answer": "yes",
       "comment": "Carsharing by měl být podporován např. možností parkovat zdarma na placených parkovištích, nikoli finančně."
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-24",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-24",
+      "id": "komunalni-2022-532053-a-73",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-25",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-25",
+      "id": "komunalni-2022-532053-a-76",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-26",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-26",
+      "id": "komunalni-2022-532053-a-79",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-27",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-27",
+      "id": "komunalni-2022-532053-a-82",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-27",
       "answer": "no",
       "comment": "Město má všechny druhy dopravy považovat za rovnocenné a musí usilovat o to, aby všechny způsoby byly bezpečné a pohodlné."
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-28",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-28",
+      "id": "komunalni-2022-532053-a-85",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-28",
       "comment": "To je spíš otázka mimo rámec komunální politiky."
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-29",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-29",
+      "id": "komunalni-2022-532053-a-88",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-30",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-30",
+      "id": "komunalni-2022-532053-a-91",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-31",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-31",
+      "id": "komunalni-2022-532053-a-94",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-32",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-32",
+      "id": "komunalni-2022-532053-a-97",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-32",
       "answer": "no",
       "comment": "Preferujeme MHD zdarma do 6 let, u starších za snížené jízdné."
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-33",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-33",
+      "id": "komunalni-2022-532053-a-100",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-34",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-34",
+      "id": "komunalni-2022-532053-a-103",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-35",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-35",
+      "id": "komunalni-2022-532053-a-106",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-36",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-36",
+      "id": "komunalni-2022-532053-a-109",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-37",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-37",
+      "id": "komunalni-2022-532053-a-112",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-38",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-38",
+      "id": "komunalni-2022-532053-a-115",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-39",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-39",
+      "id": "komunalni-2022-532053-a-118",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-40",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-40",
+      "id": "komunalni-2022-532053-a-121",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-41",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-41",
+      "id": "komunalni-2022-532053-a-124",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-42",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-42",
+      "id": "komunalni-2022-532053-a-127",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-43",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-43",
+      "id": "komunalni-2022-532053-a-130",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-44",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-44",
+      "id": "komunalni-2022-532053-a-133",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-45",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-45",
+      "id": "komunalni-2022-532053-a-136",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-45",
       "answer": "no",
       "comment": "Město má využít jiné nástroje než finanční pomoc."
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-46",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-46",
+      "id": "komunalni-2022-532053-a-139",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-47",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-47",
+      "id": "komunalni-2022-532053-a-142",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-48",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-48",
+      "id": "komunalni-2022-532053-a-145",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-532053-answer-646539-49",
-      "candidate_id": "komunalni-2022-532053-candidate-646539",
-      "question_id": "komunalni-2022-532053-question-49",
+      "id": "komunalni-2022-532053-a-148",
+      "candidate_id": "komunalni-2022-532053-c-646539",
+      "question_id": "komunalni-2022-532053-q-49",
       "comment": "Řada otázek se ptá na postoje k celostátním tématům, řada řeší marginality (menstruační pomůcky), některé otázky jsou chybně/návodně formulované (má mít přednost určitý typ dopravy), chybí otázky na hodnotové nastavení ve vztahu ke komunální politice (např. budování modrozelené infrastruktury, má město omezovat počet jízd automobilem atd.)."
+    },
+    {
+      "id": "komunalni-2022-532053-a-4",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-1",
+      "answer": "yes",
+      "comment": "Každý by si měl v žádaných městských částech na své bydlení vydělat."
+    },
+    {
+      "id": "komunalni-2022-532053-a-7",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-2",
+      "answer": "yes",
+      "comment": "Nic není zadarmo. Obyvatelé poplatek stejně zaplatí ze svých daní, jen jiným způsobem."
+    },
+    {
+      "id": "komunalni-2022-532053-a-10",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-3",
+      "answer": "no",
+      "comment": "Sociální a zdravotní zařízení mají v případech nouze absolutní prioritu"
+    },
+    {
+      "id": "komunalni-2022-532053-a-13",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-4",
+      "answer": "no",
+      "comment": "Stávají úprava rychlosti je dostačující."
+    },
+    {
+      "id": "komunalni-2022-532053-a-16",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-19",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-532053-a-22",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-7",
+      "answer": "yes",
+      "comment": "Je důležité aby o této otázce rozhodli sami občané v referendu"
+    },
+    {
+      "id": "komunalni-2022-532053-a-25",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-8",
+      "answer": "no",
+      "comment": "Nic není zadarmo. Obyvatelé hromadnou dopravu stejně zaplatí ze svých daní, jen jiným způsobem."
+    },
+    {
+      "id": "komunalni-2022-532053-a-28",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-31",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-10",
+      "answer": "yes",
+      "comment": "Přispělo by to k větší odpovědnosti a transparentnosti při rozhodování zastupitelů."
+    },
+    {
+      "id": "komunalni-2022-532053-a-34",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-11",
+      "answer": "yes",
+      "comment": "Přispělo by to k větší odpovědnosti a transparentnosti při rozhodování."
+    },
+    {
+      "id": "komunalni-2022-532053-a-37",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-40",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-13"
+    },
+    {
+      "id": "komunalni-2022-532053-a-43",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-46",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-15",
+      "answer": "yes",
+      "comment": "V době krize ano, jen to nemusí být technicky proveditelné."
+    },
+    {
+      "id": "komunalni-2022-532053-a-49",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-16",
+      "answer": "yes",
+      "comment": "Ne dramatické snížení, a s výjimkou pro školská zařízení."
+    },
+    {
+      "id": "komunalni-2022-532053-a-52",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-55",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-58",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-61",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-64",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-67",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-22",
+      "answer": "no",
+      "comment": "Výjimka pro děti ze sociálně slabých rodin."
+    },
+    {
+      "id": "komunalni-2022-532053-a-70",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-532053-a-73",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-532053-a-76",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-25",
+      "answer": "no",
+      "comment": "Město má mít svůj bytový fond"
+    },
+    {
+      "id": "komunalni-2022-532053-a-79",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-82",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-27"
+    },
+    {
+      "id": "komunalni-2022-532053-a-85",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-28"
+    },
+    {
+      "id": "komunalni-2022-532053-a-88",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-91",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-94",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-97",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-32",
+      "answer": "no",
+      "comment": "Jen sociální případy"
+    },
+    {
+      "id": "komunalni-2022-532053-a-100",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-103",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-34",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-532053-a-106",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-532053-a-109",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-532053-a-112",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-115",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-38"
+    },
+    {
+      "id": "komunalni-2022-532053-a-118",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-121",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-124",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-127",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-42"
+    },
+    {
+      "id": "komunalni-2022-532053-a-130",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-532053-a-133",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-532053-a-136",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-532053-a-139",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-532053-a-142",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-47"
+    },
+    {
+      "id": "komunalni-2022-532053-a-145",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-532053-a-148",
+      "candidate_id": "komunalni-2022-532053-c-897710",
+      "question_id": "komunalni-2022-532053-q-49"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/533165.json
+++ b/data/kalkulacka/komunalni-2022/533165.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-533165",
   "name": "Kolín",
-  "description": "Kolín - DESCRIPTION",
+  "description": "Kolín",
   "district_code": "533165",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-533165-question-1",
+      "id": "komunalni-2022-533165-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-2",
+      "id": "komunalni-2022-533165-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-3",
+      "id": "komunalni-2022-533165-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-4",
+      "id": "komunalni-2022-533165-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-5",
+      "id": "komunalni-2022-533165-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-6",
+      "id": "komunalni-2022-533165-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-7",
+      "id": "komunalni-2022-533165-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-8",
+      "id": "komunalni-2022-533165-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-9",
+      "id": "komunalni-2022-533165-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-10",
+      "id": "komunalni-2022-533165-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-11",
+      "id": "komunalni-2022-533165-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-12",
+      "id": "komunalni-2022-533165-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-13",
+      "id": "komunalni-2022-533165-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-14",
+      "id": "komunalni-2022-533165-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-15",
+      "id": "komunalni-2022-533165-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-16",
+      "id": "komunalni-2022-533165-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-17",
+      "id": "komunalni-2022-533165-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-18",
+      "id": "komunalni-2022-533165-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-19",
+      "id": "komunalni-2022-533165-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-20",
+      "id": "komunalni-2022-533165-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-21",
+      "id": "komunalni-2022-533165-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-22",
+      "id": "komunalni-2022-533165-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-23",
+      "id": "komunalni-2022-533165-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-24",
+      "id": "komunalni-2022-533165-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-25",
+      "id": "komunalni-2022-533165-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-26",
+      "id": "komunalni-2022-533165-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-27",
+      "id": "komunalni-2022-533165-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-28",
+      "id": "komunalni-2022-533165-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-29",
+      "id": "komunalni-2022-533165-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-30",
+      "id": "komunalni-2022-533165-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-31",
+      "id": "komunalni-2022-533165-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-32",
+      "id": "komunalni-2022-533165-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-33",
+      "id": "komunalni-2022-533165-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-34",
+      "id": "komunalni-2022-533165-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-35",
+      "id": "komunalni-2022-533165-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-36",
+      "id": "komunalni-2022-533165-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-37",
+      "id": "komunalni-2022-533165-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-38",
+      "id": "komunalni-2022-533165-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-39",
+      "id": "komunalni-2022-533165-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-40",
+      "id": "komunalni-2022-533165-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-41",
+      "id": "komunalni-2022-533165-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-42",
+      "id": "komunalni-2022-533165-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-43",
+      "id": "komunalni-2022-533165-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-44",
+      "id": "komunalni-2022-533165-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-45",
+      "id": "komunalni-2022-533165-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-46",
+      "id": "komunalni-2022-533165-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-47",
+      "id": "komunalni-2022-533165-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-533165-question-48",
+      "id": "komunalni-2022-533165-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,16 +399,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-533165-candidate-447119",
+      "id": "komunalni-2022-533165-c-447119",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-533165-447119-party",
+          "id": "komunalni-2022-533165-c-447119-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -417,16 +420,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-533165-candidate-359453",
+      "id": "komunalni-2022-533165-c-359453",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-533165-359453-party",
+          "id": "komunalni-2022-533165-c-359453-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -437,10 +441,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-533165-candidate-732747",
+      "id": "komunalni-2022-533165-c-732747",
       "name": "ZMĚNA PRO KOLÍN",
       "type": "party",
       "description": "ZMĚNA PRO KOLÍN - DESCRIPTION",
+      "img_url": "stan-nk",
       "contacts": {
         "web": [
           {
@@ -452,7 +457,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-533165-732747-party",
+          "id": "komunalni-2022-533165-c-732747-p",
           "name": "ZMĚNA PRO KOLÍN",
           "description": "ZMĚNA PRO KOLÍN - DESCRIPTION",
           "contacts": {
@@ -469,10 +474,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-533165-candidate-480055",
+      "id": "komunalni-2022-533165-c-480055",
       "name": "VOLBA PRO KOLÍN",
       "type": "party",
       "description": "VOLBA PRO KOLÍN - DESCRIPTION",
+      "img_url": "kdu-čsl-nk",
       "contacts": {
         "web": [
           {
@@ -484,7 +490,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-533165-480055-party",
+          "id": "komunalni-2022-533165-c-480055-p",
           "name": "VOLBA PRO KOLÍN",
           "description": "VOLBA PRO KOLÍN - DESCRIPTION",
           "contacts": {
@@ -501,10 +507,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-533165-candidate-290359",
+      "id": "komunalni-2022-533165-c-290359",
       "name": "Kolíňáci",
       "type": "party",
       "description": "Kolíňáci - DESCRIPTION",
+      "img_url": "sd-sn-nk",
       "contacts": {
         "web": [
           {
@@ -516,7 +523,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-533165-290359-party",
+          "id": "komunalni-2022-533165-c-290359-p",
           "name": "Kolíňáci",
           "description": "Kolíňáci - DESCRIPTION",
           "contacts": {
@@ -533,16 +540,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-533165-candidate-241611",
+      "id": "komunalni-2022-533165-c-241611",
       "name": "Platforma pro Kolín s podporou hnutí Přísaha",
       "type": "party",
       "description": "Platforma pro Kolín s podporou hnutí Přísaha - DESCRIPTION",
+      "img_url": "přísaha-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-533165-241611-party",
+          "id": "komunalni-2022-533165-c-241611-p",
           "name": "Platforma pro Kolín s podporou hnutí Přísaha",
           "description": "Platforma pro Kolín s podporou hnutí Přísaha - DESCRIPTION",
           "contacts": {
@@ -553,10 +561,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-533165-candidate-656909",
+      "id": "komunalni-2022-533165-c-656909",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": [
           {
@@ -572,7 +581,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-533165-656909-party",
+          "id": "komunalni-2022-533165-c-656909-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -593,10 +602,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-533165-candidate-692233",
+      "id": "komunalni-2022-533165-c-692233",
       "name": "SPOLEČNĚ ODS a TOP 09",
       "type": "party",
       "description": "SPOLEČNĚ ODS a TOP 09 - DESCRIPTION",
+      "img_url": "ods-top 09",
       "contacts": {
         "web": [
           {
@@ -609,7 +619,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-533165-692233-party",
+          "id": "komunalni-2022-533165-c-692233-p",
           "name": "SPOLEČNĚ ODS a TOP 09",
           "description": "SPOLEČNĚ ODS a TOP 09 - DESCRIPTION",
           "contacts": {
@@ -627,16 +637,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-533165-candidate-121551",
+      "id": "komunalni-2022-533165-c-121551",
       "name": "Zvíře není věc — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
       "type": "party",
       "description": "Zvíře není věc — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+      "img_url": "dsz-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-533165-121551-party",
+          "id": "komunalni-2022-533165-c-121551-p",
           "name": "Zvíře není věc — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
           "description": "Zvíře není věc — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
           "contacts": {
@@ -649,1177 +660,1177 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-533165-answer-241611-1",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-1",
+      "id": "komunalni-2022-533165-a-4",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-1",
       "comment": "V libovolné městské části může být sociální zařízení města, případně městské byty, prostřednictvím kterých bude město realizovat svou sociální politiku. V těchto programech mohou být lidé z různých příjmových skupin."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-2",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-2",
+      "id": "komunalni-2022-533165-a-7",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-2",
       "answer": "yes",
       "comment": "V tomto ohledu by město mělo diferencovat poplatek dle množství vyprodukovaného odpadu, nikoliv dle člena domácnosti."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-3",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-3",
+      "id": "komunalni-2022-533165-a-10",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-3",
       "answer": "no",
       "comment": "Ohrožená populace seniorů je obzvláště citlivá na tepelný komfort, toto by mělo být opravdu až tím posledním krokem v úsporách."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-4",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-4",
+      "id": "komunalni-2022-533165-a-13",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-4",
       "comment": "Ve městě by se mělo zajistit dodržování rychlosti 50 km/h (například ulice Pražská). Úseky, kde by bylo vhodné snížení rychlosti jsou již  tuto chvíli vyšší rychlostí neprůjezdné. Tedy takovéto opatření nepřinese, kromě dalších značek, nic pozitivního."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-5",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-5",
+      "id": "komunalni-2022-533165-a-16",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-5",
       "answer": "yes",
       "comment": "Město Kolín jako lidská komunita musí dbát především na etický a přívětivý přístup ke svým občanům. "
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-6",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-6",
+      "id": "komunalni-2022-533165-a-19",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-6",
       "comment": "Dle vyhodnocení využití a efektivity současných kamer. V exponovaných místech je možné zvážit, doplnit, případně vyměnit adekvátní zařízení, nicméně i soukromí občanů má pro nás svou hodnotu. "
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-7",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-7",
+      "id": "komunalni-2022-533165-a-22",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-7",
       "comment": "Státní legislativa po poslední změně zákonů je natolik přísná (zamezuje přístupu do heren závislým lidem, lidem na sociálních dávkách a dalším rizikovým skupinám), že pozbývá smyslu toto řešit na komunální úrovni."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-8",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-8",
+      "id": "komunalni-2022-533165-a-25",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-8",
       "answer": "yes",
       "comment": "Do uspokojivého vyřešení dostatku parkovacích míst a dopravní situace v Kolíně. Minimální podoba tohoto řešení spočívá v dopravě zdarma pro obyvatele postižených oblastí - dle ekonomických možností a situace městského rozpočtu."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-9",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-9",
+      "id": "komunalni-2022-533165-a-28",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-9",
       "answer": "yes",
       "comment": "Kolín nikdy nebude přívětivým městem pro své obyvatele, pokud senioři, kočárky a handicapovaní lidé nebudou mít spolehlivě dostupná všechna místa dopravní infrastruktury."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-10",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-10",
+      "id": "komunalni-2022-533165-a-31",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-10",
       "answer": "yes",
       "comment": "Jednoznačně ANO, každý musí být připraven čelit otázkám a osobní odpovědnosti před voliči."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-11",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-11",
+      "id": "komunalni-2022-533165-a-34",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-11",
       "answer": "yes",
       "comment": "Jednoznačně ANO, každý musí být připraven čelit otázkám a osobní odpovědnosti před voliči."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-12",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-12",
+      "id": "komunalni-2022-533165-a-37",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-12",
       "answer": "yes",
       "comment": "Negativa (domácí zvířata, malé děti) převažují nad myslitelnými pozitivy (zábava)."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-13",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-13",
+      "id": "komunalni-2022-533165-a-40",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-13",
       "answer": "yes",
       "comment": "Město jako komunita lidí musí nést část odpovědnosti za své občany. V tomto případě se jedná o ohroženou část populace, které hrozí závažné důsledky (zdravotní/životní), pokud takováto možnost nebude dostupná."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-14",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-14",
+      "id": "komunalni-2022-533165-a-43",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-14",
       "comment": "Je třeba individuálně posoudit dle zdroje energie (např. soběstačná fotovoltaika apod.)."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-15",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-15",
+      "id": "komunalni-2022-533165-a-46",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-15",
       "answer": "no",
       "comment": "S ohledem na bezpečnost je vhodnější spíše hledat úspornou formu osvětlení (LED apod.), nikoliv jeho vypnutí nebo zásadní omezení."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-16",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-16",
+      "id": "komunalni-2022-533165-a-49",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-16",
       "answer": "no",
       "comment": "Na místě je vyhodnotit zda-li jsou místnosti ve kterých vytápění není třeba (např. archiv), nicméně uvést zaměstnance a občany do zdravotního rizika není řešením. Adekvátní by bylo spíše redukovat potřebu osobní přítomnosti a využívat dálkové formy komunikace a řešení osobních a pracovních záležitostí. Tedy neomezovat vytápění v počtu stupňů, ale spíše redukovat dny, kdy je vytápěno (a kdy jsou lidé ve veřejných budovách)."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-17",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-17",
+      "id": "komunalni-2022-533165-a-52",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-17",
       "answer": "yes",
       "comment": "Toto je základní předpoklad pro zabránění následného sociálního vyloučení. Pokud vnikají \"dětští dlužníci\", město selhává na poli sociální ochrany dětí."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-18",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-18",
+      "id": "komunalni-2022-533165-a-55",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-19",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-19",
+      "id": "komunalni-2022-533165-a-58",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-20",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-20",
+      "id": "komunalni-2022-533165-a-61",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-20",
       "answer": "yes",
       "comment": "Tomuto by měla předcházet analýza současného využití bytového fondu, stavu bytového fondu a návaznost na sociální politiku a strategii města. V současné době je tato oblast hrubě poddimenzována."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-21",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-21",
+      "id": "komunalni-2022-533165-a-64",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-21",
       "comment": "Dle aktuální situace v době, kdy se bude rozhodovat. Pokud bude třeba hledat úspory, nebudou se týkat pouze osvětlení. A naopak osvětlení může být pouhým bezvýznamným zlomkem z toho, co je podstatné."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-22",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-22",
+      "id": "komunalni-2022-533165-a-67",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-22",
       "answer": "yes",
       "comment": "Zda-li však budou mít obědy zdarma by mělo rozhodovat zařazení do sociálně ohrožené skupiny, dle předem stanovených kritérií."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-23",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-23"
+      "id": "komunalni-2022-533165-a-70",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-23"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-24",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-24",
+      "id": "komunalni-2022-533165-a-73",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-24",
       "answer": "yes",
       "comment": "Kolín a jeho občané potřebují flexibilitu v pohybu automobilem. MHD není dostatečně dimenzovaná a významný je i pohyb směrem k okolním obcím a příměstským částem. Toto ani nelze (díky relativně nízké koncentraci populace) řešit spolehlivě MHD. Naopak takovéto řešení vytvoří další třecí plochu do již tak problematické situace s parkováním v Kolíně."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-25",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-25",
+      "id": "komunalni-2022-533165-a-76",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-25",
       "answer": "no",
       "comment": "Není pro to žádný důvod. Město by mělo naopak začít pečlivě dbát o své byty, jejich správu a rozvoj bytového portfolia."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-26",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-26",
+      "id": "komunalni-2022-533165-a-79",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-26",
       "answer": "yes",
       "comment": "V reáliích Kolína minimálně dvě parkovací místa na bytovou jednotku, a podíl na stavbách veřejné infrastruktury (školy, školky apod.)."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-27",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-27",
+      "id": "komunalni-2022-533165-a-82",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-27",
       "answer": "no",
       "comment": "V reáliích Kolína spíše problematizující faktor (vzhledem ke vzdálenostem, které mnozí musí každý den překonat)."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-28",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-28",
+      "id": "komunalni-2022-533165-a-85",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-29",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-29",
+      "id": "komunalni-2022-533165-a-88",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-30",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-30",
+      "id": "komunalni-2022-533165-a-91",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-30",
       "answer": "no",
       "comment": "Není zřejmé, jaká je budoucnost elektromobility, a stejně jako město nepřispívá na benzinové stanice, toto je v gesti buď soukromé, nebo státní podpory."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-31",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-31",
+      "id": "komunalni-2022-533165-a-94",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-32",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-32",
+      "id": "komunalni-2022-533165-a-97",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-33",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-33"
+      "id": "komunalni-2022-533165-a-100",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-33"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-34",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-34",
+      "id": "komunalni-2022-533165-a-103",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-35",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-35"
+      "id": "komunalni-2022-533165-a-106",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-35"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-36",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-36",
+      "id": "komunalni-2022-533165-a-109",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-37",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-37"
+      "id": "komunalni-2022-533165-a-112",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-37"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-38",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-38",
+      "id": "komunalni-2022-533165-a-115",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-39",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-39",
+      "id": "komunalni-2022-533165-a-118",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-39",
       "answer": "yes",
       "comment": "Toto je naprosto nezbytné v Kolíně, kde koncentrace cizích státních příslušníků dlouhodobě převyšuje celostátní průměr. Každý, kdo chce být členem komunity občanů, se v Kolíně musí cítit dobře."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-40",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-40",
+      "id": "komunalni-2022-533165-a-121",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-40",
       "answer": "yes",
       "comment": "Měli by být vidět v ulicích a zejména na exponovaných místech (nádraží, Futurum apod.)"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-41",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-41",
+      "id": "komunalni-2022-533165-a-124",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-41",
       "comment": "Zelená střecha není zárukou ekologičnosti budovy, ani efektivity chlazení. Existují pozitivní realizace i realizace, které neplní svou funkci."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-42",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-42"
+      "id": "komunalni-2022-533165-a-127",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-42"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-43",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-43",
+      "id": "komunalni-2022-533165-a-130",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-43",
       "answer": "no",
       "comment": "Město by mělo podporovat maximální aktivní sportování svých občanů. Profesionální sport by měl být financován ze soukromých zdrojů."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-44",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-44"
+      "id": "komunalni-2022-533165-a-133",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-44"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-45",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-45",
+      "id": "komunalni-2022-533165-a-136",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-46",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-46",
+      "id": "komunalni-2022-533165-a-139",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-47",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-47",
+      "id": "komunalni-2022-533165-a-142",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-47",
       "comment": "Město musí mít koncepci pro efektivní integraci sociálně znevýhodněných osob. Samotné rozdělení do mnoha lokalit nevyřeší tento problém, pouze vytvoří problém v mnoha lokalitách. Tedy samotné shromažďování při citlivém a cíleném pedagogickém managementu mlže být větším přínosem, než bezmyšlenkovité rozdělení do mnoha škol, které na to nejsou připraveny."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-48",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-48",
+      "id": "komunalni-2022-533165-a-145",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-48",
       "answer": "yes",
       "comment": "Městská předškolní zařízení."
     },
     {
-      "id": "komunalni-2022-533165-answer-241611-49",
-      "candidate_id": "komunalni-2022-533165-candidate-241611",
-      "question_id": "komunalni-2022-533165-question-49"
+      "id": "komunalni-2022-533165-a-148",
+      "candidate_id": "komunalni-2022-533165-c-241611",
+      "question_id": "komunalni-2022-533165-q-49"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-1",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-1",
+      "id": "komunalni-2022-533165-a-4",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-2",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-2",
+      "id": "komunalni-2022-533165-a-7",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-3",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-3",
+      "id": "komunalni-2022-533165-a-10",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-4",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-4",
+      "id": "komunalni-2022-533165-a-13",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-5",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-5",
+      "id": "komunalni-2022-533165-a-16",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-6",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-6",
+      "id": "komunalni-2022-533165-a-19",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-7",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-7",
+      "id": "komunalni-2022-533165-a-22",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-8",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-8",
+      "id": "komunalni-2022-533165-a-25",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-9",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-9",
+      "id": "komunalni-2022-533165-a-28",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-10",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-10",
+      "id": "komunalni-2022-533165-a-31",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-11",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-11",
+      "id": "komunalni-2022-533165-a-34",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-12",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-12",
+      "id": "komunalni-2022-533165-a-37",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-13",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-13",
+      "id": "komunalni-2022-533165-a-40",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-13",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-14",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-14",
+      "id": "komunalni-2022-533165-a-43",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-15",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-15",
+      "id": "komunalni-2022-533165-a-46",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-15",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-16",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-16",
+      "id": "komunalni-2022-533165-a-49",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-17",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-17",
+      "id": "komunalni-2022-533165-a-52",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-17",
       "answer": "no",
       "comment": "Určitě ne plošně a automaticky "
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-18",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-18",
+      "id": "komunalni-2022-533165-a-55",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-19",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-19"
+      "id": "komunalni-2022-533165-a-58",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-19"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-20",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-20",
+      "id": "komunalni-2022-533165-a-61",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-20",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-21",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-21",
+      "id": "komunalni-2022-533165-a-64",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-22",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-22",
+      "id": "komunalni-2022-533165-a-67",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-23",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-23",
+      "id": "komunalni-2022-533165-a-70",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-24",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-24",
+      "id": "komunalni-2022-533165-a-73",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-25",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-25",
+      "id": "komunalni-2022-533165-a-76",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-25",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-26",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-26",
+      "id": "komunalni-2022-533165-a-79",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-27",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-27",
+      "id": "komunalni-2022-533165-a-82",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-28",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-28",
+      "id": "komunalni-2022-533165-a-85",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-29",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-29"
+      "id": "komunalni-2022-533165-a-88",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-29"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-30",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-30",
+      "id": "komunalni-2022-533165-a-91",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-31",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-31",
+      "id": "komunalni-2022-533165-a-94",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-31",
       "comment": "Jak podporovat? město tomu nemá bránit a jistou nefinanční podporu proč ne."
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-32",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-32",
+      "id": "komunalni-2022-533165-a-97",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-33",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-33",
+      "id": "komunalni-2022-533165-a-100",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-33",
       "comment": "Jak pomoc? město tomu nemá bránit a jistou nefinanční podporu proč ne."
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-34",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-34",
+      "id": "komunalni-2022-533165-a-103",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-34",
       "answer": "no",
       "comment": "Záleží jaké muzea a jaké sportoviště. Je rozdíl mezi tělocvičnou u školy a zimním stadionem."
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-35",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-35",
+      "id": "komunalni-2022-533165-a-106",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-36",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-36",
+      "id": "komunalni-2022-533165-a-109",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-37",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-37",
+      "id": "komunalni-2022-533165-a-112",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-38",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-38",
+      "id": "komunalni-2022-533165-a-115",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-39",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-39",
+      "id": "komunalni-2022-533165-a-118",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-40",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-40",
+      "id": "komunalni-2022-533165-a-121",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-41",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-41",
+      "id": "komunalni-2022-533165-a-124",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-42",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-42",
+      "id": "komunalni-2022-533165-a-127",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-43",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-43",
+      "id": "komunalni-2022-533165-a-130",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-44",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-44",
+      "id": "komunalni-2022-533165-a-133",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-45",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-45",
+      "id": "komunalni-2022-533165-a-136",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-45",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-46",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-46",
+      "id": "komunalni-2022-533165-a-139",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-47",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-47",
+      "id": "komunalni-2022-533165-a-142",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-48",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-48",
+      "id": "komunalni-2022-533165-a-145",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-48",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-692233-49",
-      "candidate_id": "komunalni-2022-533165-candidate-692233",
-      "question_id": "komunalni-2022-533165-question-49",
+      "id": "komunalni-2022-533165-a-148",
+      "candidate_id": "komunalni-2022-533165-c-692233",
+      "question_id": "komunalni-2022-533165-q-49",
       "comment": "některé otázky jsou nejednoznačné"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-1",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-1"
+      "id": "komunalni-2022-533165-a-4",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-1"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-2",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-2",
+      "id": "komunalni-2022-533165-a-7",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-3",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-3",
+      "id": "komunalni-2022-533165-a-10",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-4",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-4",
+      "id": "komunalni-2022-533165-a-13",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-5",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-5"
+      "id": "komunalni-2022-533165-a-16",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-5"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-6",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-6",
+      "id": "komunalni-2022-533165-a-19",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-7",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-7",
+      "id": "komunalni-2022-533165-a-22",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-8",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-8"
+      "id": "komunalni-2022-533165-a-25",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-8"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-9",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-9"
+      "id": "komunalni-2022-533165-a-28",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-9"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-10",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-10",
+      "id": "komunalni-2022-533165-a-31",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-11",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-11",
+      "id": "komunalni-2022-533165-a-34",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-12",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-12",
+      "id": "komunalni-2022-533165-a-37",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-13",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-13"
+      "id": "komunalni-2022-533165-a-40",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-13"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-14",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-14",
+      "id": "komunalni-2022-533165-a-43",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-15",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-15",
+      "id": "komunalni-2022-533165-a-46",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-15",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-16",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-16",
+      "id": "komunalni-2022-533165-a-49",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-16",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-17",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-17"
+      "id": "komunalni-2022-533165-a-52",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-17"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-18",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-18"
+      "id": "komunalni-2022-533165-a-55",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-18"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-19",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-19"
+      "id": "komunalni-2022-533165-a-58",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-19"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-20",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-20",
+      "id": "komunalni-2022-533165-a-61",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-21",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-21"
+      "id": "komunalni-2022-533165-a-64",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-21"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-22",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-22"
+      "id": "komunalni-2022-533165-a-67",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-22"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-23",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-23",
+      "id": "komunalni-2022-533165-a-70",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-24",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-24",
+      "id": "komunalni-2022-533165-a-73",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-25",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-25",
+      "id": "komunalni-2022-533165-a-76",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-26",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-26"
+      "id": "komunalni-2022-533165-a-79",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-26"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-27",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-27",
+      "id": "komunalni-2022-533165-a-82",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-28",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-28"
+      "id": "komunalni-2022-533165-a-85",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-28"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-29",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-29"
+      "id": "komunalni-2022-533165-a-88",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-29"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-30",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-30"
+      "id": "komunalni-2022-533165-a-91",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-30"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-31",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-31",
+      "id": "komunalni-2022-533165-a-94",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-32",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-32",
+      "id": "komunalni-2022-533165-a-97",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-33",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-33"
+      "id": "komunalni-2022-533165-a-100",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-33"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-34",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-34",
+      "id": "komunalni-2022-533165-a-103",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-35",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-35"
+      "id": "komunalni-2022-533165-a-106",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-35"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-36",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-36"
+      "id": "komunalni-2022-533165-a-109",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-36"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-37",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-37"
+      "id": "komunalni-2022-533165-a-112",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-37"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-38",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-38",
+      "id": "komunalni-2022-533165-a-115",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-39",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-39"
+      "id": "komunalni-2022-533165-a-118",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-39"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-40",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-40",
+      "id": "komunalni-2022-533165-a-121",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-41",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-41"
+      "id": "komunalni-2022-533165-a-124",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-41"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-42",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-42"
+      "id": "komunalni-2022-533165-a-127",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-42"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-43",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-43",
+      "id": "komunalni-2022-533165-a-130",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-44",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-44"
+      "id": "komunalni-2022-533165-a-133",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-44"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-45",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-45"
+      "id": "komunalni-2022-533165-a-136",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-45"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-46",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-46",
+      "id": "komunalni-2022-533165-a-139",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-47",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-47"
+      "id": "komunalni-2022-533165-a-142",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-47"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-48",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-48",
+      "id": "komunalni-2022-533165-a-145",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-447119-49",
-      "candidate_id": "komunalni-2022-533165-candidate-447119",
-      "question_id": "komunalni-2022-533165-question-49"
+      "id": "komunalni-2022-533165-a-148",
+      "candidate_id": "komunalni-2022-533165-c-447119",
+      "question_id": "komunalni-2022-533165-q-49"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-1",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-1",
+      "id": "komunalni-2022-533165-a-4",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-1",
       "answer": "no",
       "comment": "Segregace v bydlení vede i k segregaci ve společnosti. Lidé by měli znát jak se žije ostatní mimo jejich sociální bublinu."
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-2",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-2",
+      "id": "komunalni-2022-533165-a-7",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-3",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-3",
+      "id": "komunalni-2022-533165-a-10",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-3",
       "answer": "no",
       "comment": "Senioři se již těžce přizpůsobují, umím si představit omezení teploty např. ve školách nebo na úřadech."
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-4",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-4",
+      "id": "komunalni-2022-533165-a-13",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-4",
       "answer": "yes",
       "comment": "Auta mimoměstská by měla být vedena po obchvatech a ve městě by měly být páteřní silnice a zbytek klidové zóny s 30 kmh."
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-5",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-5",
+      "id": "komunalni-2022-533165-a-16",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-5",
       "answer": "yes",
       "comment": "Ukazuje to na ochotu města pomoci svým občanům."
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-6",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-6",
+      "id": "komunalni-2022-533165-a-19",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-6",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-7",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-7",
+      "id": "komunalni-2022-533165-a-22",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-8",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-8",
+      "id": "komunalni-2022-533165-a-25",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-8",
       "answer": "yes",
       "comment": "Pouze pokud to významně neohrozí rozpočet města."
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-9",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-9"
+      "id": "komunalni-2022-533165-a-28",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-9"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-10",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-10",
+      "id": "komunalni-2022-533165-a-31",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-11",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-11",
+      "id": "komunalni-2022-533165-a-34",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-12",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-12"
+      "id": "komunalni-2022-533165-a-37",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-12"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-13",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-13",
+      "id": "komunalni-2022-533165-a-40",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-13",
       "answer": "yes",
       "comment": "V současné době určitě."
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-14",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-14",
+      "id": "komunalni-2022-533165-a-43",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-14",
       "answer": "yes",
       "comment": "Jsou věci nezbytné, ale osvícení památek do nich nepatří."
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-15",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-15",
+      "id": "komunalni-2022-533165-a-46",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-15",
       "answer": "yes",
       "comment": "Takovým způsobem, aby neohrozilo bezpečnost na silnicích i ulicích."
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-16",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-16",
+      "id": "komunalni-2022-533165-a-49",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-17",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-17",
+      "id": "komunalni-2022-533165-a-52",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-18",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-18",
+      "id": "komunalni-2022-533165-a-55",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-19",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-19",
+      "id": "komunalni-2022-533165-a-58",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-20",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-20",
+      "id": "komunalni-2022-533165-a-61",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-21",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-21",
+      "id": "komunalni-2022-533165-a-64",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-21",
       "comment": "V průběhu roku ano, v době Vánoc bude záležet na aktuální situaci."
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-22",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-22",
+      "id": "komunalni-2022-533165-a-67",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-22",
       "answer": "no",
       "comment": "Jsme spíše pro zavedení jednotného místa (vývařovny) a úspoře fixních nákladů."
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-23",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-23"
+      "id": "komunalni-2022-533165-a-70",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-23"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-24",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-24",
+      "id": "komunalni-2022-533165-a-73",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-24",
       "answer": "yes",
       "comment": "Parkování rezidentů a nerezidentů má být oddělené."
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-25",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-25",
+      "id": "komunalni-2022-533165-a-76",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-26",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-26",
+      "id": "komunalni-2022-533165-a-79",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-27",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-27",
+      "id": "komunalni-2022-533165-a-82",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-28",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-28"
+      "id": "komunalni-2022-533165-a-85",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-28"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-29",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-29",
+      "id": "komunalni-2022-533165-a-88",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-30",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-30",
+      "id": "komunalni-2022-533165-a-91",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-30",
       "comment": "Město se má připravit na rychlé vybudování - příkon elektrické energie, rozvody a pak bude moci rychle jednat na základě požadavků trhu/občanů."
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-31",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-31",
+      "id": "komunalni-2022-533165-a-94",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-32",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-32",
+      "id": "komunalni-2022-533165-a-97",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-33",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-33",
+      "id": "komunalni-2022-533165-a-100",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-34",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-34",
+      "id": "komunalni-2022-533165-a-103",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-35",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-35",
+      "id": "komunalni-2022-533165-a-106",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-36",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-36",
+      "id": "komunalni-2022-533165-a-109",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-36",
       "answer": "no",
       "comment": "Nevidíme důvod proč zákonnou. Dá se to dělat i bez zákonného rámce."
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-37",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-37",
+      "id": "komunalni-2022-533165-a-112",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-37",
       "answer": "yes",
       "comment": "Už mělo."
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-38",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-38",
+      "id": "komunalni-2022-533165-a-115",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-39",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-39",
+      "id": "komunalni-2022-533165-a-118",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-40",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-40"
+      "id": "komunalni-2022-533165-a-121",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-40"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-41",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-41",
+      "id": "komunalni-2022-533165-a-124",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-42",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-42",
+      "id": "komunalni-2022-533165-a-127",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-43",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-43",
+      "id": "komunalni-2022-533165-a-130",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-44",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-44"
+      "id": "komunalni-2022-533165-a-133",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-44"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-45",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-45",
+      "id": "komunalni-2022-533165-a-136",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-46",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-46",
+      "id": "komunalni-2022-533165-a-139",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-47",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-47",
+      "id": "komunalni-2022-533165-a-142",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-48",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-48",
+      "id": "komunalni-2022-533165-a-145",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-48",
       "answer": "no",
       "comment": "Osobní názor lídra kandidátky: Děti do 2 let věku by měly být s matkou a ne v předškolním zařízení."
     },
     {
-      "id": "komunalni-2022-533165-answer-656909-49",
-      "candidate_id": "komunalni-2022-533165-candidate-656909",
-      "question_id": "komunalni-2022-533165-question-49",
+      "id": "komunalni-2022-533165-a-148",
+      "candidate_id": "komunalni-2022-533165-c-656909",
+      "question_id": "komunalni-2022-533165-q-49",
       "comment": "Děkujeme za práci, kterou odvádíte :-)"
     }
   ]

--- a/data/kalkulacka/komunalni-2022/535419.json
+++ b/data/kalkulacka/komunalni-2022/535419.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-535419",
   "name": "Mladá Boleslav",
-  "description": "Mladá Boleslav - DESCRIPTION",
+  "description": "Mladá Boleslav",
   "district_code": "535419",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-535419-question-1",
+      "id": "komunalni-2022-535419-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-2",
+      "id": "komunalni-2022-535419-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-3",
+      "id": "komunalni-2022-535419-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-4",
+      "id": "komunalni-2022-535419-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-5",
+      "id": "komunalni-2022-535419-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-6",
+      "id": "komunalni-2022-535419-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-7",
+      "id": "komunalni-2022-535419-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-8",
+      "id": "komunalni-2022-535419-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-9",
+      "id": "komunalni-2022-535419-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-10",
+      "id": "komunalni-2022-535419-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-11",
+      "id": "komunalni-2022-535419-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-12",
+      "id": "komunalni-2022-535419-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-13",
+      "id": "komunalni-2022-535419-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-14",
+      "id": "komunalni-2022-535419-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-15",
+      "id": "komunalni-2022-535419-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-16",
+      "id": "komunalni-2022-535419-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-17",
+      "id": "komunalni-2022-535419-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-18",
+      "id": "komunalni-2022-535419-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-19",
+      "id": "komunalni-2022-535419-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-20",
+      "id": "komunalni-2022-535419-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-21",
+      "id": "komunalni-2022-535419-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-22",
+      "id": "komunalni-2022-535419-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-23",
+      "id": "komunalni-2022-535419-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-24",
+      "id": "komunalni-2022-535419-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-25",
+      "id": "komunalni-2022-535419-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-26",
+      "id": "komunalni-2022-535419-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-27",
+      "id": "komunalni-2022-535419-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-28",
+      "id": "komunalni-2022-535419-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-29",
+      "id": "komunalni-2022-535419-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-30",
+      "id": "komunalni-2022-535419-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-31",
+      "id": "komunalni-2022-535419-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-32",
+      "id": "komunalni-2022-535419-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-33",
+      "id": "komunalni-2022-535419-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-34",
+      "id": "komunalni-2022-535419-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-35",
+      "id": "komunalni-2022-535419-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-36",
+      "id": "komunalni-2022-535419-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-37",
+      "id": "komunalni-2022-535419-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-38",
+      "id": "komunalni-2022-535419-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-39",
+      "id": "komunalni-2022-535419-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-40",
+      "id": "komunalni-2022-535419-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-41",
+      "id": "komunalni-2022-535419-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-42",
+      "id": "komunalni-2022-535419-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-43",
+      "id": "komunalni-2022-535419-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-44",
+      "id": "komunalni-2022-535419-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-45",
+      "id": "komunalni-2022-535419-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-46",
+      "id": "komunalni-2022-535419-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-47",
+      "id": "komunalni-2022-535419-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-535419-question-48",
+      "id": "komunalni-2022-535419-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,16 +399,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-535419-candidate-502371",
+      "id": "komunalni-2022-535419-c-502371",
       "name": "Levicoví občané",
       "type": "party",
       "description": "Levicoví občané - DESCRIPTION",
+      "img_url": "ksčm-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-535419-502371-party",
+          "id": "komunalni-2022-535419-c-502371-p",
           "name": "Levicoví občané",
           "description": "Levicoví občané - DESCRIPTION",
           "contacts": {
@@ -417,16 +420,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-535419-candidate-341365",
+      "id": "komunalni-2022-535419-c-341365",
       "name": "ANO 2011 + Volba pro Mladou Boleslav",
       "type": "party",
       "description": "ANO 2011 + Volba pro Mladou Boleslav - DESCRIPTION",
+      "img_url": "vpmb-ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-535419-341365-party",
+          "id": "komunalni-2022-535419-c-341365-p",
           "name": "ANO 2011 + Volba pro Mladou Boleslav",
           "description": "ANO 2011 + Volba pro Mladou Boleslav - DESCRIPTION",
           "contacts": {
@@ -437,10 +441,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-535419-candidate-378057",
+      "id": "komunalni-2022-535419-c-378057",
       "name": "Občanská demokratická strana, TOP 09 a nezávislí kandidáti",
       "type": "party",
       "description": "Občanská demokratická strana, TOP 09 a nezávislí kandidáti - DESCRIPTION",
+      "img_url": "ods-top 09-nk",
       "contacts": {
         "web": [
           {
@@ -451,7 +456,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-535419-378057-party",
+          "id": "komunalni-2022-535419-c-378057-p",
           "name": "Občanská demokratická strana, TOP 09 a nezávislí kandidáti",
           "description": "Občanská demokratická strana, TOP 09 a nezávislí kandidáti - DESCRIPTION",
           "contacts": {
@@ -467,16 +472,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-535419-candidate-418049",
+      "id": "komunalni-2022-535419-c-418049",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-535419-418049-party",
+          "id": "komunalni-2022-535419-c-418049-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -487,16 +493,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-535419-candidate-680014",
+      "id": "komunalni-2022-535419-c-680014",
       "name": "KRÁSNÁ MLADÁ BOLESLAV",
       "type": "party",
       "description": "KRÁSNÁ MLADÁ BOLESLAV - DESCRIPTION",
+      "img_url": "apb-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-535419-680014-party",
+          "id": "komunalni-2022-535419-c-680014-p",
           "name": "KRÁSNÁ MLADÁ BOLESLAV",
           "description": "KRÁSNÁ MLADÁ BOLESLAV - DESCRIPTION",
           "contacts": {
@@ -507,16 +514,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-535419-candidate-651475",
+      "id": "komunalni-2022-535419-c-651475",
       "name": "HLAS PRO BOLESLAV",
       "type": "party",
       "description": "HLAS PRO BOLESLAV - DESCRIPTION",
+      "img_url": "čssd-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-535419-651475-party",
+          "id": "komunalni-2022-535419-c-651475-p",
           "name": "HLAS PRO BOLESLAV",
           "description": "HLAS PRO BOLESLAV - DESCRIPTION",
           "contacts": {
@@ -527,16 +535,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-535419-candidate-174626",
+      "id": "komunalni-2022-535419-c-174626",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
       "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "img_url": "stan",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-535419-174626-party",
+          "id": "komunalni-2022-535419-c-174626-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
           "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
           "contacts": {
@@ -547,16 +556,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-535419-candidate-602724",
+      "id": "komunalni-2022-535419-c-602724",
       "name": "ŠANCE PRO MLADOU BOLESLAV (KOALICE STRANY ZELENÝCH A KDU-ČSL)",
       "type": "party",
       "description": "ŠANCE PRO MLADOU BOLESLAV (KOALICE STRANY ZELENÝCH A KDU-ČSL) - DESCRIPTION",
+      "img_url": "kdu-čsl-zelení",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-535419-602724-party",
+          "id": "komunalni-2022-535419-c-602724-p",
           "name": "ŠANCE PRO MLADOU BOLESLAV (KOALICE STRANY ZELENÝCH A KDU-ČSL)",
           "description": "ŠANCE PRO MLADOU BOLESLAV (KOALICE STRANY ZELENÝCH A KDU-ČSL) - DESCRIPTION",
           "contacts": {
@@ -569,317 +579,317 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-535419-answer-602724-1",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-1",
+      "id": "komunalni-2022-535419-a-4",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-1",
       "answer": "no",
       "comment": "Rozdělováním města na preferované a zanedbávané lokality vytváříme ghetta, což působí pnutí ve společnosti. To je naprosto nežádoucí. Vedení měst má usilovat o to, aby soužití bylo poklidné, bezpečné a na dostatečně vysoké úrovni, abychom nerovnostem předcházeli. Město má mít k dispozici dostatečně velký bytový fond pro potřebné profese i méně movité. Dobré příklady můžeme najít v evropských městech, kde jsou v této problematice podstatně dál."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-2",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-2",
+      "id": "komunalni-2022-535419-a-7",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-2",
       "answer": "yes",
       "comment": "Odpad jsou suroviny, které bylo nutné vytěžit, složitě zpracovat s využitím energie a vody a komplikovaných výrobních procesů. To vše stojí nejen peníze, ale i lidské úsilí a práci, aby se výrobek v obalu dostal ke spotřebiteli. Je odpovědností každého z nás, jak s odpadními surovinami dále nakládáme, protože peníze, čas a energii stojí sběr, odvoz i další zpracování odpadů. Třídit a znovu maximálně využívat odpady má být samozřejmostí. Spoustu odpadů ani nemusíme vytvořit, čímž chráníme životní prostředí i naše peněženky.  "
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-3",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-3",
+      "id": "komunalni-2022-535419-a-10",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-3",
       "answer": "no",
       "comment": "Společnost se má primárně co nejlépe postarat o nejslabší z nás, tedy ty, kteří jsou na tom ekonomicky i sociálně nejhůře. Okamžité úspory lze hledat jinde, např. v rozpočtu města, ve větší transparentnosti zakázek, v efektivitě práce apod. Nejvíce šetří energie tam, kde je již zatepleno, těsní dobře okna a dveře, přešli na alternativní zdroje. Mnozí se připravili včas, v Mladé Boleslavi však na možná rizika budoucnosti nebyl brán zřetel, bohužel pro občany."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-4",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-4",
+      "id": "komunalni-2022-535419-a-13",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-4",
       "answer": "yes",
       "comment": "Nízká rychlost by měla být v obytných zónách a v okolí škol, ale tam snad ani normální rychlost kvůli zácpám není možná. Problémem je překračování rychlosti na rovných táhlých úsecích ve městě, kterou však nikdo nepostihuje a neřeší."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-5",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-5",
+      "id": "komunalni-2022-535419-a-16",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-5",
       "answer": "yes",
       "comment": "Radnice slouží občanům, má tedy vynakládat maximální úsilí, aby každý občan našel podporu v místě bydliště. Dnešní doba je složitá, rychle se proměňuje, je snadné se ztratit v informacích a utopit se v problémech. Radnice má být místem, kde se každý snadno zorientuje a najde potřebnou pomoc."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-6",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-6",
+      "id": "komunalni-2022-535419-a-19",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-6",
       "answer": "yes",
       "comment": "Vnímáme problém zneužívání dat, informací i kamerových záznamů, avšak na místech, kde často dochází k překračování rychlosti, útokům, krádežím nebo jiné kriminalitě, je smysluplné při nedostatku policistů instalovat více kamer ve městě. Je však nutné spolu s tím řešit problémy ve městě i dalšími způsoby, např. zvýšením počtu policejních hlídek v ulicích, nastavením jasných priorit a pravidel, aby byla srozumitelná pro každého, dodržovat zákony a předpisy samotnými představiteli města. A samozřejmě kontrola, zda vše funguje jak má."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-7",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-7",
+      "id": "komunalni-2022-535419-a-22",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-7",
       "answer": "yes",
       "comment": "Procházka centrem je děsivá, taková koncentrace heren je jinde nevídaná, snad v Las Vegas. Pro město je to prašivý zdroj příjmů, bez kterého se obejdeme. Spíše je otázkou, zda veškeré činnosti, související s provozem heren, jsou skutečně legální?! Probíhá dostatečná osvěta mezi dětmi a mládeží o rizicích (nejen) gamblingu?! "
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-8",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-8",
+      "id": "komunalni-2022-535419-a-25",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-8",
       "answer": "yes",
       "comment": "Je to jedna z možností, jak lidi motivovat nesedat vůbec do aut, když to není nezbytně nutné. Naše město je díky silnému automobilovému průmyslu počtem aut přetížené, ne všichni jsou ochotni jezdit na kole nebo chodit pěšky. Spolehlivá a příjemná doprava městskými autobusy má být proto samozřejmostí."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-9",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-9",
+      "id": "komunalni-2022-535419-a-28",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-9",
       "answer": "yes",
       "comment": "Nejde jen o bezbariérovost, ale i o tristní nedostatek chytrých zastávek. Ve městě, kde působí jedna z nejmodernějších firem světa, máme jízdní řády tištěné a pro většinu lidí s nečitelným písmem. Často chybí zastínění či posezení, o bezpečnosti v okolí nemluvě. Samostatnou kapitolou je autobusové nádraží, znečištěné výkaly holubů."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-10",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-10",
+      "id": "komunalni-2022-535419-a-31",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-10",
       "answer": "yes",
       "comment": "Na webu města Mladá Boleslav jsou k dohledání jmenovité seznamy při hlasování zastupitelstva, avšak dělá se jen zvukový, nikoliv obrazový záznam jednání. Také zahájení programu je od 15 hodin, kdy většina běžné populace je ještě v práci. Tím se snižuje možnost zapojení veřejnosti."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-11",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-11",
+      "id": "komunalni-2022-535419-a-34",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-11",
       "answer": "yes",
       "comment": "Zastupitelé města dostávají sbírky usnesení rady města, avšak není uváděno, kdo jak hlasoval ani jak projednávání bodů probíhalo."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-12",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-12",
+      "id": "komunalni-2022-535419-a-37",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-12",
       "answer": "yes",
       "comment": "Vzhledem k vysokému zatížení města hlukem z provozu průmyslu a jiným možnostem silvestrovských atrakcí se domníváme, že pyrotechniku není nutné používat vůbec. Chceme ohleduplnější silvestrovskou zábavu, např. využitím videomappingu. Tak zabráníme nepříjemným důsledkům pro život a zdraví nejen lidí, ale i zvířat."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-13",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-13",
+      "id": "komunalni-2022-535419-a-40",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-14",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-14",
+      "id": "komunalni-2022-535419-a-43",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-14",
       "comment": "V Mladé Boleslavi za osvětlení platíme astronomické sumy proto, že zakázka není transparentně vysoutěžená. Spořit se dá tedy primárně tam - najít spravedlivou cenu, kde se ušetří desítky milionů ročně jen na řádně vysoutěžené zakázce. A to jde jen o osvětlení, takových neférových zakázek je město přesycené. Během let se tímto způsobem \"ztratily\" miliardy."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-15",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-15",
+      "id": "komunalni-2022-535419-a-46",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-15",
       "answer": "no",
       "comment": "Viz odpověď na otázku č. 14."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-16",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-16",
+      "id": "komunalni-2022-535419-a-49",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-16",
       "comment": "Bylo by dobré mít předem analýzu, kde nejen utíkají peníze z rozpočtu, ale i energie. Pak má smysl se bavit o formě úspor. Zatím se vynakládají nepřiměřené výdaje v řádech milionů až miliard tam, kde z toho občané nemají vůbec nic. "
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-17",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-17",
+      "id": "komunalni-2022-535419-a-52",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-18",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-18",
+      "id": "komunalni-2022-535419-a-55",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-18",
       "answer": "yes",
       "comment": "Vzhledem k masivní nehospodárnosti zacházení s městským rozpočtem je to nutnost!"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-19",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-19",
+      "id": "komunalni-2022-535419-a-58",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-20",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-20",
+      "id": "komunalni-2022-535419-a-61",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-20",
       "answer": "yes",
       "comment": "Město dělá vše pro to, aby bydlení bylo nedostupné pro běžného občana - rozprodalo nejen byty, ale i většinu pozemků města, naopak zvýhodnilo pozemky soukromníků účelovými machinacemi. "
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-21",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-21",
+      "id": "komunalni-2022-535419-a-64",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-21",
       "answer": "no",
       "comment": "Za špatně odvedenou zakázku vánočního osvětlení město muselo zaplatit pokutu, vyměřenou Úřadem pro ochranu hospodářské soutěže. Spořit se v Mladé Boleslavi musí především na zakázkách díky vyšší transparentnosti, pak se ušetří stovky milionů ročně!"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-22",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-22",
+      "id": "komunalni-2022-535419-a-67",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-22",
       "comment": "Podporujeme pomoc rodinám a dětem, o vhodné formě je nezbytné diskutovat a najít nejlepší řešení."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-23",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-23",
+      "id": "komunalni-2022-535419-a-70",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-23",
       "answer": "yes",
       "comment": "Jak je možné, že ve městě automobilů to ještě nezačalo?!"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-24",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-24",
+      "id": "komunalni-2022-535419-a-73",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-24",
       "answer": "no",
       "comment": "Do Mladé Boleslavi dojíždí příliš mnoho zaměstnanců, což vytváří nespravedlivé podmínky pro místní občany - většina parkovacích ploch je zdarma, parkovací domy zejí prázdnotou, ačkoliv za parkování je směšný poplatek. V některých ulicích dochází k porušování legislativy, neboť kvůli zaparkovaným autům nemůže projet např. záchranka či hasiči. Před každými volbami vítězná strana slibovala zavést parkovací systém, ani na čtvrtý pokus to však neudělala. Občané žádají srozumitelné podmínky parkování, ne šikanu policie při výběru pokut za špatné parkování."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-25",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-25",
+      "id": "komunalni-2022-535419-a-76",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-26",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-26",
+      "id": "komunalni-2022-535419-a-79",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-27",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-27",
+      "id": "komunalni-2022-535419-a-82",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-28",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-28",
+      "id": "komunalni-2022-535419-a-85",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-28",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-29",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-29",
+      "id": "komunalni-2022-535419-a-88",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-30",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-30",
+      "id": "komunalni-2022-535419-a-91",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-31",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-31",
+      "id": "komunalni-2022-535419-a-94",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-32",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-32",
+      "id": "komunalni-2022-535419-a-97",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-33",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-33",
+      "id": "komunalni-2022-535419-a-100",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-34",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-34",
+      "id": "komunalni-2022-535419-a-103",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-35",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-35",
+      "id": "komunalni-2022-535419-a-106",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-36",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-36",
+      "id": "komunalni-2022-535419-a-109",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-36",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-37",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-37",
+      "id": "komunalni-2022-535419-a-112",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-38",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-38",
+      "id": "komunalni-2022-535419-a-115",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-39",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-39",
+      "id": "komunalni-2022-535419-a-118",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-40",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-40",
+      "id": "komunalni-2022-535419-a-121",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-41",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-41",
+      "id": "komunalni-2022-535419-a-124",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-42",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-42",
+      "id": "komunalni-2022-535419-a-127",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-43",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-43",
+      "id": "komunalni-2022-535419-a-130",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-43",
       "answer": "yes",
       "comment": "Primárně však se má starat o dostatečné možnosti sportovního vyžití pro všechny! Je nutné dobudovat sportovní zázemí, opravit kabiny a klubovny, nové vytvořit. Pozornost se dosud soustředí bohužel na dva hlavní sporty, avšak mnoho i úspěšných oddílů zůstává bez větší pozornosti. Vytvořme spravedlivější pravidla nejen pro malé, ale i pro dospělé sportovce, aby mohl sportovat každý, kdo chce."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-44",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-44",
+      "id": "komunalni-2022-535419-a-133",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-45",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-45",
+      "id": "komunalni-2022-535419-a-136",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-45",
       "answer": "yes",
       "comment": "Vzhledem k množství sociálních problémů v Mladé Boleslavi, které se postupem času zhoršují, je nezbytné situaci začít konstruktivně řešit! Musíme se zabývat množstvím bezdomovců, drogových uživatelů, sociálně slabých rodin, cizinců apod., dosud byly problémy přehlíženy. To způsobuje rostoucí nespokojenost místních."
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-46",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-46",
+      "id": "komunalni-2022-535419-a-139",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-47",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-47",
+      "id": "komunalni-2022-535419-a-142",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-48",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-48",
+      "id": "komunalni-2022-535419-a-145",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-535419-answer-602724-49",
-      "candidate_id": "komunalni-2022-535419-candidate-602724",
-      "question_id": "komunalni-2022-535419-question-49"
+      "id": "komunalni-2022-535419-a-148",
+      "candidate_id": "komunalni-2022-535419-c-602724",
+      "question_id": "komunalni-2022-535419-q-49"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/539911.json
+++ b/data/kalkulacka/komunalni-2022/539911.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-539911",
   "name": "Příbram",
-  "description": "Příbram - DESCRIPTION",
+  "description": "Příbram",
   "district_code": "539911",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-539911-question-1",
+      "id": "komunalni-2022-539911-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-2",
+      "id": "komunalni-2022-539911-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-3",
+      "id": "komunalni-2022-539911-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-4",
+      "id": "komunalni-2022-539911-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-5",
+      "id": "komunalni-2022-539911-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-6",
+      "id": "komunalni-2022-539911-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-7",
+      "id": "komunalni-2022-539911-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-8",
+      "id": "komunalni-2022-539911-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-9",
+      "id": "komunalni-2022-539911-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-10",
+      "id": "komunalni-2022-539911-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-11",
+      "id": "komunalni-2022-539911-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-12",
+      "id": "komunalni-2022-539911-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-13",
+      "id": "komunalni-2022-539911-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-14",
+      "id": "komunalni-2022-539911-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-15",
+      "id": "komunalni-2022-539911-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-16",
+      "id": "komunalni-2022-539911-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-17",
+      "id": "komunalni-2022-539911-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-18",
+      "id": "komunalni-2022-539911-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-19",
+      "id": "komunalni-2022-539911-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-20",
+      "id": "komunalni-2022-539911-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-21",
+      "id": "komunalni-2022-539911-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-22",
+      "id": "komunalni-2022-539911-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-23",
+      "id": "komunalni-2022-539911-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-24",
+      "id": "komunalni-2022-539911-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-25",
+      "id": "komunalni-2022-539911-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-26",
+      "id": "komunalni-2022-539911-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-27",
+      "id": "komunalni-2022-539911-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-28",
+      "id": "komunalni-2022-539911-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-29",
+      "id": "komunalni-2022-539911-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-30",
+      "id": "komunalni-2022-539911-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-31",
+      "id": "komunalni-2022-539911-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-32",
+      "id": "komunalni-2022-539911-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-33",
+      "id": "komunalni-2022-539911-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-34",
+      "id": "komunalni-2022-539911-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-35",
+      "id": "komunalni-2022-539911-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-36",
+      "id": "komunalni-2022-539911-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-37",
+      "id": "komunalni-2022-539911-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-38",
+      "id": "komunalni-2022-539911-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-39",
+      "id": "komunalni-2022-539911-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-40",
+      "id": "komunalni-2022-539911-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-41",
+      "id": "komunalni-2022-539911-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-42",
+      "id": "komunalni-2022-539911-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-43",
+      "id": "komunalni-2022-539911-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-44",
+      "id": "komunalni-2022-539911-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-45",
+      "id": "komunalni-2022-539911-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-46",
+      "id": "komunalni-2022-539911-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-47",
+      "id": "komunalni-2022-539911-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-539911-question-48",
+      "id": "komunalni-2022-539911-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,16 +399,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-539911-candidate-690545",
+      "id": "komunalni-2022-539911-c-690545",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-539911-690545-party",
+          "id": "komunalni-2022-539911-c-690545-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -417,16 +420,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-539911-candidate-928263",
+      "id": "komunalni-2022-539911-c-928263",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-539911-928263-party",
+          "id": "komunalni-2022-539911-c-928263-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -437,10 +441,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-539911-candidate-835803",
+      "id": "komunalni-2022-539911-c-835803",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": [
           {
@@ -456,7 +461,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-539911-835803-party",
+          "id": "komunalni-2022-539911-c-835803-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -477,16 +482,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-539911-candidate-967823",
+      "id": "komunalni-2022-539911-c-967823",
       "name": "ČSSD a Přátelé",
       "type": "party",
       "description": "ČSSD a Přátelé - DESCRIPTION",
+      "img_url": "čssd-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-539911-967823-party",
+          "id": "komunalni-2022-539911-c-967823-p",
           "name": "ČSSD a Přátelé",
           "description": "ČSSD a Přátelé - DESCRIPTION",
           "contacts": {
@@ -497,16 +503,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-539911-candidate-746189",
+      "id": "komunalni-2022-539911-c-746189",
       "name": "Občanská demokratická strana",
       "type": "party",
       "description": "Občanská demokratická strana - DESCRIPTION",
+      "img_url": "ods",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-539911-746189-party",
+          "id": "komunalni-2022-539911-c-746189-p",
           "name": "Občanská demokratická strana",
           "description": "Občanská demokratická strana - DESCRIPTION",
           "contacts": {
@@ -517,10 +524,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-539911-candidate-163633",
+      "id": "komunalni-2022-539911-c-163633",
       "name": "KDU-ČSL a nezávislí kandidáti",
       "type": "party",
       "description": "KDU-ČSL a nezávislí kandidáti - DESCRIPTION",
+      "img_url": "kdu-čsl-nk",
       "contacts": {
         "web": [
           {
@@ -531,7 +539,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-539911-163633-party",
+          "id": "komunalni-2022-539911-c-163633-p",
           "name": "KDU-ČSL a nezávislí kandidáti",
           "description": "KDU-ČSL a nezávislí kandidáti - DESCRIPTION",
           "contacts": {
@@ -547,17 +555,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-539911-candidate-529696",
+      "id": "komunalni-2022-539911-c-529696",
       "name": "SPOJENCI - TOP 09, STAROSTOVÉ A NEZÁVISLÍ, POLITICKÉ HNUTÍ HLAS, SOS PŘÍBRAM A NEZÁVISLÍ KANDIDÁTI",
       "type": "party",
       "description": "SPOJENCI - TOP 09, STAROSTOVÉ A NEZÁVISLÍ, POLITICKÉ HNUTÍ HLAS, SOS PŘÍBRAM A NEZÁVISLÍ KANDIDÁTI - DESCRIPTION",
+      "img_url": "stan-top-hl-nk",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/spojencipribram/"
       },
       "parties": [
         {
-          "id": "komunalni-2022-539911-529696-party",
+          "id": "komunalni-2022-539911-c-529696-p",
           "name": "SPOJENCI - TOP 09, STAROSTOVÉ A NEZÁVISLÍ, POLITICKÉ HNUTÍ HLAS, SOS PŘÍBRAM A NEZÁVISLÍ KANDIDÁTI",
           "description": "SPOJENCI - TOP 09, STAROSTOVÉ A NEZÁVISLÍ, POLITICKÉ HNUTÍ HLAS, SOS PŘÍBRAM A NEZÁVISLÍ KANDIDÁTI - DESCRIPTION",
           "contacts": {
@@ -569,16 +578,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-539911-candidate-743793",
+      "id": "komunalni-2022-539911-c-743793",
       "name": "Příbramáci pro Příbram a Přísaha - občanské hnutí Roberta Šlachty",
       "type": "party",
       "description": "Příbramáci pro Příbram a Přísaha - občanské hnutí Roberta Šlachty - DESCRIPTION",
+      "img_url": "snked-přísah-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-539911-743793-party",
+          "id": "komunalni-2022-539911-c-743793-p",
           "name": "Příbramáci pro Příbram a Přísaha - občanské hnutí Roberta Šlachty",
           "description": "Příbramáci pro Příbram a Přísaha - občanské hnutí Roberta Šlachty - DESCRIPTION",
           "contacts": {
@@ -589,16 +599,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-539911-candidate-169921",
+      "id": "komunalni-2022-539911-c-169921",
       "name": "PŘÍBRAM 2030 (Nestraníci)",
       "type": "party",
       "description": "PŘÍBRAM 2030 (Nestraníci) - DESCRIPTION",
+      "img_url": "nestraníci-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-539911-169921-party",
+          "id": "komunalni-2022-539911-c-169921-p",
           "name": "PŘÍBRAM 2030 (Nestraníci)",
           "description": "PŘÍBRAM 2030 (Nestraníci) - DESCRIPTION",
           "contacts": {
@@ -609,10 +620,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-539911-candidate-235005",
+      "id": "komunalni-2022-539911-c-235005",
       "name": "Šance pro Příbram",
       "type": "party",
       "description": "Šance pro Příbram - DESCRIPTION",
+      "img_url": "monarchiste-nk",
       "contacts": {
         "web": [
           {
@@ -623,7 +635,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-539911-235005-party",
+          "id": "komunalni-2022-539911-c-235005-p",
           "name": "Šance pro Příbram",
           "description": "Šance pro Příbram - DESCRIPTION",
           "contacts": {
@@ -639,16 +651,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-539911-candidate-929443",
+      "id": "komunalni-2022-539911-c-929443",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-539911-929443-party",
+          "id": "komunalni-2022-539911-c-929443-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -659,16 +672,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-539911-candidate-629364",
+      "id": "komunalni-2022-539911-c-629364",
       "name": "Dělnická strana sociální spravedlnosti",
       "type": "party",
       "description": "Dělnická strana sociální spravedlnosti - DESCRIPTION",
+      "img_url": "dsss",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-539911-629364-party",
+          "id": "komunalni-2022-539911-c-629364-p",
           "name": "Dělnická strana sociální spravedlnosti",
           "description": "Dělnická strana sociální spravedlnosti - DESCRIPTION",
           "contacts": {
@@ -681,914 +695,914 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-539911-answer-163633-1",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-1",
+      "id": "komunalni-2022-539911-a-4",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-1",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-2",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-2",
+      "id": "komunalni-2022-539911-a-7",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-3",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-3",
+      "id": "komunalni-2022-539911-a-10",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-4",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-4",
+      "id": "komunalni-2022-539911-a-13",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-5",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-5",
+      "id": "komunalni-2022-539911-a-16",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-6",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-6",
+      "id": "komunalni-2022-539911-a-19",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-6",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-7",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-7",
+      "id": "komunalni-2022-539911-a-22",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-7",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-8",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-8",
+      "id": "komunalni-2022-539911-a-25",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-9",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-9",
+      "id": "komunalni-2022-539911-a-28",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-10",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-10",
+      "id": "komunalni-2022-539911-a-31",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-10",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-11",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-11",
+      "id": "komunalni-2022-539911-a-34",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-11",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-12",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-12",
+      "id": "komunalni-2022-539911-a-37",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-12",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-13",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-13",
+      "id": "komunalni-2022-539911-a-40",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-14",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-14",
+      "id": "komunalni-2022-539911-a-43",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-15",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-15",
+      "id": "komunalni-2022-539911-a-46",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-15",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-16",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-16",
+      "id": "komunalni-2022-539911-a-49",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-17",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-17",
+      "id": "komunalni-2022-539911-a-52",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-17",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-18",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-18",
+      "id": "komunalni-2022-539911-a-55",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-18",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-19",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-19",
+      "id": "komunalni-2022-539911-a-58",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-20",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-20",
+      "id": "komunalni-2022-539911-a-61",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-21",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-21"
+      "id": "komunalni-2022-539911-a-64",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-21"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-22",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-22",
+      "id": "komunalni-2022-539911-a-67",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-23",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-23",
+      "id": "komunalni-2022-539911-a-70",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-24",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-24",
+      "id": "komunalni-2022-539911-a-73",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-25",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-25",
+      "id": "komunalni-2022-539911-a-76",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-26",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-26",
+      "id": "komunalni-2022-539911-a-79",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-27",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-27",
+      "id": "komunalni-2022-539911-a-82",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-27",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-28",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-28",
+      "id": "komunalni-2022-539911-a-85",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-29",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-29",
+      "id": "komunalni-2022-539911-a-88",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-30",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-30",
+      "id": "komunalni-2022-539911-a-91",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-30",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-31",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-31",
+      "id": "komunalni-2022-539911-a-94",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-32",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-32",
+      "id": "komunalni-2022-539911-a-97",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-33",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-33",
+      "id": "komunalni-2022-539911-a-100",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-34",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-34",
+      "id": "komunalni-2022-539911-a-103",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-34",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-35",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-35",
+      "id": "komunalni-2022-539911-a-106",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-36",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-36",
+      "id": "komunalni-2022-539911-a-109",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-37",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-37",
+      "id": "komunalni-2022-539911-a-112",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-38",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-38",
+      "id": "komunalni-2022-539911-a-115",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-39",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-39",
+      "id": "komunalni-2022-539911-a-118",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-40",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-40",
+      "id": "komunalni-2022-539911-a-121",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-41",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-41",
+      "id": "komunalni-2022-539911-a-124",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-41",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-42",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-42",
+      "id": "komunalni-2022-539911-a-127",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-42",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-43",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-43",
+      "id": "komunalni-2022-539911-a-130",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-44",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-44",
+      "id": "komunalni-2022-539911-a-133",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-45",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-45",
+      "id": "komunalni-2022-539911-a-136",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-45",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-46",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-46",
+      "id": "komunalni-2022-539911-a-139",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-47",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-47",
+      "id": "komunalni-2022-539911-a-142",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-47",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-48",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-48",
+      "id": "komunalni-2022-539911-a-145",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-163633-49",
-      "candidate_id": "komunalni-2022-539911-candidate-163633",
-      "question_id": "komunalni-2022-539911-question-49"
+      "id": "komunalni-2022-539911-a-148",
+      "candidate_id": "komunalni-2022-539911-c-163633",
+      "question_id": "komunalni-2022-539911-q-49"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-1",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-1",
+      "id": "komunalni-2022-539911-a-4",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-2",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-2",
+      "id": "komunalni-2022-539911-a-7",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-2",
       "answer": "yes",
       "comment": "Kdo vytváří odpad, měl by platit za jeho svoz."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-3",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-3",
+      "id": "komunalni-2022-539911-a-10",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-4",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-4",
+      "id": "komunalni-2022-539911-a-13",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-4",
       "answer": "yes",
       "comment": "V řádně označených obytných zónách s hustou zástavbou bytových a rodinných domů ano."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-5",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-5",
+      "id": "komunalni-2022-539911-a-16",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-5",
       "answer": "no",
       "comment": "Máme za to, že se dlužníci dozvídají o Milostivém létu z jiných veřejně dostupných zdrojů."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-6",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-6",
+      "id": "komunalni-2022-539911-a-19",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-6",
       "answer": "yes",
       "comment": "Veřejná prostranství, kde dochází často ke kriminální činnosti by měla být lépe monitorována."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-7",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-7",
+      "id": "komunalni-2022-539911-a-22",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-8",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-8",
+      "id": "komunalni-2022-539911-a-25",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-8",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-9",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-9",
+      "id": "komunalni-2022-539911-a-28",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-10",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-10",
+      "id": "komunalni-2022-539911-a-31",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-11",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-11",
+      "id": "komunalni-2022-539911-a-34",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-12",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-12",
+      "id": "komunalni-2022-539911-a-37",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-13",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-13",
+      "id": "komunalni-2022-539911-a-40",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-14",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-14",
+      "id": "komunalni-2022-539911-a-43",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-15",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-15",
+      "id": "komunalni-2022-539911-a-46",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-15",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-16",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-16",
+      "id": "komunalni-2022-539911-a-49",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-16",
       "answer": "yes",
       "comment": "Podporujeme jen v určitých budovách."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-17",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-17",
+      "id": "komunalni-2022-539911-a-52",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-18",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-18",
+      "id": "komunalni-2022-539911-a-55",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-18",
       "comment": "Obecně jsme pro větší otevřenost a transparentnost, ale je nutné zajistit soulad s GDPR a chránit osobní údaje."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-19",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-19",
+      "id": "komunalni-2022-539911-a-58",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-20",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-20",
+      "id": "komunalni-2022-539911-a-61",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-21",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-21",
+      "id": "komunalni-2022-539911-a-64",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-21",
       "answer": "yes",
       "comment": "Úspora s tím, že bude zachována slavnostní doba Vánoc."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-22",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-22",
+      "id": "komunalni-2022-539911-a-67",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-22",
       "answer": "yes",
       "comment": "Děti nemohou za to, že jim rodiče nezaplatí obědy. Hladové dítě se naučí méně, protože řeší primárně svůj hlad."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-23",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-23",
+      "id": "komunalni-2022-539911-a-70",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-23",
       "answer": "no",
       "comment": "Preferujeme čistou dopravu - sdílení kol."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-24",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-24",
+      "id": "komunalni-2022-539911-a-73",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-24",
       "answer": "no",
       "comment": "Příbram je přestupní město, přespolní tak bez parkovacích zón blokují celý den parkování pro občany města."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-25",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-25",
+      "id": "komunalni-2022-539911-a-76",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-26",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-26",
+      "id": "komunalni-2022-539911-a-79",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-26",
       "answer": "yes",
       "comment": "Již nyní developeři v Příbrami přispívají na vybudování komunikací a sítí."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-27",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-27",
+      "id": "komunalni-2022-539911-a-82",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-28",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-28",
+      "id": "komunalni-2022-539911-a-85",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-28",
       "answer": "yes",
       "comment": "V Příbrami nejde o tak závažný problém jako v Praze, ale obecně souhlasíme."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-29",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-29",
+      "id": "komunalni-2022-539911-a-88",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-29",
       "answer": "yes",
       "comment": "Souhlasíme, pokud budou tyto příspěvky použity účelně na rozvoj oblasti výstavby."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-30",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-30",
+      "id": "komunalni-2022-539911-a-91",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-31",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-31",
+      "id": "komunalni-2022-539911-a-94",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-32",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-32",
+      "id": "komunalni-2022-539911-a-97",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-33",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-33",
+      "id": "komunalni-2022-539911-a-100",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-34",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-34",
+      "id": "komunalni-2022-539911-a-103",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-35",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-35",
+      "id": "komunalni-2022-539911-a-106",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-35",
       "comment": "Obáváme se zneužití."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-36",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-36"
+      "id": "komunalni-2022-539911-a-109",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-36"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-37",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-37",
+      "id": "komunalni-2022-539911-a-112",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-38",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-38",
+      "id": "komunalni-2022-539911-a-115",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-39",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-39",
+      "id": "komunalni-2022-539911-a-118",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-40",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-40",
+      "id": "komunalni-2022-539911-a-121",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-41",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-41",
+      "id": "komunalni-2022-539911-a-124",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-42",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-42",
+      "id": "komunalni-2022-539911-a-127",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-43",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-43",
+      "id": "komunalni-2022-539911-a-130",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-44",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-44",
+      "id": "komunalni-2022-539911-a-133",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-44",
       "answer": "no",
       "comment": "Nyní je na průměru ČR."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-45",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-45",
+      "id": "komunalni-2022-539911-a-136",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-45",
       "answer": "no",
       "comment": "Je nutná lepší prevence a časem bude počet chudých klesat."
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-46",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-46",
+      "id": "komunalni-2022-539911-a-139",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-47",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-47",
+      "id": "komunalni-2022-539911-a-142",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-48",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-48",
+      "id": "komunalni-2022-539911-a-145",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-169921-49",
-      "candidate_id": "komunalni-2022-539911-candidate-169921",
-      "question_id": "komunalni-2022-539911-question-49"
+      "id": "komunalni-2022-539911-a-148",
+      "candidate_id": "komunalni-2022-539911-c-169921",
+      "question_id": "komunalni-2022-539911-q-49"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-1",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-1"
+      "id": "komunalni-2022-539911-a-4",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-1"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-2",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-2",
+      "id": "komunalni-2022-539911-a-7",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-3",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-3",
+      "id": "komunalni-2022-539911-a-10",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-3",
       "answer": "no",
       "comment": "Rezervy úspor energií se dají najít jinde, (např. omezit noční osvětlení památek). Jsme proti omezování vytápění v domovech pro seniory i ve školách. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-4",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-4",
+      "id": "komunalni-2022-539911-a-13",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-4",
       "answer": "yes",
       "comment": "Například v klidných rezidenčních zónách, u škol a školek. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-5",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-5",
+      "id": "komunalni-2022-539911-a-16",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-5",
       "answer": "yes",
       "comment": "Obecně je pro společnost prospěšné snížit počet exekucí a pomáhat lidem z dluhových pastí. Primárně těm, kteří spolupracují a chtějí svou situaci řešit.  "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-6",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-6",
+      "id": "komunalni-2022-539911-a-19",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-6",
       "comment": "Nechceme nezbytně zvyšovat počet kamer ve veřejném prostou. Nicméně jsou lokality, kde je to vzhledem ke zvýšení bezpečnosti obyvatel žádoucí. V konkrétních případech, po dohodě s Policií ČR, bychom případnou instalaci podpořili. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-7",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-7",
+      "id": "komunalni-2022-539911-a-22",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-8",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-8",
+      "id": "komunalni-2022-539911-a-25",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-8",
       "answer": "no",
       "comment": "Současná cena MHD v Příbrami je 12 kč (pro držitelé kuponu 10 kč, pro děti a důchodce 6 kč). Ceny považujeme za příznivé. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-9",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-9",
+      "id": "komunalni-2022-539911-a-28",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-10",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-10",
+      "id": "komunalni-2022-539911-a-31",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-11",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-11",
+      "id": "komunalni-2022-539911-a-34",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-12",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-12",
+      "id": "komunalni-2022-539911-a-37",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-12",
       "answer": "yes",
       "comment": "Nadužíváním zábavní pyrotechniky trpí zvířata, proto bychom jí rádi omezili.  "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-13",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-13",
+      "id": "komunalni-2022-539911-a-40",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-13",
       "comment": "Záleží v které budově a s jakým režimem. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-14",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-14",
+      "id": "komunalni-2022-539911-a-43",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-15",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-15",
+      "id": "komunalni-2022-539911-a-46",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-15",
       "answer": "yes",
       "comment": "Omezení ale nesmí být na úkor bezpečnosti obyvatel města, proto je třeba zvážit konkrétní lokality za součinnosti Policie ČR a Technických služeb. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-16",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-16",
+      "id": "komunalni-2022-539911-a-49",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-16",
       "answer": "yes",
       "comment": "Úspory energií jsou nezbytné. Je zapotřebí zmapovat situaci a hledat úspory vytápění tam, kde to nebude na úkor dětí a seniorů. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-17",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-17",
+      "id": "komunalni-2022-539911-a-52",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-18",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-18",
+      "id": "komunalni-2022-539911-a-55",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-18",
       "answer": "yes",
       "comment": "Určitě v případě investic a různých výdajů města. (Samozřejmě by se to nemělo týkat platů zaměstnanců). "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-19",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-19",
+      "id": "komunalni-2022-539911-a-58",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-19",
       "answer": "no",
       "comment": "Podporujeme participativní rozpočty města, do kterých se občané mohou zapojit se svými kvalitními projekty. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-20",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-20",
+      "id": "komunalni-2022-539911-a-61",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-20",
       "answer": "yes",
       "comment": "Navyšování počtu bytů rozhodně podporujeme. Stejně tak výstavbu startovacích bytů a družstevního bydlení. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-21",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-21",
+      "id": "komunalni-2022-539911-a-64",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-21",
       "answer": "no",
       "comment": "Vánoce považujeme za důležité svátky jejich připomenutí a důstojná výzdoba města je pro nás důležitá. Pokud bychom hledali úspory, tak například v úsporném režimu nočního osvětlení.  "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-22",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-22",
+      "id": "komunalni-2022-539911-a-67",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-22",
       "answer": "no",
       "comment": "Podpoříme programy pro znevýhodněné děti, plošně to ale nepodporujeme, protože obědy jsou již z části dotované."
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-23",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-23",
+      "id": "komunalni-2022-539911-a-70",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-23",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-24",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-24",
+      "id": "komunalni-2022-539911-a-73",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-24",
       "answer": "no",
       "comment": "Situace s parkováním ve městě je velmi složitá. Podporujeme parkovací zóny, ale jen za určitých podmínek. Nejdříve je zapotřebí navýšit počet parkovacích míst v daných lokalitách (ale ne na úkor zeleně). S zónami se musí také řešit stav ulic a parkovacích míst. \nNa místech pro rezidenty by neměli parkovat přespolní. Těm musí město nabídnout nějakou reálnou alternativu (záchytná parkoviště na rozumných místech s rozumnou infrastrukturou, jako je osvětlení, odpadkové koše, bezpečnostní kamery, dobrý příjezd, poblíž autobusových zastávek, atp ..). Ceny za parkování a zóny je nutné nastavit tak, aby to lidé finančně unesli. Když resident vlastní jedno auto bude platit nějakou symbolickou částku, za další auto, zaplatí víc. \nPeníze vybrané za parkovací zóny se musí opět otočit do dopravy a parkování. Mohou posloužit jako investice do parkovacích domů nebo výstavbu nových míst. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-25",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-25",
+      "id": "komunalni-2022-539911-a-76",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-25",
       "answer": "no",
       "comment": "Město nemá byty, které by mohlo privatizovat, už tak vlastní pouze 4% bytového fondu v Příbrami. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-26",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-26",
+      "id": "komunalni-2022-539911-a-79",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-27",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-27",
+      "id": "komunalni-2022-539911-a-82",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-27",
       "answer": "yes",
       "comment": "Dopravní situace ve městě je v ranní a odpolední špičce neúnosná, je tedy třeba hledat cesty jak městu ulevit. Podpora pěší, cyklistické a hromadné dopravy mezi tyto cesty patří.  "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-28",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-28",
+      "id": "komunalni-2022-539911-a-85",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-28",
       "answer": "no",
       "comment": "Tento problém se týká hlavně metropolí a větších měst, ne Příbrami. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-29",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-29",
+      "id": "komunalni-2022-539911-a-88",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-30",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-30",
+      "id": "komunalni-2022-539911-a-91",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-31",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-31",
+      "id": "komunalni-2022-539911-a-94",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-32",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-32",
+      "id": "komunalni-2022-539911-a-97",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-33",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-33",
+      "id": "komunalni-2022-539911-a-100",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-33",
       "answer": "yes",
       "comment": "Navrhujeme, aby pro občany vzniklo při městě odborné poradenské centrum, které jim pomůže a poradí, jak zvládnout energetickou krizi (např. s dotacemi)."
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-34",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-34",
+      "id": "komunalni-2022-539911-a-103",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-35",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-35",
+      "id": "komunalni-2022-539911-a-106",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-35",
       "answer": "no",
       "comment": "Myslíme si, že v současné ekonomický náročné době je toto plošné gesto nadbytečné. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-36",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-36",
+      "id": "komunalni-2022-539911-a-109",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-37",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-37",
+      "id": "komunalni-2022-539911-a-112",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-38",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-38",
+      "id": "komunalni-2022-539911-a-115",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-39",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-39"
+      "id": "komunalni-2022-539911-a-118",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-39"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-40",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-40",
+      "id": "komunalni-2022-539911-a-121",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-41",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-41",
+      "id": "komunalni-2022-539911-a-124",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-42",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-42",
+      "id": "komunalni-2022-539911-a-127",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-42",
       "answer": "yes",
       "comment": "Pokud chceme podpořit dopravu obyvatel do práce a do školy na kole, je zapotřebí zohlednit bezpečnost tras. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-43",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-43",
+      "id": "komunalni-2022-539911-a-130",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-43",
       "answer": "yes",
       "comment": "Je potřeba podporovat sport profesionální, ale ne na úkor toho amatérského a především mládežnického. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-44",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-44",
+      "id": "komunalni-2022-539911-a-133",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-45",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-45",
+      "id": "komunalni-2022-539911-a-136",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-45",
       "answer": "yes",
       "comment": "Primárně takové občany, kteří chtěj svou situací konstruktivně a prakticky řešit.  "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-46",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-46",
+      "id": "komunalni-2022-539911-a-139",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-47",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-47",
+      "id": "komunalni-2022-539911-a-142",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-47",
       "comment": "Rodiče by měli mít svobodu při výběru školy pro své děti. Není dobré, aby se sociálně znevýhodněné děti shromažďovali jen na několika školách. "
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-48",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-48",
+      "id": "komunalni-2022-539911-a-145",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-539911-answer-835803-49",
-      "candidate_id": "komunalni-2022-539911-candidate-835803",
-      "question_id": "komunalni-2022-539911-question-49",
+      "id": "komunalni-2022-539911-a-148",
+      "candidate_id": "komunalni-2022-539911-c-835803",
+      "question_id": "komunalni-2022-539911-q-49",
       "comment": "V dotazníku jednoznačně postrádáme programové návrhy jak ZŠ přiblížit potřebám \n21. století, péči o veřejný prostor a městkou zeleň.    "
     }
   ]

--- a/data/kalkulacka/komunalni-2022/544256.json
+++ b/data/kalkulacka/komunalni-2022/544256.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-544256",
   "name": "České Budějovice",
-  "description": "České Budějovice - DESCRIPTION",
+  "description": "České Budějovice",
   "district_code": "544256",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-544256-question-1",
+      "id": "komunalni-2022-544256-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-2",
+      "id": "komunalni-2022-544256-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-3",
+      "id": "komunalni-2022-544256-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-4",
+      "id": "komunalni-2022-544256-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-5",
+      "id": "komunalni-2022-544256-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-6",
+      "id": "komunalni-2022-544256-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-7",
+      "id": "komunalni-2022-544256-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-8",
+      "id": "komunalni-2022-544256-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-9",
+      "id": "komunalni-2022-544256-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-10",
+      "id": "komunalni-2022-544256-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-11",
+      "id": "komunalni-2022-544256-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-12",
+      "id": "komunalni-2022-544256-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-13",
+      "id": "komunalni-2022-544256-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-14",
+      "id": "komunalni-2022-544256-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-15",
+      "id": "komunalni-2022-544256-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-16",
+      "id": "komunalni-2022-544256-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-17",
+      "id": "komunalni-2022-544256-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-18",
+      "id": "komunalni-2022-544256-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-19",
+      "id": "komunalni-2022-544256-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-20",
+      "id": "komunalni-2022-544256-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-21",
+      "id": "komunalni-2022-544256-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-22",
+      "id": "komunalni-2022-544256-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-23",
+      "id": "komunalni-2022-544256-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-24",
+      "id": "komunalni-2022-544256-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-25",
+      "id": "komunalni-2022-544256-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-26",
+      "id": "komunalni-2022-544256-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-27",
+      "id": "komunalni-2022-544256-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-28",
+      "id": "komunalni-2022-544256-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-29",
+      "id": "komunalni-2022-544256-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-30",
+      "id": "komunalni-2022-544256-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-31",
+      "id": "komunalni-2022-544256-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-32",
+      "id": "komunalni-2022-544256-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-33",
+      "id": "komunalni-2022-544256-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-34",
+      "id": "komunalni-2022-544256-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-35",
+      "id": "komunalni-2022-544256-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-36",
+      "id": "komunalni-2022-544256-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-37",
+      "id": "komunalni-2022-544256-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-38",
+      "id": "komunalni-2022-544256-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-39",
+      "id": "komunalni-2022-544256-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-40",
+      "id": "komunalni-2022-544256-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-41",
+      "id": "komunalni-2022-544256-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-42",
+      "id": "komunalni-2022-544256-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-43",
+      "id": "komunalni-2022-544256-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-44",
+      "id": "komunalni-2022-544256-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-45",
+      "id": "komunalni-2022-544256-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-46",
+      "id": "komunalni-2022-544256-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-47",
+      "id": "komunalni-2022-544256-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-48",
+      "id": "komunalni-2022-544256-q-48",
       "name": "Demontáž laviček",
       "title": "Souhlasím s tím, aby město demontovalo lavičky obsazované lidmi bez domova.",
       "gist": "",
@@ -395,7 +397,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-49",
+      "id": "komunalni-2022-544256-q-49",
       "name": "Bydlení především",
       "title": "Podporuji, aby České Budějovice pokračovaly v projektu Housing First.",
       "gist": "Projekty Housing First zajišťují stabilní bydlení pro nejohroženější skupinu obyvatel. V Česku díky nim získalo bezpečný domov a podporu sociálních pracovníků více než 700 lidí, z toho 320 dětí. Do projektu se zapojují i další česká i světová města; např. ve Vídni si bydlení udrželo 98 % domácností. Pilotní Brno i přes úspěch i ocenění od projektu postupně ustoupilo. Vedení města argumentovalo vysokými náklady, zastánci projektu ale poukazovali, že je většina výdajů hrazená z fondů EU.",
@@ -403,7 +405,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-544256-question-50",
+      "id": "komunalni-2022-544256-q-50",
       "name": "Online rozpočet",
       "title": "Město má mít rozklikávací rozpočet na webu.",
       "gist": "Zastánci chtějí rozpočty poskytovat v otevřeném formátu na webu.",
@@ -413,10 +415,11 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-544256-candidate-795985",
+      "id": "komunalni-2022-544256-c-795985",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": [
           {
@@ -429,7 +432,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-544256-795985-party",
+          "id": "komunalni-2022-544256-c-795985-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -447,16 +450,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-544256-candidate-725515",
+      "id": "komunalni-2022-544256-c-725515",
       "name": "Českobudějovičtí ROZUMNĚ NAŠTVANÍ",
       "type": "party",
       "description": "Českobudějovičtí ROZUMNĚ NAŠTVANÍ - DESCRIPTION",
+      "img_url": "rozumní-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-544256-725515-party",
+          "id": "komunalni-2022-544256-c-725515-p",
           "name": "Českobudějovičtí ROZUMNĚ NAŠTVANÍ",
           "description": "Českobudějovičtí ROZUMNĚ NAŠTVANÍ - DESCRIPTION",
           "contacts": {
@@ -467,17 +471,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-544256-candidate-307120",
+      "id": "komunalni-2022-544256-c-307120",
       "name": "KSČM fungující Budějce",
       "type": "party",
       "description": "KSČM fungující Budějce - DESCRIPTION",
+      "img_url": "ksčm-nk",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/OV-KS%C4%8CM-%C4%8Cesk%C3%A9-Bud%C4%9Bjovice-112568740670438/"
       },
       "parties": [
         {
-          "id": "komunalni-2022-544256-307120-party",
+          "id": "komunalni-2022-544256-c-307120-p",
           "name": "KSČM fungující Budějce",
           "description": "KSČM fungující Budějce - DESCRIPTION",
           "contacts": {
@@ -489,16 +494,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-544256-candidate-145079",
+      "id": "komunalni-2022-544256-c-145079",
       "name": "ČSSD a NEZÁVISLÉ OSOBNOSTI",
       "type": "party",
       "description": "ČSSD a NEZÁVISLÉ OSOBNOSTI - DESCRIPTION",
+      "img_url": "čssd-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-544256-145079-party",
+          "id": "komunalni-2022-544256-c-145079-p",
           "name": "ČSSD a NEZÁVISLÉ OSOBNOSTI",
           "description": "ČSSD a NEZÁVISLÉ OSOBNOSTI - DESCRIPTION",
           "contacts": {
@@ -509,10 +515,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-544256-candidate-508138",
+      "id": "komunalni-2022-544256-c-508138",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
       "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "img_url": "stan",
       "contacts": {
         "web": [
           {
@@ -524,7 +531,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-544256-508138-party",
+          "id": "komunalni-2022-544256-c-508138-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
           "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
           "contacts": {
@@ -541,10 +548,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-544256-candidate-243110",
+      "id": "komunalni-2022-544256-c-243110",
       "name": "OBČANÉ PRO BUDĚJOVICE",
       "type": "party",
       "description": "OBČANÉ PRO BUDĚJOVICE - DESCRIPTION",
+      "img_url": "hopb-jih 12-nk",
       "contacts": {
         "web": [
           {
@@ -557,7 +565,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-544256-243110-party",
+          "id": "komunalni-2022-544256-c-243110-p",
           "name": "OBČANÉ PRO BUDĚJOVICE",
           "description": "OBČANÉ PRO BUDĚJOVICE - DESCRIPTION",
           "contacts": {
@@ -575,17 +583,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-544256-candidate-721258",
+      "id": "komunalni-2022-544256-c-721258",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/ANO.Budejce"
       },
       "parties": [
         {
-          "id": "komunalni-2022-544256-721258-party",
+          "id": "komunalni-2022-544256-c-721258-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -597,16 +606,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-544256-candidate-749146",
+      "id": "komunalni-2022-544256-c-749146",
       "name": "Občanská demokratická strana",
       "type": "party",
       "description": "Občanská demokratická strana - DESCRIPTION",
+      "img_url": "ods",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-544256-749146-party",
+          "id": "komunalni-2022-544256-c-749146-p",
           "name": "Občanská demokratická strana",
           "description": "Občanská demokratická strana - DESCRIPTION",
           "contacts": {
@@ -617,17 +627,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-544256-candidate-861576",
+      "id": "komunalni-2022-544256-c-861576",
       "name": "KDU-ČSL a TOP 09 - Společně pro Budějovice",
       "type": "party",
       "description": "KDU-ČSL a TOP 09 - Společně pro Budějovice - DESCRIPTION",
+      "img_url": "kdu-čsl-top 09",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/spolecneprocb/"
       },
       "parties": [
         {
-          "id": "komunalni-2022-544256-861576-party",
+          "id": "komunalni-2022-544256-c-861576-p",
           "name": "KDU-ČSL a TOP 09 - Společně pro Budějovice",
           "description": "KDU-ČSL a TOP 09 - Společně pro Budějovice - DESCRIPTION",
           "contacts": {
@@ -639,16 +650,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-544256-candidate-313089",
+      "id": "komunalni-2022-544256-c-313089",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-544256-313089-party",
+          "id": "komunalni-2022-544256-c-313089-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -659,16 +671,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-544256-candidate-135731",
+      "id": "komunalni-2022-544256-c-135731",
       "name": "Budějce srdcem a rozumem",
       "type": "party",
       "description": "Budějce srdcem a rozumem - DESCRIPTION",
+      "img_url": "svobodní-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-544256-135731-party",
+          "id": "komunalni-2022-544256-c-135731-p",
           "name": "Budějce srdcem a rozumem",
           "description": "Budějce srdcem a rozumem - DESCRIPTION",
           "contacts": {
@@ -681,886 +694,886 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-544256-answer-307120-1",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-1"
+      "id": "komunalni-2022-544256-a-4",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-1"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-2",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-2",
+      "id": "komunalni-2022-544256-a-7",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-2",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-3",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-3",
+      "id": "komunalni-2022-544256-a-10",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-4",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-4",
+      "id": "komunalni-2022-544256-a-13",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-5",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-5"
+      "id": "komunalni-2022-544256-a-16",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-5"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-6",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-6",
+      "id": "komunalni-2022-544256-a-19",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-7",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-7",
+      "id": "komunalni-2022-544256-a-22",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-8",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-8",
+      "id": "komunalni-2022-544256-a-25",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-8",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-9",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-9"
+      "id": "komunalni-2022-544256-a-28",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-9"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-10",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-10"
+      "id": "komunalni-2022-544256-a-31",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-10"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-11",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-11"
+      "id": "komunalni-2022-544256-a-34",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-11"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-12",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-12",
+      "id": "komunalni-2022-544256-a-37",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-13",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-13"
+      "id": "komunalni-2022-544256-a-40",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-13"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-14",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-14"
+      "id": "komunalni-2022-544256-a-43",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-14"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-15",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-15",
+      "id": "komunalni-2022-544256-a-46",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-15",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-16",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-16"
+      "id": "komunalni-2022-544256-a-49",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-16"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-17",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-17",
+      "id": "komunalni-2022-544256-a-52",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-17",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-18",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-18",
+      "id": "komunalni-2022-544256-a-55",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-19",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-19",
+      "id": "komunalni-2022-544256-a-58",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-20",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-20",
+      "id": "komunalni-2022-544256-a-61",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-21",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-21",
+      "id": "komunalni-2022-544256-a-64",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-22",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-22",
+      "id": "komunalni-2022-544256-a-67",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-22",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-23",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-23"
+      "id": "komunalni-2022-544256-a-70",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-23"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-24",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-24"
+      "id": "komunalni-2022-544256-a-73",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-24"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-25",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-25",
+      "id": "komunalni-2022-544256-a-76",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-26",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-26",
+      "id": "komunalni-2022-544256-a-79",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-27",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-27",
+      "id": "komunalni-2022-544256-a-82",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-28",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-28",
+      "id": "komunalni-2022-544256-a-85",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-28",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-29",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-29",
+      "id": "komunalni-2022-544256-a-88",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-30",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-30"
+      "id": "komunalni-2022-544256-a-91",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-30"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-31",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-31",
+      "id": "komunalni-2022-544256-a-94",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-32",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-32",
+      "id": "komunalni-2022-544256-a-97",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-33",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-33"
+      "id": "komunalni-2022-544256-a-100",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-33"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-34",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-34",
+      "id": "komunalni-2022-544256-a-103",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-35",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-35"
+      "id": "komunalni-2022-544256-a-106",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-35"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-36",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-36"
+      "id": "komunalni-2022-544256-a-109",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-36"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-37",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-37"
+      "id": "komunalni-2022-544256-a-112",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-37"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-38",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-38"
+      "id": "komunalni-2022-544256-a-115",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-38"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-39",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-39"
+      "id": "komunalni-2022-544256-a-118",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-39"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-40",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-40",
+      "id": "komunalni-2022-544256-a-121",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-41",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-41"
+      "id": "komunalni-2022-544256-a-124",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-41"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-42",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-42",
+      "id": "komunalni-2022-544256-a-127",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-43",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-43",
+      "id": "komunalni-2022-544256-a-130",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-44",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-44"
+      "id": "komunalni-2022-544256-a-133",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-44"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-45",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-45",
+      "id": "komunalni-2022-544256-a-136",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-46",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-46",
+      "id": "komunalni-2022-544256-a-139",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-47",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-47"
+      "id": "komunalni-2022-544256-a-142",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-47"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-48",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-48"
+      "id": "komunalni-2022-544256-a-145",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-48"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-49",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-49"
+      "id": "komunalni-2022-544256-a-148",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-49"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-50",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-50"
+      "id": "komunalni-2022-544256-a-151",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-50"
     },
     {
-      "id": "komunalni-2022-544256-answer-307120-51",
-      "candidate_id": "komunalni-2022-544256-candidate-307120",
-      "question_id": "komunalni-2022-544256-question-51",
+      "id": "komunalni-2022-544256-a-154",
+      "candidate_id": "komunalni-2022-544256-c-307120",
+      "question_id": "komunalni-2022-544256-q-51",
       "comment": "Volby prováděné zakroužkováním jména v seznamu voličů se dají snadno ošidit. Volby elektronickým způsobem by tomu mohly úplně zabránit."
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-1",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-1",
+      "id": "komunalni-2022-544256-a-4",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-2",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-2",
+      "id": "komunalni-2022-544256-a-7",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-3",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-3",
+      "id": "komunalni-2022-544256-a-10",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-4",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-4",
+      "id": "komunalni-2022-544256-a-13",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-5",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-5",
+      "id": "komunalni-2022-544256-a-16",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-5",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-6",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-6",
+      "id": "komunalni-2022-544256-a-19",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-7",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-7",
+      "id": "komunalni-2022-544256-a-22",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-8",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-8",
+      "id": "komunalni-2022-544256-a-25",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-9",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-9",
+      "id": "komunalni-2022-544256-a-28",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-10",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-10",
+      "id": "komunalni-2022-544256-a-31",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-10",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-11",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-11",
+      "id": "komunalni-2022-544256-a-34",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-11",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-12",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-12",
+      "id": "komunalni-2022-544256-a-37",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-12",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-13",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-13",
+      "id": "komunalni-2022-544256-a-40",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-13",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-14",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-14",
+      "id": "komunalni-2022-544256-a-43",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-14",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-15",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-15",
+      "id": "komunalni-2022-544256-a-46",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-15",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-16",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-16",
+      "id": "komunalni-2022-544256-a-49",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-16",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-17",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-17",
+      "id": "komunalni-2022-544256-a-52",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-17",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-18",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-18",
+      "id": "komunalni-2022-544256-a-55",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-18",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-19",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-19",
+      "id": "komunalni-2022-544256-a-58",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-20",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-20",
+      "id": "komunalni-2022-544256-a-61",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-21",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-21",
+      "id": "komunalni-2022-544256-a-64",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-21",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-22",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-22",
+      "id": "komunalni-2022-544256-a-67",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-23",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-23",
+      "id": "komunalni-2022-544256-a-70",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-24",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-24",
+      "id": "komunalni-2022-544256-a-73",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-25",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-25",
+      "id": "komunalni-2022-544256-a-76",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-26",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-26",
+      "id": "komunalni-2022-544256-a-79",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-27",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-27",
+      "id": "komunalni-2022-544256-a-82",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-28",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-28",
+      "id": "komunalni-2022-544256-a-85",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-29",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-29",
+      "id": "komunalni-2022-544256-a-88",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-30",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-30",
+      "id": "komunalni-2022-544256-a-91",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-30",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-31",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-31",
+      "id": "komunalni-2022-544256-a-94",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-32",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-32",
+      "id": "komunalni-2022-544256-a-97",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-33",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-33",
+      "id": "komunalni-2022-544256-a-100",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-34",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-34",
+      "id": "komunalni-2022-544256-a-103",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-35",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-35",
+      "id": "komunalni-2022-544256-a-106",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-36",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-36",
+      "id": "komunalni-2022-544256-a-109",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-37",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-37",
+      "id": "komunalni-2022-544256-a-112",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-38",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-38",
+      "id": "komunalni-2022-544256-a-115",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-39",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-39",
+      "id": "komunalni-2022-544256-a-118",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-39",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-40",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-40",
+      "id": "komunalni-2022-544256-a-121",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-41",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-41",
+      "id": "komunalni-2022-544256-a-124",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-42",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-42",
+      "id": "komunalni-2022-544256-a-127",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-43",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-43",
+      "id": "komunalni-2022-544256-a-130",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-44",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-44",
+      "id": "komunalni-2022-544256-a-133",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-44",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-45",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-45",
+      "id": "komunalni-2022-544256-a-136",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-46",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-46",
+      "id": "komunalni-2022-544256-a-139",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-47",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-47",
+      "id": "komunalni-2022-544256-a-142",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-48",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-48",
+      "id": "komunalni-2022-544256-a-145",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-48",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-49",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-49"
+      "id": "komunalni-2022-544256-a-148",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-49"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-50",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-50",
+      "id": "komunalni-2022-544256-a-151",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-50",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-721258-51",
-      "candidate_id": "komunalni-2022-544256-candidate-721258",
-      "question_id": "komunalni-2022-544256-question-51"
+      "id": "komunalni-2022-544256-a-154",
+      "candidate_id": "komunalni-2022-544256-c-721258",
+      "question_id": "komunalni-2022-544256-q-51"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-1",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-1"
+      "id": "komunalni-2022-544256-a-4",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-1"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-2",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-2",
+      "id": "komunalni-2022-544256-a-7",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-3",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-3",
+      "id": "komunalni-2022-544256-a-10",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-4",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-4",
+      "id": "komunalni-2022-544256-a-13",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-5",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-5",
+      "id": "komunalni-2022-544256-a-16",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-6",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-6"
+      "id": "komunalni-2022-544256-a-19",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-6"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-7",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-7",
+      "id": "komunalni-2022-544256-a-22",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-8",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-8",
+      "id": "komunalni-2022-544256-a-25",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-9",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-9",
+      "id": "komunalni-2022-544256-a-28",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-10",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-10",
+      "id": "komunalni-2022-544256-a-31",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-11",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-11"
+      "id": "komunalni-2022-544256-a-34",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-11"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-12",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-12",
+      "id": "komunalni-2022-544256-a-37",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-13",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-13"
+      "id": "komunalni-2022-544256-a-40",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-13"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-14",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-14"
+      "id": "komunalni-2022-544256-a-43",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-14"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-15",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-15"
+      "id": "komunalni-2022-544256-a-46",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-15"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-16",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-16",
+      "id": "komunalni-2022-544256-a-49",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-17",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-17"
+      "id": "komunalni-2022-544256-a-52",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-17"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-18",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-18",
+      "id": "komunalni-2022-544256-a-55",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-19",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-19",
+      "id": "komunalni-2022-544256-a-58",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-20",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-20",
+      "id": "komunalni-2022-544256-a-61",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-21",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-21",
+      "id": "komunalni-2022-544256-a-64",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-22",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-22",
+      "id": "komunalni-2022-544256-a-67",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-23",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-23",
+      "id": "komunalni-2022-544256-a-70",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-23",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-24",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-24",
+      "id": "komunalni-2022-544256-a-73",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-25",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-25",
+      "id": "komunalni-2022-544256-a-76",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-26",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-26",
+      "id": "komunalni-2022-544256-a-79",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-27",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-27",
+      "id": "komunalni-2022-544256-a-82",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-28",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-28"
+      "id": "komunalni-2022-544256-a-85",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-28"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-29",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-29"
+      "id": "komunalni-2022-544256-a-88",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-29"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-30",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-30",
+      "id": "komunalni-2022-544256-a-91",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-31",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-31",
+      "id": "komunalni-2022-544256-a-94",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-32",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-32",
+      "id": "komunalni-2022-544256-a-97",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-33",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-33",
+      "id": "komunalni-2022-544256-a-100",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-33",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-34",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-34",
+      "id": "komunalni-2022-544256-a-103",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-35",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-35",
+      "id": "komunalni-2022-544256-a-106",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-36",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-36",
+      "id": "komunalni-2022-544256-a-109",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-37",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-37",
+      "id": "komunalni-2022-544256-a-112",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-38",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-38",
+      "id": "komunalni-2022-544256-a-115",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-39",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-39",
+      "id": "komunalni-2022-544256-a-118",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-40",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-40",
+      "id": "komunalni-2022-544256-a-121",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-40",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-41",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-41",
+      "id": "komunalni-2022-544256-a-124",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-41",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-42",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-42",
+      "id": "komunalni-2022-544256-a-127",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-43",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-43",
+      "id": "komunalni-2022-544256-a-130",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-43",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-44",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-44",
+      "id": "komunalni-2022-544256-a-133",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-45",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-45",
+      "id": "komunalni-2022-544256-a-136",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-46",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-46",
+      "id": "komunalni-2022-544256-a-139",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-47",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-47"
+      "id": "komunalni-2022-544256-a-142",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-47"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-48",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-48",
+      "id": "komunalni-2022-544256-a-145",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-48",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-49",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-49",
+      "id": "komunalni-2022-544256-a-148",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-50",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-50",
+      "id": "komunalni-2022-544256-a-151",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-50",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-544256-answer-508138-51",
-      "candidate_id": "komunalni-2022-544256-candidate-508138",
-      "question_id": "komunalni-2022-544256-question-51",
+      "id": "komunalni-2022-544256-a-154",
+      "candidate_id": "komunalni-2022-544256-c-508138",
+      "question_id": "komunalni-2022-544256-q-51",
       "comment": "NE"
     }
   ]

--- a/data/kalkulacka/komunalni-2022/549240.json
+++ b/data/kalkulacka/komunalni-2022/549240.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-549240",
   "name": "Písek",
-  "description": "Písek - DESCRIPTION",
+  "description": "Písek",
   "district_code": "549240",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-549240-question-1",
+      "id": "komunalni-2022-549240-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-2",
+      "id": "komunalni-2022-549240-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-3",
+      "id": "komunalni-2022-549240-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-4",
+      "id": "komunalni-2022-549240-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-5",
+      "id": "komunalni-2022-549240-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-6",
+      "id": "komunalni-2022-549240-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-7",
+      "id": "komunalni-2022-549240-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-8",
+      "id": "komunalni-2022-549240-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-9",
+      "id": "komunalni-2022-549240-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-10",
+      "id": "komunalni-2022-549240-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-11",
+      "id": "komunalni-2022-549240-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-12",
+      "id": "komunalni-2022-549240-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-13",
+      "id": "komunalni-2022-549240-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-14",
+      "id": "komunalni-2022-549240-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-15",
+      "id": "komunalni-2022-549240-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-16",
+      "id": "komunalni-2022-549240-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-17",
+      "id": "komunalni-2022-549240-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-18",
+      "id": "komunalni-2022-549240-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-19",
+      "id": "komunalni-2022-549240-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-20",
+      "id": "komunalni-2022-549240-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-21",
+      "id": "komunalni-2022-549240-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-22",
+      "id": "komunalni-2022-549240-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-23",
+      "id": "komunalni-2022-549240-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-24",
+      "id": "komunalni-2022-549240-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-25",
+      "id": "komunalni-2022-549240-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-26",
+      "id": "komunalni-2022-549240-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-27",
+      "id": "komunalni-2022-549240-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-28",
+      "id": "komunalni-2022-549240-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-29",
+      "id": "komunalni-2022-549240-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-30",
+      "id": "komunalni-2022-549240-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-31",
+      "id": "komunalni-2022-549240-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-32",
+      "id": "komunalni-2022-549240-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-33",
+      "id": "komunalni-2022-549240-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-34",
+      "id": "komunalni-2022-549240-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-35",
+      "id": "komunalni-2022-549240-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-36",
+      "id": "komunalni-2022-549240-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-37",
+      "id": "komunalni-2022-549240-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-38",
+      "id": "komunalni-2022-549240-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-39",
+      "id": "komunalni-2022-549240-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-40",
+      "id": "komunalni-2022-549240-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-41",
+      "id": "komunalni-2022-549240-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-42",
+      "id": "komunalni-2022-549240-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-43",
+      "id": "komunalni-2022-549240-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-44",
+      "id": "komunalni-2022-549240-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-45",
+      "id": "komunalni-2022-549240-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-46",
+      "id": "komunalni-2022-549240-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-47",
+      "id": "komunalni-2022-549240-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-549240-question-48",
+      "id": "komunalni-2022-549240-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,16 +399,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-549240-candidate-315187",
+      "id": "komunalni-2022-549240-c-315187",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-549240-315187-party",
+          "id": "komunalni-2022-549240-c-315187-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -417,16 +420,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-549240-candidate-332281",
+      "id": "komunalni-2022-549240-c-332281",
       "name": "Občanská demokratická strana",
       "type": "party",
       "description": "Občanská demokratická strana - DESCRIPTION",
+      "img_url": "ods",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-549240-332281-party",
+          "id": "komunalni-2022-549240-c-332281-p",
           "name": "Občanská demokratická strana",
           "description": "Občanská demokratická strana - DESCRIPTION",
           "contacts": {
@@ -437,16 +441,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-549240-candidate-270780",
+      "id": "komunalni-2022-549240-c-270780",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-549240-270780-party",
+          "id": "komunalni-2022-549240-c-270780-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -457,10 +462,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-549240-candidate-746441",
+      "id": "komunalni-2022-549240-c-746441",
       "name": "PÍSEK SRDCEM A ROZUMEM = Písek sobě + Svobodní + Písecký patrioti + Trikolora + nezávislí kandidáti: Spojili jsme se…",
       "type": "party",
       "description": "PÍSEK SRDCEM A ROZUMEM = Písek sobě + Svobodní + Písecký patrioti + Trikolora + nezávislí kandidáti: Spojili jsme se… - DESCRIPTION",
+      "img_url": "svob-trikol-nk",
       "contacts": {
         "web": [
           {
@@ -476,7 +482,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-549240-746441-party",
+          "id": "komunalni-2022-549240-c-746441-p",
           "name": "PÍSEK SRDCEM A ROZUMEM = Písek sobě + Svobodní + Písecký patrioti + Trikolora + nezávislí kandidáti: Spojili jsme se…",
           "description": "PÍSEK SRDCEM A ROZUMEM = Písek sobě + Svobodní + Písecký patrioti + Trikolora + nezávislí kandidáti: Spojili jsme se… - DESCRIPTION",
           "contacts": {
@@ -497,16 +503,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-549240-candidate-471937",
+      "id": "komunalni-2022-549240-c-471937",
       "name": "Hlas Písku",
       "type": "party",
       "description": "Hlas Písku - DESCRIPTION",
+      "img_url": "čssd-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-549240-471937-party",
+          "id": "komunalni-2022-549240-c-471937-p",
           "name": "Hlas Písku",
           "description": "Hlas Písku - DESCRIPTION",
           "contacts": {
@@ -517,16 +524,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-549240-candidate-424512",
+      "id": "komunalni-2022-549240-c-424512",
       "name": "PRO PÍSEK",
       "type": "party",
       "description": "PRO PÍSEK - DESCRIPTION",
+      "img_url": "top 09-jih 12",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-549240-424512-party",
+          "id": "komunalni-2022-549240-c-424512-p",
           "name": "PRO PÍSEK",
           "description": "PRO PÍSEK - DESCRIPTION",
           "contacts": {
@@ -537,16 +545,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-549240-candidate-669759",
+      "id": "komunalni-2022-549240-c-669759",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-549240-669759-party",
+          "id": "komunalni-2022-549240-c-669759-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -557,16 +566,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-549240-candidate-772524",
+      "id": "komunalni-2022-549240-c-772524",
       "name": "Demokratická strana zelených - za práva zvířat a spravedlnost v Písku",
       "type": "party",
       "description": "Demokratická strana zelených - za práva zvířat a spravedlnost v Písku - DESCRIPTION",
+      "img_url": "dsz-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-549240-772524-party",
+          "id": "komunalni-2022-549240-c-772524-p",
           "name": "Demokratická strana zelených - za práva zvířat a spravedlnost v Písku",
           "description": "Demokratická strana zelených - za práva zvířat a spravedlnost v Písku - DESCRIPTION",
           "contacts": {
@@ -577,16 +587,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-549240-candidate-149444",
+      "id": "komunalni-2022-549240-c-149444",
       "name": "KDU-ČSL",
       "type": "party",
       "description": "KDU-ČSL - DESCRIPTION",
+      "img_url": "kdu-čsl",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-549240-149444-party",
+          "id": "komunalni-2022-549240-c-149444-p",
           "name": "KDU-ČSL",
           "description": "KDU-ČSL - DESCRIPTION",
           "contacts": {
@@ -597,17 +608,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-549240-candidate-877605",
+      "id": "komunalni-2022-549240-c-877605",
       "name": "VAŠE VOLBA",
       "type": "party",
       "description": "VAŠE VOLBA - DESCRIPTION",
+      "img_url": "vpm-stan",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/vasevolbapisek"
       },
       "parties": [
         {
-          "id": "komunalni-2022-549240-877605-party",
+          "id": "komunalni-2022-549240-c-877605-p",
           "name": "VAŠE VOLBA",
           "description": "VAŠE VOLBA - DESCRIPTION",
           "contacts": {
@@ -621,313 +633,313 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-549240-answer-424512-1",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-1",
+      "id": "komunalni-2022-549240-a-4",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-2",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-2",
+      "id": "komunalni-2022-549240-a-7",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-2",
       "answer": "yes",
       "comment": "Odpad produkuje každý z nás, poplatek by měl být zachován. Celkové roční náklady na svoz odpadu jsou 29 mil. Kč. Zrušením poplatku přijde město o 12 mil., které bude muset investovat navíc a za které by se daly opravit např. povrchy ve 3 ulicích."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-3",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-3",
+      "id": "komunalni-2022-549240-a-10",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-3",
       "answer": "no",
       "comment": "Město zatím žádné domy pro seniory neprovozuje, ani prostřednictvím jím zřízených organizací."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-4",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-4",
+      "id": "komunalni-2022-549240-a-13",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-4",
       "answer": "yes",
       "comment": "Tato zóna by mohla být vytvořena v centru města, minimálně na Velkém náměstí. Vytvořil by se bezpečný prostor pro chodce a zároveň by to umožnilo jednoúrovňové řešení plochy bez zbytečných bariér (vysoké obrubníky, atd.)"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-5",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-5",
+      "id": "komunalni-2022-549240-a-16",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-6",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-6"
+      "id": "komunalni-2022-549240-a-19",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-6"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-7",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-7",
+      "id": "komunalni-2022-549240-a-22",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-8",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-8",
+      "id": "komunalni-2022-549240-a-25",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-8",
       "answer": "no",
       "comment": "Pro seniory a studenty je cena za roční jízdenku 100 Kč, je to víceméně symbolická suma. "
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-9",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-9",
+      "id": "komunalni-2022-549240-a-28",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-9",
       "answer": "yes",
       "comment": "Postupně by mělo dojít na úpravy zastávek tak, jak se budou jednotlivé ulice rekonstruovat."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-10",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-10",
+      "id": "komunalni-2022-549240-a-31",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-11",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-11",
+      "id": "komunalni-2022-549240-a-34",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-12",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-12",
+      "id": "komunalni-2022-549240-a-37",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-13",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-13",
+      "id": "komunalni-2022-549240-a-40",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-13",
       "answer": "yes",
       "comment": "Městská knihovna slouží široké veřejnosti, přijít se ohřát a při té příležitosti si i něco přečíst by neměl být problém."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-14",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-14",
+      "id": "komunalni-2022-549240-a-43",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-14",
       "answer": "no",
       "comment": "Noční nasvícení kulturních památek tvoří jen velmi zanedbatelnou položku v celkovém objemu."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-15",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-15",
+      "id": "komunalni-2022-549240-a-46",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-15",
       "answer": "yes",
       "comment": "Momentálně pracujeme na úsporných opatřeních v oblasti veřejného opatření."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-16",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-16",
+      "id": "komunalni-2022-549240-a-49",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-16",
       "answer": "yes",
       "comment": "Městské budovy jsou až na několik výjimek napojené na městskou teplárnu. Nicméně pokud chceme, aby si svůj komfort snížili i občané, je třeba jít příkladem."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-17",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-17",
+      "id": "komunalni-2022-549240-a-52",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-18",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-18",
+      "id": "komunalni-2022-549240-a-55",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-19",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-19",
+      "id": "komunalni-2022-549240-a-58",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-19",
       "answer": "yes",
       "comment": "Město má vyčleněnou částku 3 mil. Kč na participativní rozpočet, tedy na projekty, které vymýšlejí sami občané a také o nich sami rozhodují. Chtěli bychom v tom pokračovat."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-20",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-20",
+      "id": "komunalni-2022-549240-a-61",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-21",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-21",
+      "id": "komunalni-2022-549240-a-64",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-21",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-22",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-22",
+      "id": "komunalni-2022-549240-a-67",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-23",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-23",
+      "id": "komunalni-2022-549240-a-70",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-23",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-24",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-24",
+      "id": "komunalni-2022-549240-a-73",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-24",
       "answer": "no",
       "comment": "Parkovací zóny se momentálně jeví jako nejvhodnější nástroj k regulaci parkování např. na sídlištích nebo i v centru města. Nicméně musí být doplněny vhodnou alternativou, jako jsou např. kapacitní parkovací domy."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-25",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-25",
+      "id": "komunalni-2022-549240-a-76",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-26",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-26",
+      "id": "komunalni-2022-549240-a-79",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-26",
       "answer": "yes",
       "comment": "Již připravujeme podklady k přípravě pravidel pro spolupráci s developery."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-27",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-27",
+      "id": "komunalni-2022-549240-a-82",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-28",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-28"
+      "id": "komunalni-2022-549240-a-85",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-28"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-29",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-29",
+      "id": "komunalni-2022-549240-a-88",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-29",
       "answer": "yes",
       "comment": "Momentálně je výše příspěvků 0, takže by se určitě měly zvýšit, resp. zavést."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-30",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-30",
+      "id": "komunalni-2022-549240-a-91",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-31",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-31",
+      "id": "komunalni-2022-549240-a-94",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-31",
       "answer": "yes",
       "comment": "Pro takové formy výstavby jsme schopni poskytnout vhodné pozemky, ale je třeba je vybavit potřebnou infrastrukturou."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-32",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-32",
+      "id": "komunalni-2022-549240-a-97",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-32",
       "answer": "no",
       "comment": "Děti do 18 let dnes platí 100 Kč ročně, jde o symbolický poplatek."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-33",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-33",
+      "id": "komunalni-2022-549240-a-100",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-33",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-34",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-34",
+      "id": "komunalni-2022-549240-a-103",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-35",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-35",
+      "id": "komunalni-2022-549240-a-106",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-36",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-36",
+      "id": "komunalni-2022-549240-a-109",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-37",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-37",
+      "id": "komunalni-2022-549240-a-112",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-38",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-38",
+      "id": "komunalni-2022-549240-a-115",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-39",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-39",
+      "id": "komunalni-2022-549240-a-118",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-40",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-40",
+      "id": "komunalni-2022-549240-a-121",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-40",
       "answer": "yes",
       "comment": "Ale bude to generovat samozřejmě vyšší náklady na platy. Dále je také nedostatek vhodných zájemců o tuto nepopulární práci."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-41",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-41",
+      "id": "komunalni-2022-549240-a-124",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-41",
       "answer": "yes",
       "comment": "Město prosazovat zelené střechy chce, ale bohužel naráží na odpor ze strany památkové péče."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-42",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-42",
+      "id": "komunalni-2022-549240-a-127",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-43",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-43",
+      "id": "komunalni-2022-549240-a-130",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-44",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-44",
+      "id": "komunalni-2022-549240-a-133",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-45",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-45",
+      "id": "komunalni-2022-549240-a-136",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-45",
       "answer": "no",
       "comment": "Podpora by měla být motivační, např. zvýhodněné nájemné na dobu určitou nebo možnost splátkových kalendářů. NE finanční podpora."
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-46",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-46",
+      "id": "komunalni-2022-549240-a-139",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-47",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-47",
+      "id": "komunalni-2022-549240-a-142",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-48",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-48",
+      "id": "komunalni-2022-549240-a-145",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-549240-answer-424512-49",
-      "candidate_id": "komunalni-2022-549240-candidate-424512",
-      "question_id": "komunalni-2022-549240-question-49"
+      "id": "komunalni-2022-549240-a-148",
+      "candidate_id": "komunalni-2022-549240-c-424512",
+      "question_id": "komunalni-2022-549240-q-49"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/552046.json
+++ b/data/kalkulacka/komunalni-2022/552046.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-552046",
   "name": "Tábor",
-  "description": "Tábor - DESCRIPTION",
+  "description": "Tábor",
   "district_code": "552046",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-552046-question-1",
+      "id": "komunalni-2022-552046-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-2",
+      "id": "komunalni-2022-552046-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-3",
+      "id": "komunalni-2022-552046-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-4",
+      "id": "komunalni-2022-552046-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-5",
+      "id": "komunalni-2022-552046-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-6",
+      "id": "komunalni-2022-552046-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-7",
+      "id": "komunalni-2022-552046-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-8",
+      "id": "komunalni-2022-552046-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-9",
+      "id": "komunalni-2022-552046-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-10",
+      "id": "komunalni-2022-552046-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-11",
+      "id": "komunalni-2022-552046-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-12",
+      "id": "komunalni-2022-552046-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-13",
+      "id": "komunalni-2022-552046-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-14",
+      "id": "komunalni-2022-552046-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-15",
+      "id": "komunalni-2022-552046-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-16",
+      "id": "komunalni-2022-552046-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-17",
+      "id": "komunalni-2022-552046-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-18",
+      "id": "komunalni-2022-552046-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-19",
+      "id": "komunalni-2022-552046-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-20",
+      "id": "komunalni-2022-552046-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-21",
+      "id": "komunalni-2022-552046-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-22",
+      "id": "komunalni-2022-552046-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-23",
+      "id": "komunalni-2022-552046-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-24",
+      "id": "komunalni-2022-552046-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-25",
+      "id": "komunalni-2022-552046-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-26",
+      "id": "komunalni-2022-552046-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-27",
+      "id": "komunalni-2022-552046-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-28",
+      "id": "komunalni-2022-552046-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-29",
+      "id": "komunalni-2022-552046-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-30",
+      "id": "komunalni-2022-552046-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-31",
+      "id": "komunalni-2022-552046-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-32",
+      "id": "komunalni-2022-552046-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-33",
+      "id": "komunalni-2022-552046-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-34",
+      "id": "komunalni-2022-552046-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-35",
+      "id": "komunalni-2022-552046-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-36",
+      "id": "komunalni-2022-552046-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-37",
+      "id": "komunalni-2022-552046-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-38",
+      "id": "komunalni-2022-552046-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-39",
+      "id": "komunalni-2022-552046-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-40",
+      "id": "komunalni-2022-552046-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-41",
+      "id": "komunalni-2022-552046-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-42",
+      "id": "komunalni-2022-552046-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-43",
+      "id": "komunalni-2022-552046-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-44",
+      "id": "komunalni-2022-552046-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-45",
+      "id": "komunalni-2022-552046-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-46",
+      "id": "komunalni-2022-552046-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-47",
+      "id": "komunalni-2022-552046-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-552046-question-48",
+      "id": "komunalni-2022-552046-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,16 +399,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-552046-candidate-653212",
+      "id": "komunalni-2022-552046-c-653212",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-552046-653212-party",
+          "id": "komunalni-2022-552046-c-653212-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -417,10 +420,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-552046-candidate-711686",
+      "id": "komunalni-2022-552046-c-711686",
       "name": "Tábor 2020",
       "type": "party",
       "description": "Tábor 2020 - DESCRIPTION",
+      "img_url": "t2020",
       "contacts": {
         "web": [
           {
@@ -439,7 +443,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-552046-711686-party",
+          "id": "komunalni-2022-552046-c-711686-p",
           "name": "Tábor 2020",
           "description": "Tábor 2020 - DESCRIPTION",
           "contacts": {
@@ -463,10 +467,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-552046-candidate-887165",
+      "id": "komunalni-2022-552046-c-887165",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": [
           {
@@ -477,7 +482,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-552046-887165-party",
+          "id": "komunalni-2022-552046-c-887165-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -493,16 +498,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-552046-candidate-479115",
+      "id": "komunalni-2022-552046-c-479115",
       "name": "ŠANCE pro TÁBOR (ČSSD, SPD, KSČM, nezávislí)",
       "type": "party",
       "description": "ŠANCE pro TÁBOR (ČSSD, SPD, KSČM, nezávislí) - DESCRIPTION",
+      "img_url": "čssdksčmspdnk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-552046-479115-party",
+          "id": "komunalni-2022-552046-c-479115-p",
           "name": "ŠANCE pro TÁBOR (ČSSD, SPD, KSČM, nezávislí)",
           "description": "ŠANCE pro TÁBOR (ČSSD, SPD, KSČM, nezávislí) - DESCRIPTION",
           "contacts": {
@@ -513,10 +519,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-552046-candidate-624531",
+      "id": "komunalni-2022-552046-c-624531",
       "name": "SPOLEČNĚ PRO TÁBOR",
       "type": "party",
       "description": "SPOLEČNĚ PRO TÁBOR - DESCRIPTION",
+      "img_url": "ods-top 09",
       "contacts": {
         "web": [
           {
@@ -527,7 +534,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-552046-624531-party",
+          "id": "komunalni-2022-552046-c-624531-p",
           "name": "SPOLEČNĚ PRO TÁBOR",
           "description": "SPOLEČNĚ PRO TÁBOR - DESCRIPTION",
           "contacts": {
@@ -543,16 +550,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-552046-candidate-923685",
+      "id": "komunalni-2022-552046-c-923685",
       "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
       "type": "party",
       "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+      "img_url": "dsz-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-552046-923685-party",
+          "id": "komunalni-2022-552046-c-923685-p",
           "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
           "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
           "contacts": {
@@ -563,16 +571,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-552046-candidate-605202",
+      "id": "komunalni-2022-552046-c-605202",
       "name": "KDU-ČSL a nezávislí kandidáti",
       "type": "party",
       "description": "KDU-ČSL a nezávislí kandidáti - DESCRIPTION",
+      "img_url": "kdu-čsl-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-552046-605202-party",
+          "id": "komunalni-2022-552046-c-605202-p",
           "name": "KDU-ČSL a nezávislí kandidáti",
           "description": "KDU-ČSL a nezávislí kandidáti - DESCRIPTION",
           "contacts": {
@@ -583,10 +592,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-552046-candidate-706920",
+      "id": "komunalni-2022-552046-c-706920",
       "name": "JiNAK! - sdružení zelených a nezávislých",
       "type": "party",
       "description": "JiNAK! - sdružení zelených a nezávislých - DESCRIPTION",
+      "img_url": "zelení-nk",
       "contacts": {
         "web": [
           {
@@ -605,7 +615,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-552046-706920-party",
+          "id": "komunalni-2022-552046-c-706920-p",
           "name": "JiNAK! - sdružení zelených a nezávislých",
           "description": "JiNAK! - sdružení zelených a nezávislých - DESCRIPTION",
           "contacts": {
@@ -629,10 +639,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-552046-candidate-892184",
+      "id": "komunalni-2022-552046-c-892184",
       "name": "TÁBOR - NÁŠ DOMOV",
       "type": "party",
       "description": "TÁBOR - NÁŠ DOMOV - DESCRIPTION",
+      "img_url": "domov-nk",
       "contacts": {
         "web": [
           {
@@ -644,7 +655,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-552046-892184-party",
+          "id": "komunalni-2022-552046-c-892184-p",
           "name": "TÁBOR - NÁŠ DOMOV",
           "description": "TÁBOR - NÁŠ DOMOV - DESCRIPTION",
           "contacts": {

--- a/data/kalkulacka/komunalni-2022/554481.json
+++ b/data/kalkulacka/komunalni-2022/554481.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-554481",
   "name": "Cheb",
-  "description": "Cheb - DESCRIPTION",
+  "description": "Cheb",
   "district_code": "554481",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-554481-question-1",
+      "id": "komunalni-2022-554481-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-2",
+      "id": "komunalni-2022-554481-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-3",
+      "id": "komunalni-2022-554481-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-4",
+      "id": "komunalni-2022-554481-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-5",
+      "id": "komunalni-2022-554481-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-6",
+      "id": "komunalni-2022-554481-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-7",
+      "id": "komunalni-2022-554481-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-8",
+      "id": "komunalni-2022-554481-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-9",
+      "id": "komunalni-2022-554481-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-10",
+      "id": "komunalni-2022-554481-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-11",
+      "id": "komunalni-2022-554481-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-12",
+      "id": "komunalni-2022-554481-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-13",
+      "id": "komunalni-2022-554481-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-14",
+      "id": "komunalni-2022-554481-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-15",
+      "id": "komunalni-2022-554481-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-16",
+      "id": "komunalni-2022-554481-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-17",
+      "id": "komunalni-2022-554481-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-18",
+      "id": "komunalni-2022-554481-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-19",
+      "id": "komunalni-2022-554481-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-20",
+      "id": "komunalni-2022-554481-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-21",
+      "id": "komunalni-2022-554481-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-22",
+      "id": "komunalni-2022-554481-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-23",
+      "id": "komunalni-2022-554481-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-24",
+      "id": "komunalni-2022-554481-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-25",
+      "id": "komunalni-2022-554481-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-26",
+      "id": "komunalni-2022-554481-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-27",
+      "id": "komunalni-2022-554481-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-28",
+      "id": "komunalni-2022-554481-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-29",
+      "id": "komunalni-2022-554481-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-30",
+      "id": "komunalni-2022-554481-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-31",
+      "id": "komunalni-2022-554481-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-32",
+      "id": "komunalni-2022-554481-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-33",
+      "id": "komunalni-2022-554481-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-34",
+      "id": "komunalni-2022-554481-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-35",
+      "id": "komunalni-2022-554481-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-36",
+      "id": "komunalni-2022-554481-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-37",
+      "id": "komunalni-2022-554481-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-38",
+      "id": "komunalni-2022-554481-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-39",
+      "id": "komunalni-2022-554481-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-40",
+      "id": "komunalni-2022-554481-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-41",
+      "id": "komunalni-2022-554481-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-42",
+      "id": "komunalni-2022-554481-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-43",
+      "id": "komunalni-2022-554481-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-44",
+      "id": "komunalni-2022-554481-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-45",
+      "id": "komunalni-2022-554481-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-46",
+      "id": "komunalni-2022-554481-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-47",
+      "id": "komunalni-2022-554481-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554481-question-48",
+      "id": "komunalni-2022-554481-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,16 +399,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-554481-candidate-523408",
+      "id": "komunalni-2022-554481-c-523408",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554481-523408-party",
+          "id": "komunalni-2022-554481-c-523408-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -417,16 +420,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554481-candidate-357413",
+      "id": "komunalni-2022-554481-c-357413",
       "name": "Občanská demokratická strana",
       "type": "party",
       "description": "Občanská demokratická strana - DESCRIPTION",
+      "img_url": "ods",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554481-357413-party",
+          "id": "komunalni-2022-554481-c-357413-p",
           "name": "Občanská demokratická strana",
           "description": "Občanská demokratická strana - DESCRIPTION",
           "contacts": {
@@ -437,10 +441,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554481-candidate-906107",
+      "id": "komunalni-2022-554481-c-906107",
       "name": "VOLBA PRO MĚSTO CHEB",
       "type": "party",
       "description": "VOLBA PRO MĚSTO CHEB - DESCRIPTION",
+      "img_url": "stan-nk",
       "contacts": {
         "web": [
           {
@@ -452,7 +457,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554481-906107-party",
+          "id": "komunalni-2022-554481-c-906107-p",
           "name": "VOLBA PRO MĚSTO CHEB",
           "description": "VOLBA PRO MĚSTO CHEB - DESCRIPTION",
           "contacts": {
@@ -469,16 +474,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554481-candidate-295770",
+      "id": "komunalni-2022-554481-c-295770",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554481-295770-party",
+          "id": "komunalni-2022-554481-c-295770-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -489,16 +495,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554481-candidate-933475",
+      "id": "komunalni-2022-554481-c-933475",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554481-933475-party",
+          "id": "komunalni-2022-554481-c-933475-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -509,17 +516,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-554481-candidate-261938",
+      "id": "komunalni-2022-554481-c-261938",
       "name": "Volba pro kraj",
       "type": "party",
       "description": "Volba pro kraj - DESCRIPTION",
+      "img_url": "vok",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/vokcheb/"
       },
       "parties": [
         {
-          "id": "komunalni-2022-554481-261938-party",
+          "id": "komunalni-2022-554481-c-261938-p",
           "name": "Volba pro kraj",
           "description": "Volba pro kraj - DESCRIPTION",
           "contacts": {
@@ -531,16 +539,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554481-candidate-668721",
+      "id": "komunalni-2022-554481-c-668721",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554481-668721-party",
+          "id": "komunalni-2022-554481-c-668721-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -551,16 +560,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554481-candidate-470199",
+      "id": "komunalni-2022-554481-c-470199",
       "name": "Demokratická strana zelených – ZA PRÁVA ZVÍŘAT — sdružení DSZ – ZA PRÁVA ZVÍŘAT a NK",
       "type": "party",
       "description": "Demokratická strana zelených – ZA PRÁVA ZVÍŘAT — sdružení DSZ – ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+      "img_url": "dsz-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554481-470199-party",
+          "id": "komunalni-2022-554481-c-470199-p",
           "name": "Demokratická strana zelených – ZA PRÁVA ZVÍŘAT — sdružení DSZ – ZA PRÁVA ZVÍŘAT a NK",
           "description": "Demokratická strana zelených – ZA PRÁVA ZVÍŘAT — sdružení DSZ – ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
           "contacts": {
@@ -571,16 +581,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554481-candidate-969613",
+      "id": "komunalni-2022-554481-c-969613",
       "name": "Koalice pro Cheb",
       "type": "party",
       "description": "Koalice pro Cheb - DESCRIPTION",
+      "img_url": "kdu-zel-top-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554481-969613-party",
+          "id": "komunalni-2022-554481-c-969613-p",
           "name": "Koalice pro Cheb",
           "description": "Koalice pro Cheb - DESCRIPTION",
           "contacts": {
@@ -593,604 +604,604 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-554481-answer-906107-1",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-1",
+      "id": "komunalni-2022-554481-a-4",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-1",
       "answer": "no",
       "comment": "Úkolem města je zajistit rovnoměrný rozvoj jednotlivých částí. Není tedy žádoucí, aby vznikala na jedné straně ghetta, na straně druhé milionářské čtvrti. Samozřejmě, že určitá diferenciace na základě příjmů bude existovat vždy, ale úkolem radnice je dopady sociálních rozdílů zmírňovat."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-2",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-2",
+      "id": "komunalni-2022-554481-a-7",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-2",
       "answer": "yes",
       "comment": "Každá služba něco stojí a ceny za svoz a ukládání odpadu jsou stále vyšší. Hradit desítky milionů z jiných příjmů města nepovažujeme za vhodné."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-3",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-3",
+      "id": "komunalni-2022-554481-a-10",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-3",
       "comment": "V opravdu extrémních případech, jsou-li vyčerpány všechny možnosti úspor ano. V ostatních je třeba komfort pro seniory, kteří většinou mají oslabenou imunitu a zhoršenou termoregulaci, zachovat."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-4",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-4",
+      "id": "komunalni-2022-554481-a-13",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-4",
       "answer": "no",
       "comment": "Současný rozsah podobné zóny v centru města postačuje. Navíc nemá příliš smysl rozšiřovat něco, co se z hlediska přestupků celkem obtížně následně vymáhá."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-5",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-5",
+      "id": "komunalni-2022-554481-a-16",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-5",
       "answer": "no",
       "comment": "Většinu dlužníků tvoří lidé, u kterých dluh vznikl kvůli pokutě, na což se Milostivé léto nevztahuje.  Ostatní je určitě vhodné informovat přes web či sociální sítě, ale dopisy, které se mnohdy u těchto lidí vrací jako nedoručitelné, postrádají smysl."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-6",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-6",
+      "id": "komunalni-2022-554481-a-19",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-6",
       "answer": "yes",
       "comment": "V současnosti probíhá rozšíření a modernizace kamerového systému."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-7",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-7",
+      "id": "komunalni-2022-554481-a-22",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-7",
       "answer": "yes",
       "comment": "Už máme zakázaný hazard na celém území s jedinou výjimkou lokality Svatý Kříž."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-8",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-8",
+      "id": "komunalni-2022-554481-a-25",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-8",
       "answer": "no",
       "comment": "U sociálně citlivých skupin (senioři, ZTP, žáci) už máme proplácení kupónů MHD zavedeno. U ekonomicky aktivních k tomu nevidím důvod."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-9",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-9",
+      "id": "komunalni-2022-554481-a-28",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-9",
       "answer": "no",
       "comment": "Současné investice považujeme za dostatečné, bezbariérovost je v drtivé většině případů zaručena již nyní."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-10",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-10",
+      "id": "komunalni-2022-554481-a-31",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-10",
       "answer": "yes",
       "comment": "Dávno to tak děláme."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-11",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-11"
+      "id": "komunalni-2022-554481-a-34",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-11"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-12",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-12",
+      "id": "komunalni-2022-554481-a-37",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-12",
       "comment": "Otázkou je vymahatelnost takového zákazu. Silvestr je specifický, rádi bychom prodej a použití pyrotechniky omezili."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-13",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-13",
+      "id": "komunalni-2022-554481-a-40",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-13",
       "answer": "no",
       "comment": "Od toho máme azylová zařízení a noclehárny."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-14",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-14",
+      "id": "komunalni-2022-554481-a-43",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-14",
       "answer": "yes",
       "comment": "Už se stalo."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-15",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-15",
+      "id": "komunalni-2022-554481-a-46",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-15",
       "answer": "no",
       "comment": "Jde o významný bezpečnostní prvek."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-16",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-16",
+      "id": "komunalni-2022-554481-a-49",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-16",
       "answer": "yes",
       "comment": "Máme to již připraveno v rámci souboru úsporných opatření."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-17",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-17",
+      "id": "komunalni-2022-554481-a-52",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-17",
       "answer": "no",
       "comment": "Vždy je třeba individuálně posoudit, proč dluh vznikl a jaká je situace konkrétního dlužníka."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-18",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-18",
+      "id": "komunalni-2022-554481-a-55",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-18",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-19",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-19",
+      "id": "komunalni-2022-554481-a-58",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-19",
       "answer": "yes",
       "comment": "Participativní rozpočet máme v Chebu už několik let."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-20",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-20",
+      "id": "komunalni-2022-554481-a-61",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-20",
       "answer": "no",
       "comment": "Cheb má 1275 bytů, což je více než dostatečný počet."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-21",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-21",
+      "id": "komunalni-2022-554481-a-64",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-22",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-22",
+      "id": "komunalni-2022-554481-a-67",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-23",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-23",
+      "id": "komunalni-2022-554481-a-70",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-23",
       "answer": "no",
       "comment": "To je věcí soukromých firem."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-24",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-24",
+      "id": "komunalni-2022-554481-a-73",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-24",
       "answer": "no",
       "comment": "regulace parkování a zvýhodnění rezidentů v centru města je nezbytné, aby se střed města nevylidňoval."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-25",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-25",
+      "id": "komunalni-2022-554481-a-76",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-25",
       "comment": "Jen tu část, která je provozně drahá a investičně zanedbaná."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-26",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-26",
+      "id": "komunalni-2022-554481-a-79",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-27",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-27",
+      "id": "komunalni-2022-554481-a-82",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-28",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-28",
+      "id": "komunalni-2022-554481-a-85",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-28",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-29",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-29"
+      "id": "komunalni-2022-554481-a-88",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-29"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-30",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-30",
+      "id": "komunalni-2022-554481-a-91",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-30",
       "answer": "no",
       "comment": "To je věcí soukromých firem. Zatěžovat tím rozpočet města je nezodpovědné."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-31",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-31",
+      "id": "komunalni-2022-554481-a-94",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-32",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-32",
+      "id": "komunalni-2022-554481-a-97",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-33",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-33",
+      "id": "komunalni-2022-554481-a-100",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-33",
       "answer": "yes",
       "comment": "Nikoliv ale finančně, ale v rámci poradenství např. z hlediska možnosti získání dotací."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-34",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-34",
+      "id": "komunalni-2022-554481-a-103",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-34",
       "answer": "yes",
       "comment": "Symbolické, nikoliv nulové."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-35",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-35",
+      "id": "komunalni-2022-554481-a-106",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-36",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-36",
+      "id": "komunalni-2022-554481-a-109",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-37",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-37",
+      "id": "komunalni-2022-554481-a-112",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-38",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-38",
+      "id": "komunalni-2022-554481-a-115",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-38",
       "answer": "yes",
       "comment": "Např. možností bezpečného uschování těchto \"přibližovadel\" či jejich dobíjení."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-39",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-39",
+      "id": "komunalni-2022-554481-a-118",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-40",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-40",
+      "id": "komunalni-2022-554481-a-121",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-41",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-41",
+      "id": "komunalni-2022-554481-a-124",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-42",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-42",
+      "id": "komunalni-2022-554481-a-127",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-43",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-43",
+      "id": "komunalni-2022-554481-a-130",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-43",
       "answer": "yes",
       "comment": "Pouze doplňkově v rámci reprezentace města."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-44",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-44",
+      "id": "komunalni-2022-554481-a-133",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-44",
       "answer": "no",
       "comment": "Máme ji jednu z nejnižších ze všech evropských zemí."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-45",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-45",
+      "id": "komunalni-2022-554481-a-136",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-45",
       "answer": "no",
       "comment": "To ej úkolem státu a jeho sociální politiky."
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-46",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-46",
+      "id": "komunalni-2022-554481-a-139",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-47",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-47",
+      "id": "komunalni-2022-554481-a-142",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-48",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-48",
+      "id": "komunalni-2022-554481-a-145",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-906107-49",
-      "candidate_id": "komunalni-2022-554481-candidate-906107",
-      "question_id": "komunalni-2022-554481-question-49"
+      "id": "komunalni-2022-554481-a-148",
+      "candidate_id": "komunalni-2022-554481-c-906107",
+      "question_id": "komunalni-2022-554481-q-49"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-1",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-1"
+      "id": "komunalni-2022-554481-a-4",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-1"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-2",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-2",
+      "id": "komunalni-2022-554481-a-7",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-3",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-3",
+      "id": "komunalni-2022-554481-a-10",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-4",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-4",
+      "id": "komunalni-2022-554481-a-13",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-5",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-5",
+      "id": "komunalni-2022-554481-a-16",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-6",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-6",
+      "id": "komunalni-2022-554481-a-19",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-7",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-7",
+      "id": "komunalni-2022-554481-a-22",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-7",
       "answer": "no",
       "comment": "Povolení jen pro casina s tím, že se městu zavážou se podílet na dalším společenském, kulturním a sportovním životě formou sponzoringu apod."
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-8",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-8",
+      "id": "komunalni-2022-554481-a-25",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-9",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-9",
+      "id": "komunalni-2022-554481-a-28",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-10",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-10",
+      "id": "komunalni-2022-554481-a-31",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-11",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-11",
+      "id": "komunalni-2022-554481-a-34",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-12",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-12",
+      "id": "komunalni-2022-554481-a-37",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-13",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-13"
+      "id": "komunalni-2022-554481-a-40",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-13"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-14",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-14",
+      "id": "komunalni-2022-554481-a-43",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-14",
       "answer": "yes",
       "comment": "Omezovat nejen kvůli energetickým úsporám, ale také kvůli světelnému smogu."
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-15",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-15"
+      "id": "komunalni-2022-554481-a-46",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-15"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-16",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-16",
+      "id": "komunalni-2022-554481-a-49",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-16",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-17",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-17",
+      "id": "komunalni-2022-554481-a-52",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-18",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-18",
+      "id": "komunalni-2022-554481-a-55",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-19",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-19",
+      "id": "komunalni-2022-554481-a-58",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-20",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-20",
+      "id": "komunalni-2022-554481-a-61",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-21",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-21",
+      "id": "komunalni-2022-554481-a-64",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-22",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-22",
+      "id": "komunalni-2022-554481-a-67",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-23",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-23",
+      "id": "komunalni-2022-554481-a-70",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-24",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-24",
+      "id": "komunalni-2022-554481-a-73",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-25",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-25",
+      "id": "komunalni-2022-554481-a-76",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-26",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-26",
+      "id": "komunalni-2022-554481-a-79",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-27",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-27",
+      "id": "komunalni-2022-554481-a-82",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-28",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-28",
+      "id": "komunalni-2022-554481-a-85",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-29",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-29",
+      "id": "komunalni-2022-554481-a-88",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-30",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-30",
+      "id": "komunalni-2022-554481-a-91",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-30",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-31",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-31",
+      "id": "komunalni-2022-554481-a-94",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-32",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-32",
+      "id": "komunalni-2022-554481-a-97",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-33",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-33",
+      "id": "komunalni-2022-554481-a-100",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-34",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-34"
+      "id": "komunalni-2022-554481-a-103",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-34"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-35",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-35"
+      "id": "komunalni-2022-554481-a-106",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-35"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-36",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-36",
+      "id": "komunalni-2022-554481-a-109",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-37",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-37",
+      "id": "komunalni-2022-554481-a-112",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-38",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-38",
+      "id": "komunalni-2022-554481-a-115",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-39",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-39"
+      "id": "komunalni-2022-554481-a-118",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-39"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-40",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-40",
+      "id": "komunalni-2022-554481-a-121",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-41",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-41"
+      "id": "komunalni-2022-554481-a-124",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-41"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-42",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-42"
+      "id": "komunalni-2022-554481-a-127",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-42"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-43",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-43",
+      "id": "komunalni-2022-554481-a-130",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-44",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-44"
+      "id": "komunalni-2022-554481-a-133",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-44"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-45",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-45"
+      "id": "komunalni-2022-554481-a-136",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-45"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-46",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-46",
+      "id": "komunalni-2022-554481-a-139",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-47",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-47"
+      "id": "komunalni-2022-554481-a-142",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-47"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-48",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-48",
+      "id": "komunalni-2022-554481-a-145",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554481-answer-523408-49",
-      "candidate_id": "komunalni-2022-554481-candidate-523408",
-      "question_id": "komunalni-2022-554481-question-49"
+      "id": "komunalni-2022-554481-a-148",
+      "candidate_id": "komunalni-2022-554481-c-523408",
+      "question_id": "komunalni-2022-554481-q-49"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/554782.json
+++ b/data/kalkulacka/komunalni-2022/554782.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-554782",
   "name": "Praha hl. m.",
-  "description": "Praha hl. m. - DESCRIPTION",
+  "description": "Praha hl. m.",
   "district_code": "554782",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-554782-question-1",
+      "id": "komunalni-2022-554782-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-2",
+      "id": "komunalni-2022-554782-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-3",
+      "id": "komunalni-2022-554782-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-4",
+      "id": "komunalni-2022-554782-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-5",
+      "id": "komunalni-2022-554782-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-6",
+      "id": "komunalni-2022-554782-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-7",
+      "id": "komunalni-2022-554782-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-8",
+      "id": "komunalni-2022-554782-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-9",
+      "id": "komunalni-2022-554782-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-10",
+      "id": "komunalni-2022-554782-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-11",
+      "id": "komunalni-2022-554782-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-12",
+      "id": "komunalni-2022-554782-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-13",
+      "id": "komunalni-2022-554782-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-14",
+      "id": "komunalni-2022-554782-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-15",
+      "id": "komunalni-2022-554782-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-16",
+      "id": "komunalni-2022-554782-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-17",
+      "id": "komunalni-2022-554782-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-18",
+      "id": "komunalni-2022-554782-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-19",
+      "id": "komunalni-2022-554782-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-20",
+      "id": "komunalni-2022-554782-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-21",
+      "id": "komunalni-2022-554782-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-22",
+      "id": "komunalni-2022-554782-q-22",
       "name": "Regulovaný nájem",
       "title": "Nájem v městských bytech by se měl regulovat.",
       "gist": "Kritici poukazují, že by snížené příjmy z nájmů vedly k zanedbávání těchto bytů i celých budov. Zastánci by tím chtěli mírnit růst cen nájemného.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-23",
+      "id": "komunalni-2022-554782-q-23",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-24",
+      "id": "komunalni-2022-554782-q-24",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-25",
+      "id": "komunalni-2022-554782-q-25",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-26",
+      "id": "komunalni-2022-554782-q-26",
       "name": "Jedna parkovací zóna pro celé město",
       "title": "Město má umožňovat rezidentům za jeden roční paušální poplatek parkovat kdekoli na svém území.",
       "gist": "Ve městě by existovala jen jedna rezidenční parkovací zóna, nedělená podle oblastí či městských částí. Kritikům více zón vadí, že předplatné rezidentům parkovací místo automaticky nezaručí. Podle nich by jedna zóna pomohla parkovat i v jiném bloku nebo ulici, jež například spadají do vedlejší městské části.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-27",
+      "id": "komunalni-2022-554782-q-27",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-28",
+      "id": "komunalni-2022-554782-q-28",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-29",
+      "id": "komunalni-2022-554782-q-29",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-30",
+      "id": "komunalni-2022-554782-q-30",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-31",
+      "id": "komunalni-2022-554782-q-31",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-32",
+      "id": "komunalni-2022-554782-q-32",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-33",
+      "id": "komunalni-2022-554782-q-33",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-34",
+      "id": "komunalni-2022-554782-q-34",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-35",
+      "id": "komunalni-2022-554782-q-35",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-36",
+      "id": "komunalni-2022-554782-q-36",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-37",
+      "id": "komunalni-2022-554782-q-37",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-38",
+      "id": "komunalni-2022-554782-q-38",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-39",
+      "id": "komunalni-2022-554782-q-39",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-40",
+      "id": "komunalni-2022-554782-q-40",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-41",
+      "id": "komunalni-2022-554782-q-41",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-42",
+      "id": "komunalni-2022-554782-q-42",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-43",
+      "id": "komunalni-2022-554782-q-43",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-44",
+      "id": "komunalni-2022-554782-q-44",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-45",
+      "id": "komunalni-2022-554782-q-45",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-46",
+      "id": "komunalni-2022-554782-q-46",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-47",
+      "id": "komunalni-2022-554782-q-47",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-48",
+      "id": "komunalni-2022-554782-q-48",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -395,7 +397,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-49",
+      "id": "komunalni-2022-554782-q-49",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -403,7 +405,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-50",
+      "id": "komunalni-2022-554782-q-50",
       "name": "Zklidnění dopravy v centru Prahy",
       "title": "Podporuji rozšířené chodníky a zklidnění automobilové dopravy na Smetanově nábřeží.",
       "gist": "Zastánci říkají, že Smetanovo nábřeží je historicky hodnotný prostor, který nikdy neměl sloužit výhradně dopravě. Má jít o atraktivní veřejný prostor s pěší promenádou s vyhlídkou na Pražský hrad, kde lidé chtějí trávit volný čas. Kritici namítají, že se automobilová doprava z dříve rušných komunikací přelije do okolních, rezidenčních ulic.",
@@ -411,7 +413,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-51",
+      "id": "komunalni-2022-554782-q-51",
       "name": "Zklidnění dopravy v centru Prahy",
       "title": "Masarykovo a Rašínovo nábřeží má sloužit v první řadě chodcům, cyklistům a tramvajím.",
       "gist": "Kritici namítají, že se automobilová doprava z dříve rušných komunikací přelije do okolních, rezidenčních ulic. Zastánci poukazují, že se omezení průjezdu aut už dříve osvědčilo a zlepšilo plynulost tramvají.",
@@ -419,7 +421,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-52",
+      "id": "komunalni-2022-554782-q-52",
       "name": "Krátkodobé pronájmy",
       "title": "Podporuji, aby se v Praze výrazně reguloval trh s krátkodobým bydlením.",
       "gist": "Zastánci regulace argumentují, že krátkodobě pronajímané nemovitosti křiví trh a vedou ke zvýšení cen. Vadí také nulové sousedské vazby a malá ohleduplnost hostů k dlouhodobým obyvatelům. Kritici poukazují, že se soukromým majetkem si vlastníci mohou nakládat jak chtějí.",
@@ -427,7 +429,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-53",
+      "id": "komunalni-2022-554782-q-53",
       "name": "Pravomoc magistrátu",
       "title": "Magistrát by měl mít možnost posoudit privatizaci bytů městských částí.",
       "gist": "Zastánci říkají, že by se tím mohla regulovat privatizace městských bytů, kterých má město nedostatek. Odpůrci chtějí, aby městské části v tomto jednaly autonomně. město bude schvalovat všechny prodeje bytů",
@@ -435,7 +437,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-54",
+      "id": "komunalni-2022-554782-q-54",
       "name": "Soukromé byty ve správě města",
       "title": "Podporuji, aby soukromí majitelé mohli městu nabídnout byty ke správě a pronájmu potřebným lidem.",
       "gist": "Městská nájemní agentura rozšiřuje počet bytů pro potřebné skupiny obyvatel. Majitelé se o byt po dobu trvání spolupráce nemusí starat s tím, že agentura se stará o veškerou agendu a kryje i případnou dočasnou neschopnost nájemníka platit. Zastánci usilují o to, aby bylo co nejvíce bytů na území města obydlených. Kritici namítají, že jde o nehospodárné nakládání s obecními penězi.",
@@ -443,7 +445,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-55",
+      "id": "komunalni-2022-554782-q-55",
       "name": "Sociální pomoc",
       "title": "Rodiny v bytové nouzi mají mít možnost získat od města bezúročnou půjčku na kauci.",
       "gist": "",
@@ -451,7 +453,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-56",
+      "id": "komunalni-2022-554782-q-56",
       "name": "Sociální pomoc",
       "title": "Souhlasím, aby Pražané s postižením měli komplexní pobytovou péči v Praze.",
       "gist": "Praha provozovala svá ústavní zařízení daleko za svými hranicemi. Klienti by podle svého přání měli mít možnost zůstat v Praze nebo v okolí. Síť komunitních služeb má pro Pražany zůstat přímo na území města.",
@@ -459,7 +461,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-57",
+      "id": "komunalni-2022-554782-q-57",
       "name": "Sociální pomoc",
       "title": "Praha má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -467,7 +469,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-58",
+      "id": "komunalni-2022-554782-q-58",
       "name": "Vzdělávání - gymnázia",
       "title": "Praha by měla navýšit kapacitu čtyřletých gymnázií.",
       "gist": "",
@@ -475,7 +477,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-59",
+      "id": "komunalni-2022-554782-q-59",
       "name": "Vzdělávání - střední školy",
       "title": "Praha by měla podporovat vznik nových gymnaziálních tříd v rámci jiných středních škol.",
       "gist": "",
@@ -483,7 +485,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-60",
+      "id": "komunalni-2022-554782-q-60",
       "name": "Více peněz pro Prahu",
       "title": "Praha by měla od státu dostávat víc peněz.",
       "gist": "",
@@ -491,7 +493,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-61",
+      "id": "komunalni-2022-554782-q-61",
       "name": "Obavy z gentrifikace",
       "title": "V okolí Vltavské filharmonie by měla Praha zachovat dostupné bydlení.",
       "gist": "Zastánci poukazují, že s větší atraktivitou oblasti narostou ceny nemovitostí i nájmů a že dojde k odlivu původních obyvatel.",
@@ -499,7 +501,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554782-question-62",
+      "id": "komunalni-2022-554782-q-62",
       "name": "Tramvaje na Václavském náměstí",
       "title": "Souhlasím, aby se na Václavské náměstí vrátily tramvaje.",
       "gist": "",
@@ -509,16 +511,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-554782-candidate-540309",
+      "id": "komunalni-2022-554782-c-540309",
       "name": "Svobodní",
       "type": "party",
       "description": "Svobodní - DESCRIPTION",
+      "img_url": "svobodní",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-540309-party",
+          "id": "komunalni-2022-554782-c-540309-p",
           "name": "Svobodní",
           "description": "Svobodní - DESCRIPTION",
           "contacts": {
@@ -529,10 +532,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-254716",
+      "id": "komunalni-2022-554782-c-254716",
       "name": "PRAHA NÁŠ DOMOV",
       "type": "party",
       "description": "PRAHA NÁŠ DOMOV - DESCRIPTION",
+      "img_url": "rozum-suver-dom",
       "contacts": {
         "web": [
           {
@@ -544,7 +548,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-254716-party",
+          "id": "komunalni-2022-554782-c-254716-p",
           "name": "PRAHA NÁŠ DOMOV",
           "description": "PRAHA NÁŠ DOMOV - DESCRIPTION",
           "contacts": {
@@ -561,10 +565,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-856015",
+      "id": "komunalni-2022-554782-c-856015",
       "name": "Praha bez chaosu",
       "type": "party",
       "description": "Praha bez chaosu - DESCRIPTION",
+      "img_url": "p bez chaosu-nk",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/pbch.cz",
@@ -572,7 +577,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-856015-party",
+          "id": "komunalni-2022-554782-c-856015-p",
           "name": "Praha bez chaosu",
           "description": "Praha bez chaosu - DESCRIPTION",
           "contacts": {
@@ -585,10 +590,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-550372",
+      "id": "komunalni-2022-554782-c-550372",
       "name": "PRAHA SOBĚ",
       "type": "party",
       "description": "PRAHA SOBĚ - DESCRIPTION",
+      "img_url": "praha sobě-nk",
       "contacts": {
         "web": [
           {
@@ -610,7 +616,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-550372-party",
+          "id": "komunalni-2022-554782-c-550372-p",
           "name": "PRAHA SOBĚ",
           "description": "PRAHA SOBĚ - DESCRIPTION",
           "contacts": {
@@ -637,10 +643,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-917016",
+      "id": "komunalni-2022-554782-c-917016",
       "name": "LEPŠÍ PRAHA PRO PRAŽANY – snížení daně z nemovitých věcí o 50%, městská hromadná doprava zdarma, internet zdarma…",
       "type": "party",
       "description": "LEPŠÍ PRAHA PRO PRAŽANY – snížení daně z nemovitých věcí o 50%, městská hromadná doprava zdarma, internet zdarma… - DESCRIPTION",
+      "img_url": "nd-ans",
       "contacts": {
         "web": [
           {
@@ -652,7 +659,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-917016-party",
+          "id": "komunalni-2022-554782-c-917016-p",
           "name": "LEPŠÍ PRAHA PRO PRAŽANY – snížení daně z nemovitých věcí o 50%, městská hromadná doprava zdarma, internet zdarma…",
           "description": "LEPŠÍ PRAHA PRO PRAŽANY – snížení daně z nemovitých věcí o 50%, městská hromadná doprava zdarma, internet zdarma… - DESCRIPTION",
           "contacts": {
@@ -669,10 +676,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-528817",
+      "id": "komunalni-2022-554782-c-528817",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
       "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "img_url": "stan",
       "contacts": {
         "web": [
           {
@@ -686,7 +694,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-528817-party",
+          "id": "komunalni-2022-554782-c-528817-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
           "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
           "contacts": {
@@ -705,16 +713,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-684523",
+      "id": "komunalni-2022-554782-c-684523",
       "name": "Volte Pravý Blok - stranu za ODVOLATELNOST politiků a státních úředníků PŘÍMO OBČANY",
       "type": "party",
       "description": "Volte Pravý Blok - stranu za ODVOLATELNOST politiků a státních úředníků PŘÍMO OBČANY - DESCRIPTION",
+      "img_url": "pb",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-684523-party",
+          "id": "komunalni-2022-554782-c-684523-p",
           "name": "Volte Pravý Blok - stranu za ODVOLATELNOST politiků a státních úředníků PŘÍMO OBČANY",
           "description": "Volte Pravý Blok - stranu za ODVOLATELNOST politiků a státních úředníků PŘÍMO OBČANY - DESCRIPTION",
           "contacts": {
@@ -725,10 +734,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-738486",
+      "id": "komunalni-2022-554782-c-738486",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": [
           {
@@ -745,7 +755,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-738486-party",
+          "id": "komunalni-2022-554782-c-738486-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -767,10 +777,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-401009",
+      "id": "komunalni-2022-554782-c-401009",
       "name": "Motoristé sobě",
       "type": "party",
       "description": "Motoristé sobě - DESCRIPTION",
+      "img_url": "auto",
       "contacts": {
         "web": [
           {
@@ -786,7 +797,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-401009-party",
+          "id": "komunalni-2022-554782-c-401009-p",
           "name": "Motoristé sobě",
           "description": "Motoristé sobě - DESCRIPTION",
           "contacts": {
@@ -807,10 +818,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-305273",
+      "id": "komunalni-2022-554782-c-305273",
       "name": "Přísaha s Patrioty",
       "type": "party",
       "description": "Přísaha s Patrioty - DESCRIPTION",
+      "img_url": "patrčr-přísaha",
       "contacts": {
         "web": [
           {
@@ -822,7 +834,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-305273-party",
+          "id": "komunalni-2022-554782-c-305273-p",
           "name": "Přísaha s Patrioty",
           "description": "Přísaha s Patrioty - DESCRIPTION",
           "contacts": {
@@ -839,16 +851,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-532713",
+      "id": "komunalni-2022-554782-c-532713",
       "name": "Za bezpečné ulice v Praze",
       "type": "party",
       "description": "Za bezpečné ulice v Praze - DESCRIPTION",
+      "img_url": "dsss-bez-ul",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-532713-party",
+          "id": "komunalni-2022-554782-c-532713-p",
           "name": "Za bezpečné ulice v Praze",
           "description": "Za bezpečné ulice v Praze - DESCRIPTION",
           "contacts": {
@@ -859,16 +872,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-476009",
+      "id": "komunalni-2022-554782-c-476009",
       "name": "Urza.cz: Nechceme vaše hlasy; ke svobodě se nelze provolit... Máme jinou vizi. Jdeme jinou cestou.",
       "type": "party",
       "description": "Urza.cz: Nechceme vaše hlasy; ke svobodě se nelze provolit... Máme jinou vizi. Jdeme jinou cestou. - DESCRIPTION",
+      "img_url": "nevolte urza.cz",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-476009-party",
+          "id": "komunalni-2022-554782-c-476009-p",
           "name": "Urza.cz: Nechceme vaše hlasy; ke svobodě se nelze provolit... Máme jinou vizi. Jdeme jinou cestou.",
           "description": "Urza.cz: Nechceme vaše hlasy; ke svobodě se nelze provolit... Máme jinou vizi. Jdeme jinou cestou. - DESCRIPTION",
           "contacts": {
@@ -879,10 +893,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-595054",
+      "id": "komunalni-2022-554782-c-595054",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": [
           {
@@ -894,7 +909,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-595054-party",
+          "id": "komunalni-2022-554782-c-595054-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -911,10 +926,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-304346",
+      "id": "komunalni-2022-554782-c-304346",
       "name": "SPOLU pro Prahu (ODS, TOP 09, KDU-ČSL)",
       "type": "party",
       "description": "SPOLU pro Prahu (ODS, TOP 09, KDU-ČSL) - DESCRIPTION",
+      "img_url": "kdu-ods-top 09",
       "contacts": {
         "web": [
           {
@@ -932,7 +948,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-304346-party",
+          "id": "komunalni-2022-554782-c-304346-p",
           "name": "SPOLU pro Prahu (ODS, TOP 09, KDU-ČSL)",
           "description": "SPOLU pro Prahu (ODS, TOP 09, KDU-ČSL) - DESCRIPTION",
           "contacts": {
@@ -955,10 +971,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-834158",
+      "id": "komunalni-2022-554782-c-834158",
       "name": "Solidarita – koalice ČSSD, Zelených, Budoucnosti a Idealistů",
       "type": "party",
       "description": "Solidarita – koalice ČSSD, Zelených, Budoucnosti a Idealistů - DESCRIPTION",
+      "img_url": "ze-čssd-bud-ide",
       "contacts": {
         "web": [
           {
@@ -980,7 +997,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-834158-party",
+          "id": "komunalni-2022-554782-c-834158-p",
           "name": "Solidarita – koalice ČSSD, Zelených, Budoucnosti a Idealistů",
           "description": "Solidarita – koalice ČSSD, Zelených, Budoucnosti a Idealistů - DESCRIPTION",
           "contacts": {
@@ -1007,16 +1024,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-514272",
+      "id": "komunalni-2022-554782-c-514272",
       "name": "SPD, Trikolora, Hnutí PES a nezávislí společně pro Prahu",
       "type": "party",
       "description": "SPD, Trikolora, Hnutí PES a nezávislí společně pro Prahu - DESCRIPTION",
+      "img_url": "spd-trik-pes-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-514272-party",
+          "id": "komunalni-2022-554782-c-514272-p",
           "name": "SPD, Trikolora, Hnutí PES a nezávislí společně pro Prahu",
           "description": "SPD, Trikolora, Hnutí PES a nezávislí společně pro Prahu - DESCRIPTION",
           "contacts": {
@@ -1027,16 +1045,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-393428",
+      "id": "komunalni-2022-554782-c-393428",
       "name": "Společnost proti developerské výstavbě v Prokopském údolí",
       "type": "party",
       "description": "Společnost proti developerské výstavbě v Prokopském údolí - DESCRIPTION",
+      "img_url": "spdv",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-393428-party",
+          "id": "komunalni-2022-554782-c-393428-p",
           "name": "Společnost proti developerské výstavbě v Prokopském údolí",
           "description": "Společnost proti developerské výstavbě v Prokopském údolí - DESCRIPTION",
           "contacts": {
@@ -1047,10 +1066,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-174835",
+      "id": "komunalni-2022-554782-c-174835",
       "name": "Volt",
       "type": "party",
       "description": "Volt - DESCRIPTION",
+      "img_url": "včr",
       "contacts": {
         "web": [
           {
@@ -1064,7 +1084,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-174835-party",
+          "id": "komunalni-2022-554782-c-174835-p",
           "name": "Volt",
           "description": "Volt - DESCRIPTION",
           "contacts": {
@@ -1083,16 +1103,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-318069",
+      "id": "komunalni-2022-554782-c-318069",
       "name": "DOST",
       "type": "party",
       "description": "DOST - DESCRIPTION",
+      "img_url": "dost",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-318069-party",
+          "id": "komunalni-2022-554782-c-318069-p",
           "name": "DOST",
           "description": "DOST - DESCRIPTION",
           "contacts": {
@@ -1103,16 +1124,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-464824",
+      "id": "komunalni-2022-554782-c-464824",
       "name": "S.O.S. ZA PRÁVA ZVÍŘAT — Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
       "type": "party",
       "description": "S.O.S. ZA PRÁVA ZVÍŘAT — Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+      "img_url": "dsz-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-464824-party",
+          "id": "komunalni-2022-554782-c-464824-p",
           "name": "S.O.S. ZA PRÁVA ZVÍŘAT — Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
           "description": "S.O.S. ZA PRÁVA ZVÍŘAT — Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
           "contacts": {
@@ -1123,10 +1145,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-662662",
+      "id": "komunalni-2022-554782-c-662662",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/ANOPraha/",
@@ -1134,7 +1157,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-662662-party",
+          "id": "komunalni-2022-554782-c-662662-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -1147,10 +1170,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554782-candidate-568122",
+      "id": "komunalni-2022-554782-c-568122",
       "name": "Strana soukromníků ČR, Koruna Česká (monarch. strana Čech, Moravy a Slezska), Konzervat. strana, Klub angaž. nestraníků",
       "type": "party",
       "description": "Strana soukromníků ČR, Koruna Česká (monarch. strana Čech, Moravy a Slezska), Konzervat. strana, Klub angaž. nestraníků - DESCRIPTION",
+      "img_url": "konskanmonsoukr",
       "contacts": {
         "web": [
           {
@@ -1161,7 +1185,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554782-568122-party",
+          "id": "komunalni-2022-554782-c-568122-p",
           "name": "Strana soukromníků ČR, Koruna Česká (monarch. strana Čech, Moravy a Slezska), Konzervat. strana, Klub angaž. nestraníků",
           "description": "Strana soukromníků ČR, Koruna Česká (monarch. strana Čech, Moravy a Slezska), Konzervat. strana, Klub angaž. nestraníků - DESCRIPTION",
           "contacts": {
@@ -1179,775 +1203,3040 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-554782-answer-476009-1",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-1",
+      "id": "komunalni-2022-554782-a-4",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-1",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-2",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-2",
+      "id": "komunalni-2022-554782-a-7",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-3",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-3"
+      "id": "komunalni-2022-554782-a-10",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-3"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-4",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-4",
+      "id": "komunalni-2022-554782-a-13",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-5",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-5"
+      "id": "komunalni-2022-554782-a-16",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-5"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-6",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-6",
+      "id": "komunalni-2022-554782-a-19",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-6",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-7",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-7",
+      "id": "komunalni-2022-554782-a-22",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-7",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-8",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-8",
+      "id": "komunalni-2022-554782-a-25",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-9",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-9"
+      "id": "komunalni-2022-554782-a-28",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-9"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-10",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-10",
+      "id": "komunalni-2022-554782-a-31",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-11",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-11",
+      "id": "komunalni-2022-554782-a-34",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-12",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-12",
+      "id": "komunalni-2022-554782-a-37",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-12",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-13",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-13"
+      "id": "komunalni-2022-554782-a-40",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-13"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-14",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-14",
+      "id": "komunalni-2022-554782-a-43",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-15",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-15"
+      "id": "komunalni-2022-554782-a-46",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-15"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-16",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-16"
+      "id": "komunalni-2022-554782-a-49",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-16"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-17",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-17"
+      "id": "komunalni-2022-554782-a-52",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-17"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-18",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-18",
+      "id": "komunalni-2022-554782-a-55",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-18",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-19",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-19",
+      "id": "komunalni-2022-554782-a-58",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-20",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-20",
+      "id": "komunalni-2022-554782-a-61",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-20",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-21",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-21",
+      "id": "komunalni-2022-554782-a-64",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-22",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-22",
+      "id": "komunalni-2022-554782-a-67",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-23",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-23",
+      "id": "komunalni-2022-554782-a-70",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-24",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-24",
+      "id": "komunalni-2022-554782-a-73",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-25",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-25"
+      "id": "komunalni-2022-554782-a-76",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-25"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-26",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-26"
+      "id": "komunalni-2022-554782-a-79",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-26"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-27",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-27",
+      "id": "komunalni-2022-554782-a-82",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-28",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-28",
+      "id": "komunalni-2022-554782-a-85",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-29",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-29",
+      "id": "komunalni-2022-554782-a-88",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-29",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-30",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-30",
+      "id": "komunalni-2022-554782-a-91",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-30",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-31",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-31",
+      "id": "komunalni-2022-554782-a-94",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-31",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-32",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-32",
+      "id": "komunalni-2022-554782-a-97",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-33",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-33",
+      "id": "komunalni-2022-554782-a-100",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-33",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-34",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-34",
+      "id": "komunalni-2022-554782-a-103",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-34",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-35",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-35",
+      "id": "komunalni-2022-554782-a-106",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-36",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-36",
+      "id": "komunalni-2022-554782-a-109",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-37",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-37",
+      "id": "komunalni-2022-554782-a-112",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-37",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-38",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-38",
+      "id": "komunalni-2022-554782-a-115",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-39",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-39",
+      "id": "komunalni-2022-554782-a-118",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-39",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-40",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-40",
+      "id": "komunalni-2022-554782-a-121",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-40",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-41",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-41",
+      "id": "komunalni-2022-554782-a-124",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-41",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-42",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-42",
+      "id": "komunalni-2022-554782-a-127",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-42",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-43",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-43",
+      "id": "komunalni-2022-554782-a-130",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-43",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-44",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-44",
+      "id": "komunalni-2022-554782-a-133",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-45",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-45",
+      "id": "komunalni-2022-554782-a-136",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-45",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-46",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-46",
+      "id": "komunalni-2022-554782-a-139",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-47",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-47",
+      "id": "komunalni-2022-554782-a-142",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-47",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-48",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-48",
+      "id": "komunalni-2022-554782-a-145",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-48",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-49",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-49",
+      "id": "komunalni-2022-554782-a-148",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-49",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-50",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-50",
+      "id": "komunalni-2022-554782-a-151",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-50",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-51",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-51",
+      "id": "komunalni-2022-554782-a-154",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-51",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-52",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-52",
+      "id": "komunalni-2022-554782-a-157",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-52",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-53",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-53"
+      "id": "komunalni-2022-554782-a-160",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-53"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-54",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-54",
+      "id": "komunalni-2022-554782-a-163",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-54",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-55",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-55",
+      "id": "komunalni-2022-554782-a-166",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-55",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-56",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-56"
+      "id": "komunalni-2022-554782-a-169",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-56"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-57",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-57",
+      "id": "komunalni-2022-554782-a-172",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-57",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-58",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-58"
+      "id": "komunalni-2022-554782-a-175",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-58"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-59",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-59"
+      "id": "komunalni-2022-554782-a-178",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-59"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-60",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-60",
+      "id": "komunalni-2022-554782-a-181",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-60",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-61",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-61",
+      "id": "komunalni-2022-554782-a-184",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-61",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-476009-62",
-      "candidate_id": "komunalni-2022-554782-candidate-476009",
-      "question_id": "komunalni-2022-554782-question-62"
+      "id": "komunalni-2022-554782-a-187",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-62"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-1",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-1",
+      "id": "komunalni-2022-554782-a-4",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-1",
       "answer": "no",
       "comment": "Každý má právo na důstojné bydlení."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-2",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-2",
+      "id": "komunalni-2022-554782-a-7",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-2",
       "answer": "yes",
       "comment": "Poplatek musí jen takový, aby pokryl náklady na svoz odpadů. Důsledně rozšiřovat počet bezplatných kontejnerů na tříděný odpad."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-3",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-3",
+      "id": "komunalni-2022-554782-a-10",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-3",
       "answer": "no",
       "comment": "Rozhodně ne, neboť nesmíme podléhat zeleným šíleným plánům EU, aby to odnášeli naši občané."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-4",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-4",
+      "id": "komunalni-2022-554782-a-13",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-4",
       "answer": "no",
       "comment": "Nepodléhejte cyklistickým Zeleným Khmerům, kteří svázali Prahu nesmyslnými omezeními."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-5",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-5",
+      "id": "komunalni-2022-554782-a-16",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-6",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-6",
+      "id": "komunalni-2022-554782-a-19",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-6",
       "answer": "yes",
       "comment": "Ale dejme pozor na to, aby kamery nebyly zneužívány ke sledování občanů."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-7",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-7",
+      "id": "komunalni-2022-554782-a-22",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-7",
       "answer": "yes",
       "comment": "Bez výjimek a radikálně!"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-8",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-8",
+      "id": "komunalni-2022-554782-a-25",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-8",
       "answer": "no",
       "comment": "Nezdražovat stávající jízdenky předplatné i jednotlivé. MHD musí být dostupná pro všechny. A hlavně! Udělat pořádek a vyházet všechny parazity a korupčníky z DP hl.m. Prahy.\n\n\n\n\n"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-9",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-9",
+      "id": "komunalni-2022-554782-a-28",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-10",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-10",
+      "id": "komunalni-2022-554782-a-31",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-10",
       "answer": "yes",
       "comment": "Nikdo se přece nestydí za svůj postoj, názor."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-11",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-11",
+      "id": "komunalni-2022-554782-a-34",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-11",
       "answer": "yes",
       "comment": "A tam určitě, neboť tam jde o důležité otázky, které mají mnohdy vliv na chod města na roky dopředu."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-12",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-12",
+      "id": "komunalni-2022-554782-a-37",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-13",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-13",
+      "id": "komunalni-2022-554782-a-40",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-13",
       "answer": "yes",
       "comment": "A bude to ostuda současné vlády ukrajinského místodržícího Fialy ."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-14",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-14",
+      "id": "komunalni-2022-554782-a-43",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-14",
       "answer": "no",
       "comment": "Máme se v Praze čím chlubit, tak to svítí. Ať zhasnou v Senátu a ve Skrakovce."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-15",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-15",
+      "id": "komunalni-2022-554782-a-46",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-15",
       "answer": "no",
       "comment": "Ať přestanou posílat miliardy na Ukrajinu, vystoupíme z energetické burzy, zestátníme ČEZ a bude El. proudu."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-16",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-16",
+      "id": "komunalni-2022-554782-a-49",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-16",
       "answer": "no",
       "comment": "Ať přestanou posílat miliardy na Ukrajinu, vystoupíme z energetické burzy, zestátníme ČEZ a bude El. proudu."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-17",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-17",
+      "id": "komunalni-2022-554782-a-52",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-18",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-18",
+      "id": "komunalni-2022-554782-a-55",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-18",
       "answer": "yes",
       "comment": "Přece se nemusí ničeho bát..."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-19",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-19",
+      "id": "komunalni-2022-554782-a-58",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-19",
       "answer": "yes",
       "comment": "Důsledným tlakem na své zastupitele."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-20",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-20",
+      "id": "komunalni-2022-554782-a-61",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-20",
       "answer": "yes",
       "comment": "Napravit to, co pokazilo začátkem devadesátých let."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-21",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-21",
+      "id": "komunalni-2022-554782-a-64",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-21",
       "answer": "no",
       "comment": "Ať přestanou posílat miliardy na Ukrajinu, vystoupíme z energetické burzy, zestátníme ČEZ a bude El. proudu."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-22",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-22",
+      "id": "komunalni-2022-554782-a-67",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-22",
       "answer": "no",
       "comment": "A když, tak opatrně a citlivě "
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-23",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-23",
+      "id": "komunalni-2022-554782-a-70",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-23",
       "answer": "yes",
       "comment": "Děti nesmí hladovět, ať si obědy odpustí páni senátoři a páni poslanci."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-24",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-24",
+      "id": "komunalni-2022-554782-a-73",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-24",
       "answer": "no",
       "comment": "Stop bolševizaci společnosti, sdílením aut to začíná a znárodněním a gulagy to končí."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-25",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-25",
+      "id": "komunalni-2022-554782-a-76",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-25",
       "answer": "no",
       "comment": "Ale nesmí to být výnosný kšeft jednotlivých městských částí, že tam nakonec nezaparkuje ani ten, kdož tam bydlí."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-26",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-26",
+      "id": "komunalni-2022-554782-a-79",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-27",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-27",
+      "id": "komunalni-2022-554782-a-82",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-27",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-28",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-28",
+      "id": "komunalni-2022-554782-a-85",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-28",
       "answer": "yes",
       "comment": "Kroťme developery!"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-29",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-29",
+      "id": "komunalni-2022-554782-a-88",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-29",
       "answer": "no",
       "comment": "Protože by to byla voda na bolševický mlýn Zeleným Khmerům."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-30",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-30",
+      "id": "komunalni-2022-554782-a-91",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-30",
       "answer": "no",
       "comment": "Bylo by to bolševické, zkrátka bruselské, přesně podle zadání EU ."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-31",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-31",
+      "id": "komunalni-2022-554782-a-94",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-32",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-32",
+      "id": "komunalni-2022-554782-a-97",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-32",
       "answer": "no",
       "comment": "Škoda peněz, dejme je dětem na obědy zdarma."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-33",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-33",
+      "id": "komunalni-2022-554782-a-100",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-34",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-34",
+      "id": "komunalni-2022-554782-a-103",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-34",
       "answer": "no",
       "comment": "Stačí do 15 let zadarmo a potom do 18 let za 1000 ročně "
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-35",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-35",
+      "id": "komunalni-2022-554782-a-106",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-36",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-36",
+      "id": "komunalni-2022-554782-a-109",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-36",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-37",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-37",
+      "id": "komunalni-2022-554782-a-112",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-37",
       "answer": "no",
       "comment": "Genderové šílenství."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-38",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-38",
+      "id": "komunalni-2022-554782-a-115",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-39",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-39",
+      "id": "komunalni-2022-554782-a-118",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-40",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-40",
+      "id": "komunalni-2022-554782-a-121",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-40",
       "answer": "no",
       "comment": "Koloběžky jedině ohrožují chodce. Zrušit a basta!"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-41",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-41",
+      "id": "komunalni-2022-554782-a-124",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-41",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-42",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-42",
+      "id": "komunalni-2022-554782-a-127",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-42",
       "answer": "yes",
       "comment": "Ale musí odvádět více práce, než jen nasazovat botičky..."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-43",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-43",
+      "id": "komunalni-2022-554782-a-130",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-44",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-44",
+      "id": "komunalni-2022-554782-a-133",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-44",
       "answer": "no",
       "comment": "Myslím, že je dost cyklostezek, které zpolykaly zbytečně miliardy."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-45",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-45",
+      "id": "komunalni-2022-554782-a-136",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-46",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-46",
+      "id": "komunalni-2022-554782-a-139",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-46",
       "answer": "yes",
       "comment": "Neboť rezidenti z toho, že platí daně nic moc nemají."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-47",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-47",
+      "id": "komunalni-2022-554782-a-142",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-47",
       "answer": "yes",
       "comment": "Adresně, cíleně a nepodporovat nepřizpůsobivé. "
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-48",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-48",
+      "id": "komunalni-2022-554782-a-145",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-49",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-49",
+      "id": "komunalni-2022-554782-a-148",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-49",
       "answer": "no",
       "comment": "Ale hlavně zastavme levicovou inkluzi."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-50",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-50",
+      "id": "komunalni-2022-554782-a-151",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-50",
       "answer": "no",
       "comment": "Odmítněme Zelené Khmery."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-51",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-51",
+      "id": "komunalni-2022-554782-a-154",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-51",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-52",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-52",
+      "id": "komunalni-2022-554782-a-157",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-52",
       "answer": "yes",
       "comment": "Byty mají být pro občany města a ne pro opilce za Západu, kteří sem jezdí za pivem a holkami."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-53",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-53",
+      "id": "komunalni-2022-554782-a-160",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-53",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-54",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-54",
+      "id": "komunalni-2022-554782-a-163",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-54",
       "answer": "no",
       "comment": "Žádné EU sdílené experimenty."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-55",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-55",
+      "id": "komunalni-2022-554782-a-166",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-55",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-56",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-56",
+      "id": "komunalni-2022-554782-a-169",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-56",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-57",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-57",
+      "id": "komunalni-2022-554782-a-172",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-57",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-58",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-58",
+      "id": "komunalni-2022-554782-a-175",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-58",
       "answer": "no",
       "comment": "Ať rozhodne trh na uplatnění gymnazistů "
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-59",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-59",
+      "id": "komunalni-2022-554782-a-178",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-59",
       "answer": "no",
       "comment": "Ať rozhodne trh na uplatnění gymnazistů."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-60",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-60",
+      "id": "komunalni-2022-554782-a-181",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-60",
       "answer": "no",
       "comment": "Když se nebude krást, lobovat a podplácet, bude peněz dost."
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-61",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-61",
+      "id": "komunalni-2022-554782-a-184",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-61",
       "answer": "yes",
       "comment": "Ale potřebujeme budovu Vltavské filharmonie, když nejsou peníze pro potřebné?"
     },
     {
-      "id": "komunalni-2022-554782-answer-532713-62",
-      "candidate_id": "komunalni-2022-554782-candidate-532713",
-      "question_id": "komunalni-2022-554782-question-62",
+      "id": "komunalni-2022-554782-a-187",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-62",
       "answer": "no",
       "comment": "Václavské náměstí bez tramvají a hlavně s nulovou kriminalitou. Ať se na Václavské náměstí vrátí pořádek a bezpečnost a ne tramvaje."
+    },
+    {
+      "id": "komunalni-2022-554782-a-4",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "no",
+      "comment": "Protože senioři, kteří zde bydlí celý život, by stěhování nepřežili."
+    },
+    {
+      "id": "komunalni-2022-554782-a-7",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-10",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no",
+      "comment": "Znamená to pro seniory smrt"
+    },
+    {
+      "id": "komunalni-2022-554782-a-13",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-16",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes",
+      "comment": "město musí lidi vyrozumět nezpochybnitelným způsobem"
+    },
+    {
+      "id": "komunalni-2022-554782-a-19",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-22",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-7",
+      "answer": "no",
+      "comment": "casina nám nevadí"
+    },
+    {
+      "id": "komunalni-2022-554782-a-25",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-28",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-9"
+    },
+    {
+      "id": "komunalni-2022-554782-a-31",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-34",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-37",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-12",
+      "answer": "no",
+      "comment": "s povinností ohlášení na MÚ."
+    },
+    {
+      "id": "komunalni-2022-554782-a-40",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-13",
+      "answer": "yes",
+      "comment": "nesmí tím ale město řešit nedostatek tepla pro domácnosti"
+    },
+    {
+      "id": "komunalni-2022-554782-a-43",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-14",
+      "answer": "no",
+      "comment": "Jsme proti sankcím, které toto způsobily"
+    },
+    {
+      "id": "komunalni-2022-554782-a-46",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-15",
+      "answer": "no",
+      "comment": "Zvýšila by se tím kriminalita v Praze"
+    },
+    {
+      "id": "komunalni-2022-554782-a-49",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-52",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-55",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-58",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes",
+      "comment": "Ale formou referenda"
+    },
+    {
+      "id": "komunalni-2022-554782-a-61",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-64",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-21",
+      "answer": "no",
+      "comment": "Jsme proti důsledku sankcí"
+    },
+    {
+      "id": "komunalni-2022-554782-a-67",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-70",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "no",
+      "comment": "Nutno řešit individuálně dle sociálního postavení rodiny"
+    },
+    {
+      "id": "komunalni-2022-554782-a-73",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-76",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-25",
+      "answer": "yes",
+      "comment": "Chceme jednu parkovací zónu.  "
+    },
+    {
+      "id": "komunalni-2022-554782-a-79",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-82",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-27",
+      "answer": "yes",
+      "comment": "ale pouze stávajícím nájemcům, a z těchto peněz stavět sociální byty."
+    },
+    {
+      "id": "komunalni-2022-554782-a-85",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-88",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-91",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-94",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-97",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-100",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-103",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-34",
+      "answer": "yes",
+      "comment": "všichni"
+    },
+    {
+      "id": "komunalni-2022-554782-a-106",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-109",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-112",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-115",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-118",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-39"
+    },
+    {
+      "id": "komunalni-2022-554782-a-121",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-124",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-127",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes",
+      "comment": "ale v ulicích a pěšky."
+    },
+    {
+      "id": "komunalni-2022-554782-a-130",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-43"
+    },
+    {
+      "id": "komunalni-2022-554782-a-133",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-136",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-45",
+      "answer": "no",
+      "comment": " pouze mládežnický a neprofesionální"
+    },
+    {
+      "id": "komunalni-2022-554782-a-139",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-142",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-47",
+      "answer": "no",
+      "comment": "jde o věc státu"
+    },
+    {
+      "id": "komunalni-2022-554782-a-145",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-148",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-151",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-154",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-157",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-52",
+      "answer": "no",
+      "comment": "ale kontrolovat zdanění"
+    },
+    {
+      "id": "komunalni-2022-554782-a-160",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-53",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-163",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-166",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-55",
+      "answer": "yes",
+      "comment": "ale zkontrolovat důvěryhodnost pronajímatele i  nájemce"
+    },
+    {
+      "id": "komunalni-2022-554782-a-169",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-172",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-57",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-175",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-178",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-181",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-60",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-184",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-187",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-62",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-4",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-7",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-10",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-13",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-16",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-19",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-6"
+    },
+    {
+      "id": "komunalni-2022-554782-a-22",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-7"
+    },
+    {
+      "id": "komunalni-2022-554782-a-25",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "no",
+      "comment": "Navrhujeme zavést MHD zdarma pouze dočasně, pro krizový rok 2023."
+    },
+    {
+      "id": "komunalni-2022-554782-a-28",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-31",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-34",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-37",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-40",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-43",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-46",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-49",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-52",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-55",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-58",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-61",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-64",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-67",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-70",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "no",
+      "comment": "Dočasně ano."
+    },
+    {
+      "id": "komunalni-2022-554782-a-73",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-76",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-79",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-82",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-85",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-88",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-91",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-94",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-97",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-100",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-103",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-106",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-109",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-112",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-37"
+    },
+    {
+      "id": "komunalni-2022-554782-a-115",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-118",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-121",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-40"
+    },
+    {
+      "id": "komunalni-2022-554782-a-124",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-41"
+    },
+    {
+      "id": "komunalni-2022-554782-a-127",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-130",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-133",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-44"
+    },
+    {
+      "id": "komunalni-2022-554782-a-136",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-139",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-142",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-145",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-148",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-151",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-154",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-157",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-160",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-163",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-166",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-169",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-172",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-57",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-175",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-178",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-181",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-60",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-184",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-61"
+    },
+    {
+      "id": "komunalni-2022-554782-a-187",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-62",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-4",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-7",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-10",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-13",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-16",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-19",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-22",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-25",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-28",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-31",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-10",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-34",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-11",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-37",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-12",
+      "answer": "no",
+      "comment": "Umožnit elektronickou oznamovací povinnost"
+    },
+    {
+      "id": "komunalni-2022-554782-a-40",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-43",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-46",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-49",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-52",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-55",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-58",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-61",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-64",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-67",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-70",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-73",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-76",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-25",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-79",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-82",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-85",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-88",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-91",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-94",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-97",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-100",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-103",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-106",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-109",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-112",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-115",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-118",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-121",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-124",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-127",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-130",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-133",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-136",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-139",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-142",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-47",
+      "answer": "yes",
+      "comment": "Zprůhlednit hospodaření žadatele"
+    },
+    {
+      "id": "komunalni-2022-554782-a-145",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-148",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-151",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-154",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-157",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-160",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-163",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-54",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-166",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-169",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-172",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-57",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-175",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-178",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-181",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-60",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-184",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-187",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-62",
+      "answer": "no",
+      "comment": "Tento počin ničemu nepospěje"
+    },
+    {
+      "id": "komunalni-2022-554782-a-4",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-7",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-10",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-13",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-16",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-19",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-22",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-7",
+      "answer": "no",
+      "comment": "Nejsme pro úplný zákaz, ale jsme pro silnou regulaci. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-25",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "no",
+      "comment": "Podporujeme levnou, dostupnou a kvalitní MHD. MHD zdarma by vedla ke zhoršení kvality a dostupnosti."
+    },
+    {
+      "id": "komunalni-2022-554782-a-28",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-31",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-10",
+      "answer": "yes",
+      "comment": "Stejně jako v Poslanecké sněmovně."
+    },
+    {
+      "id": "komunalni-2022-554782-a-34",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-11",
+      "answer": "no",
+      "comment": "Rada je kolektivní orgán, kde podobně jako při hlasování vlády, záleží na rozhodnutí celku. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-37",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-40",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-43",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-14",
+      "answer": "yes",
+      "comment": "Jedná se o projev solidarity s domácnostmi, které v této době musí šetřit. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-46",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-15",
+      "answer": "no",
+      "comment": "Vedlo by to ke snížení bezpečnosti v nočních hodinách."
+    },
+    {
+      "id": "komunalni-2022-554782-a-49",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-16",
+      "answer": "yes",
+      "comment": "Jedná se o omezení obdobné v jiných evropských metropolích. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-52",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-55",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-58",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes",
+      "comment": "Posiluje to participaci občanů na rozvoji města. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-61",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-64",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-21",
+      "answer": "yes",
+      "comment": "Jedná se opět o projev solidarity. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-67",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-70",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-73",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-76",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-79",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-82",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-85",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-88",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-91",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-94",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-97",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-100",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-103",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-106",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-109",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-112",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-115",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-118",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-121",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-40",
+      "answer": "no",
+      "comment": "Obecně podporujeme mikromobilitu včetně elektrokol. Elektrické koloběžky mohou mít v dopravním mixu své místo, nicméně, jejich parkovaní a umístění ve veřejném prostoru je třeba striktně regulovat.  "
+    },
+    {
+      "id": "komunalni-2022-554782-a-124",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-41",
+      "answer": "yes",
+      "comment": "Prosazujeme vytvoření Rady cizinců (Expat Council), která by byla poradním orgánem Rady hlavního města Prahy."
+    },
+    {
+      "id": "komunalni-2022-554782-a-127",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-130",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-133",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-44",
+      "answer": "yes",
+      "comment": "Chceme vybudovat bezpečnou infrastrukturu pro cyklodopravu, včetně páteřních tras tak, aby se rodiče nebáli posílat své děti na kole."
+    },
+    {
+      "id": "komunalni-2022-554782-a-136",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-139",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-46",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-142",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-145",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-148",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-151",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-154",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-157",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-160",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-163",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-166",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-169",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-172",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-57",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-175",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-178",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-59"
+    },
+    {
+      "id": "komunalni-2022-554782-a-181",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-60",
+      "answer": "yes",
+      "comment": "Motivace obyvatel ke změně trvalého bydliště, aby odpovídalo tomu, kde skutečně bydlí, je součástí programu Voltu. Přineslo by navýšení příjmu do městské pokladny. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-184",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-187",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-62",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-4",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-7",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-10",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-13",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-16",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-19",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-22",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-25",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-28",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-31",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-34",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-37",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-40",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-43",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-46",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-49",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-52",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-55",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-58",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-61",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-64",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-67",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-70",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-73",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-76",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-79",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-82",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-85",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-88",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-91",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-94",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-97",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-100",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-103",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-34",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-106",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-109",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-112",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-115",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-118",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-39",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-121",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-124",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-127",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-130",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-133",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-136",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-139",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-142",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-145",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-148",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-151",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-154",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-157",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-160",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-53",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-163",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-54",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-166",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-169",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-172",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-175",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-178",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-181",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-60",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-184",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-187",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-62",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-4",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "no",
+      "comment": "Bydlení je pro všechny, nejen pro bohaté."
+    },
+    {
+      "id": "komunalni-2022-554782-a-7",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-10",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-13",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-4",
+      "answer": "yes",
+      "comment": "V obytných lokalitách."
+    },
+    {
+      "id": "komunalni-2022-554782-a-16",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes",
+      "comment": "V součinnosti s městskými firmami, jako je dopravní podnik apod."
+    },
+    {
+      "id": "komunalni-2022-554782-a-19",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-22",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-25",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-28",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-31",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-34",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-37",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-40",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-13",
+      "answer": "yes",
+      "comment": "Jde o nouzové řešení. Prioritou je, aby lidé bydleli ve vytopeném bytě."
+    },
+    {
+      "id": "komunalni-2022-554782-a-43",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-46",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-15",
+      "answer": "no",
+      "comment": "V místech s nízkou frekvencí obyvatel zajistit chytré osvětlení reagující na pohyb."
+    },
+    {
+      "id": "komunalni-2022-554782-a-49",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-16",
+      "answer": "yes",
+      "comment": "V administrativních budovách ano, ale ne ve školách a zdravotnických a sociálních zařízeních."
+    },
+    {
+      "id": "komunalni-2022-554782-a-52",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-55",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-58",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-61",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-64",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-67",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-70",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-73",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-76",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-25",
+      "answer": "yes",
+      "comment": "Jsme pro jednotnou parkovací zónu na celém území Prahy."
+    },
+    {
+      "id": "komunalni-2022-554782-a-79",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-82",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-85",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-88",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-91",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-94",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-97",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-100",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-103",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-34",
+      "answer": "yes",
+      "comment": "Jsme pro bezplatnou MHD. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-106",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-109",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-112",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-115",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-38"
+    },
+    {
+      "id": "komunalni-2022-554782-a-118",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-121",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-124",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-41"
+    },
+    {
+      "id": "komunalni-2022-554782-a-127",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-130",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-133",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-44",
+      "answer": "yes",
+      "comment": "Cyklostezky by měly být oddělené od silniční dopravy."
+    },
+    {
+      "id": "komunalni-2022-554782-a-136",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-45"
+    },
+    {
+      "id": "komunalni-2022-554782-a-139",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-46",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-142",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-145",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-148",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-49",
+      "comment": " Ne inkluzi za každou cenu, ale podle potřeb dítěte a možností dané školy. Podporuji speciální školství."
+    },
+    {
+      "id": "komunalni-2022-554782-a-151",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-50",
+      "comment": "Obecně jsem pro zklidnění dopravy v centru, ale pokud nejsou dobudovány vnější a městský okruh, je to těžko řešitelné."
+    },
+    {
+      "id": "komunalni-2022-554782-a-154",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-51",
+      "comment": "Obecně jsem pro zklidnění dopravy v centru, ale pokud nejsou dobudovány vnější a městský okruh, je to těžko řešitelné."
+    },
+    {
+      "id": "komunalni-2022-554782-a-157",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-160",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-163",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-166",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-169",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-172",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-57",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-175",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-178",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-181",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-60",
+      "answer": "yes",
+      "comment": "Především na dopravní stavby (metro a městský okruh)."
+    },
+    {
+      "id": "komunalni-2022-554782-a-184",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-187",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-62",
+      "answer": "no"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/554791.json
+++ b/data/kalkulacka/komunalni-2022/554791.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-554791",
   "name": "Plzeň",
-  "description": "Plzeň - DESCRIPTION",
+  "description": "Plzeň",
   "district_code": "554791",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-554791-question-1",
+      "id": "komunalni-2022-554791-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-2",
+      "id": "komunalni-2022-554791-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-3",
+      "id": "komunalni-2022-554791-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-4",
+      "id": "komunalni-2022-554791-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-5",
+      "id": "komunalni-2022-554791-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-6",
+      "id": "komunalni-2022-554791-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-7",
+      "id": "komunalni-2022-554791-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-8",
+      "id": "komunalni-2022-554791-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-9",
+      "id": "komunalni-2022-554791-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-10",
+      "id": "komunalni-2022-554791-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-11",
+      "id": "komunalni-2022-554791-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-12",
+      "id": "komunalni-2022-554791-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-13",
+      "id": "komunalni-2022-554791-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-14",
+      "id": "komunalni-2022-554791-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-15",
+      "id": "komunalni-2022-554791-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-16",
+      "id": "komunalni-2022-554791-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-17",
+      "id": "komunalni-2022-554791-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-18",
+      "id": "komunalni-2022-554791-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-19",
+      "id": "komunalni-2022-554791-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-20",
+      "id": "komunalni-2022-554791-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-21",
+      "id": "komunalni-2022-554791-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-22",
+      "id": "komunalni-2022-554791-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-23",
+      "id": "komunalni-2022-554791-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-24",
+      "id": "komunalni-2022-554791-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-25",
+      "id": "komunalni-2022-554791-q-25",
       "name": "Jedna parkovací zóna pro celé město",
       "title": "Město má umožňovat rezidentům za jeden roční paušální poplatek parkovat kdekoli na svém území.",
       "gist": "Ve městě by existovala jen jedna rezidenční parkovací zóna, nedělená podle oblastí či městských částí. Kritikům více zón vadí, že předplatné rezidentům parkovací místo automaticky nezaručí. Podle nich by jedna zóna pomohla parkovat i v jiném bloku nebo ulici, jež například spadají do vedlejší městské části.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-26",
+      "id": "komunalni-2022-554791-q-26",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-27",
+      "id": "komunalni-2022-554791-q-27",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-28",
+      "id": "komunalni-2022-554791-q-28",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-29",
+      "id": "komunalni-2022-554791-q-29",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-30",
+      "id": "komunalni-2022-554791-q-30",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-31",
+      "id": "komunalni-2022-554791-q-31",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-32",
+      "id": "komunalni-2022-554791-q-32",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-33",
+      "id": "komunalni-2022-554791-q-33",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-34",
+      "id": "komunalni-2022-554791-q-34",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-35",
+      "id": "komunalni-2022-554791-q-35",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-36",
+      "id": "komunalni-2022-554791-q-36",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-37",
+      "id": "komunalni-2022-554791-q-37",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-38",
+      "id": "komunalni-2022-554791-q-38",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-39",
+      "id": "komunalni-2022-554791-q-39",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-40",
+      "id": "komunalni-2022-554791-q-40",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-41",
+      "id": "komunalni-2022-554791-q-41",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-42",
+      "id": "komunalni-2022-554791-q-42",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-43",
+      "id": "komunalni-2022-554791-q-43",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-44",
+      "id": "komunalni-2022-554791-q-44",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-45",
+      "id": "komunalni-2022-554791-q-45",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-46",
+      "id": "komunalni-2022-554791-q-46",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-47",
+      "id": "komunalni-2022-554791-q-47",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-48",
+      "id": "komunalni-2022-554791-q-48",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -395,7 +397,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-49",
+      "id": "komunalni-2022-554791-q-49",
       "name": "Bydlení především",
       "title": "Podporuji, aby Plzeň pokračovala v projektu Housing First.",
       "gist": "Projekty Housing First zajišťují stabilní bydlení pro nejohroženější skupinu obyvatel. V Česku díky nim získalo bezpečný domov a podporu sociálních pracovníků více než 700 lidí, z toho 320 dětí. Do projektu se zapojují i další česká i světová města; např. ve Vídni si bydlení udrželo 98 % domácností. Pilotní Brno i přes úspěch i ocenění od projektu postupně ustoupilo. Vedení města argumentovalo vysokými náklady, zastánci projektu ale poukazovali, že je většina výdajů hrazená z fondů EU.",
@@ -403,7 +405,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-50",
+      "id": "komunalni-2022-554791-q-50",
       "name": "Wi-Fi v MHD",
       "title": "Podporuji, aby byla ve všech vozidlech plzeňské MHD připojení Wi-Fi.",
       "gist": "Wi-Fi lze zajistit s participací třetích stran pomocí jednoduchého reklamního prokliku. Tím by se významně snížily náklady na vybudování a provoz tohoto systému a veřejný rozpočet by nebyl příliš zatížen.",
@@ -411,7 +413,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-51",
+      "id": "komunalni-2022-554791-q-51",
       "name": "Borská přehrada",
       "title": "Podporuji, aby plzeňská vodní nádrž České údolí sloužila jako rekreační a relaxační plocha.",
       "gist": "Borská přehrada má projít v nejbližších letech revitalizací. Kvůli špatné kvalitě vody není téměř využívána. Záměrem projektu je vystavět oddělovací hráz v dolní části nádrže a  vylepšit jakost vody tak, aby se na místě mohli lidé koupat, provozovat tam vodní sporty a podobně. Kritici poukazují na vysoké náklady v odhadu 272 milionů korun.",
@@ -419,7 +421,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-52",
+      "id": "komunalni-2022-554791-q-52",
       "name": "Demontáž laviček",
       "title": "Souhlasím s tím, aby město demontovalo lavičky obsazované lidmi bez domova.",
       "gist": "",
@@ -427,7 +429,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554791-question-53",
+      "id": "komunalni-2022-554791-q-53",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -437,10 +439,11 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-554791-candidate-952782",
+      "id": "komunalni-2022-554791-c-952782",
       "name": "PRO PLZEŇ",
       "type": "party",
       "description": "PRO PLZEŇ - DESCRIPTION",
+      "img_url": "pro plzeň",
       "contacts": {
         "web": [
           {
@@ -456,7 +459,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554791-952782-party",
+          "id": "komunalni-2022-554791-c-952782-p",
           "name": "PRO PLZEŇ",
           "description": "PRO PLZEŇ - DESCRIPTION",
           "contacts": {
@@ -477,16 +480,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554791-candidate-524664",
+      "id": "komunalni-2022-554791-c-524664",
       "name": "SPOLU – ODS, KDU-ČSL, TOP 09",
       "type": "party",
       "description": "SPOLU – ODS, KDU-ČSL, TOP 09 - DESCRIPTION",
+      "img_url": "kdu-ods-top 09",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554791-524664-party",
+          "id": "komunalni-2022-554791-c-524664-p",
           "name": "SPOLU – ODS, KDU-ČSL, TOP 09",
           "description": "SPOLU – ODS, KDU-ČSL, TOP 09 - DESCRIPTION",
           "contacts": {
@@ -497,16 +501,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554791-candidate-314551",
+      "id": "komunalni-2022-554791-c-314551",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554791-314551-party",
+          "id": "komunalni-2022-554791-c-314551-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -517,10 +522,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554791-candidate-995503",
+      "id": "komunalni-2022-554791-c-995503",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
       "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "img_url": "stan",
       "contacts": {
         "web": [
           {
@@ -536,7 +542,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554791-995503-party",
+          "id": "komunalni-2022-554791-c-995503-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
           "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
           "contacts": {
@@ -557,16 +563,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554791-candidate-400852",
+      "id": "komunalni-2022-554791-c-400852",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554791-400852-party",
+          "id": "komunalni-2022-554791-c-400852-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -577,16 +584,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554791-candidate-286601",
+      "id": "komunalni-2022-554791-c-286601",
       "name": "Koruna Česká (monarchistická strana Čech, Moravy a Slezska)",
       "type": "party",
       "description": "Koruna Česká (monarchistická strana Čech, Moravy a Slezska) - DESCRIPTION",
+      "img_url": "monarchiste.cz",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554791-286601-party",
+          "id": "komunalni-2022-554791-c-286601-p",
           "name": "Koruna Česká (monarchistická strana Čech, Moravy a Slezska)",
           "description": "Koruna Česká (monarchistická strana Čech, Moravy a Slezska) - DESCRIPTION",
           "contacts": {
@@ -597,16 +605,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554791-candidate-893550",
+      "id": "komunalni-2022-554791-c-893550",
       "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
       "type": "party",
       "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+      "img_url": "dsz-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554791-893550-party",
+          "id": "komunalni-2022-554791-c-893550-p",
           "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
           "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
           "contacts": {
@@ -617,16 +626,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554791-candidate-133857",
+      "id": "komunalni-2022-554791-c-133857",
       "name": "ČESKÁ PLZEŇ A BEZPEČNÉ ULICE",
       "type": "party",
       "description": "ČESKÁ PLZEŇ A BEZPEČNÉ ULICE - DESCRIPTION",
+      "img_url": "dsss-bez-ul",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554791-133857-party",
+          "id": "komunalni-2022-554791-c-133857-p",
           "name": "ČESKÁ PLZEŇ A BEZPEČNÉ ULICE",
           "description": "ČESKÁ PLZEŇ A BEZPEČNÉ ULICE - DESCRIPTION",
           "contacts": {
@@ -637,16 +647,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554791-candidate-591389",
+      "id": "komunalni-2022-554791-c-591389",
       "name": "Právo Respekt Odbornost",
       "type": "party",
       "description": "Právo Respekt Odbornost - DESCRIPTION",
+      "img_url": "pro 2022",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554791-591389-party",
+          "id": "komunalni-2022-554791-c-591389-p",
           "name": "Právo Respekt Odbornost",
           "description": "Právo Respekt Odbornost - DESCRIPTION",
           "contacts": {
@@ -657,16 +668,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554791-candidate-455134",
+      "id": "komunalni-2022-554791-c-455134",
       "name": "ANO 2011 a nezávislí",
       "type": "party",
       "description": "ANO 2011 a nezávislí - DESCRIPTION",
+      "img_url": "ano-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554791-455134-party",
+          "id": "komunalni-2022-554791-c-455134-p",
           "name": "ANO 2011 a nezávislí",
           "description": "ANO 2011 a nezávislí - DESCRIPTION",
           "contacts": {
@@ -677,10 +689,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554791-candidate-187608",
+      "id": "komunalni-2022-554791-c-187608",
       "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
       "type": "party",
       "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
+      "img_url": "přísaha",
       "contacts": {
         "web": [
           {
@@ -695,7 +708,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554791-187608-party",
+          "id": "komunalni-2022-554791-c-187608-p",
           "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
           "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
           "contacts": {
@@ -715,10 +728,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554791-candidate-733929",
+      "id": "komunalni-2022-554791-c-733929",
       "name": "Plzeň v srdci - ČSSD a nezávislí kandidáti",
       "type": "party",
       "description": "Plzeň v srdci - ČSSD a nezávislí kandidáti - DESCRIPTION",
+      "img_url": "čssd-nk",
       "contacts": {
         "web": [
           {
@@ -729,7 +743,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554791-733929-party",
+          "id": "komunalni-2022-554791-c-733929-p",
           "name": "Plzeň v srdci - ČSSD a nezávislí kandidáti",
           "description": "Plzeň v srdci - ČSSD a nezávislí kandidáti - DESCRIPTION",
           "contacts": {
@@ -745,16 +759,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554791-candidate-657721",
+      "id": "komunalni-2022-554791-c-657721",
       "name": "Ta Pravá Plzeň",
       "type": "party",
       "description": "Ta Pravá Plzeň - DESCRIPTION",
+      "img_url": "soukromníci-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554791-657721-party",
+          "id": "komunalni-2022-554791-c-657721-p",
           "name": "Ta Pravá Plzeň",
           "description": "Ta Pravá Plzeň - DESCRIPTION",
           "contacts": {
@@ -765,16 +780,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554791-candidate-809330",
+      "id": "komunalni-2022-554791-c-809330",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554791-809330-party",
+          "id": "komunalni-2022-554791-c-809330-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -787,1408 +803,1731 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-554791-answer-733929-1",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-1",
+      "id": "komunalni-2022-554791-a-4",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-1",
       "answer": "no",
       "comment": "Plzeň patří všem Plzeňákům"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-2",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-2",
+      "id": "komunalni-2022-554791-a-7",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-2",
       "answer": "yes",
       "comment": "nicméně by mělo přispět jedním svozem měsíčně zdarma navíc!"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-3",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-3",
+      "id": "komunalni-2022-554791-a-10",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-3",
       "answer": "no",
       "comment": "Plzeňská teplárenská má teplo z uhlí, Biomasy a spalovny. Není to potřeba!"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-4",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-4",
+      "id": "komunalni-2022-554791-a-13",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-5",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-5",
+      "id": "komunalni-2022-554791-a-16",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-6",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-6",
+      "id": "komunalni-2022-554791-a-19",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-6",
       "answer": "yes",
       "comment": "v pečlivě vybraných lokalitách"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-7",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-7",
+      "id": "komunalni-2022-554791-a-22",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-7",
       "comment": "Město hazard významně omezilo, ale úplný zákaz ho přesune mimo kontrolu."
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-8",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-8",
+      "id": "komunalni-2022-554791-a-25",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-8",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-9",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-9",
+      "id": "komunalni-2022-554791-a-28",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-10",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-10",
+      "id": "komunalni-2022-554791-a-31",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-11",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-11"
+      "id": "komunalni-2022-554791-a-34",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-11"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-12",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-12",
+      "id": "komunalni-2022-554791-a-37",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-12",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-13",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-13",
+      "id": "komunalni-2022-554791-a-40",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-13",
       "answer": "yes",
       "comment": "Pro ty co dodržují základní pravidla a stojí o pomoc."
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-14",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-14",
+      "id": "komunalni-2022-554791-a-43",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-15",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-15",
+      "id": "komunalni-2022-554791-a-46",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-15",
       "answer": "no",
       "comment": "Lze to řešit do budoucna solárním napájením, ale město navýšení plateb unese."
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-16",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-16",
+      "id": "komunalni-2022-554791-a-49",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-16",
       "comment": "není to nutné, protože netopíme v Plzni plynem!"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-17",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-17",
+      "id": "komunalni-2022-554791-a-52",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-18",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-18",
+      "id": "komunalni-2022-554791-a-55",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-19",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-19",
+      "id": "komunalni-2022-554791-a-58",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-20",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-20",
+      "id": "komunalni-2022-554791-a-61",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-21",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-21",
+      "id": "komunalni-2022-554791-a-64",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-21",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-22",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-22",
+      "id": "komunalni-2022-554791-a-67",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-22",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-23",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-23",
+      "id": "komunalni-2022-554791-a-70",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-23",
       "answer": "yes",
       "comment": "elektromobilů"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-24",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-24",
+      "id": "komunalni-2022-554791-a-73",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-25",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-25",
+      "id": "komunalni-2022-554791-a-76",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-25",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-26",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-26",
+      "id": "komunalni-2022-554791-a-79",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-26",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-27",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-27",
+      "id": "komunalni-2022-554791-a-82",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-28",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-28"
+      "id": "komunalni-2022-554791-a-85",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-28"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-29",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-29",
+      "id": "komunalni-2022-554791-a-88",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-29",
       "answer": "yes",
       "comment": "ale až u většího počtu nemovitostí. opatření by mělo cílit na developery a investiční byty"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-30",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-30",
+      "id": "komunalni-2022-554791-a-91",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-31",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-31",
+      "id": "komunalni-2022-554791-a-94",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-32",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-32",
+      "id": "komunalni-2022-554791-a-97",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-33",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-33",
+      "id": "komunalni-2022-554791-a-100",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-34",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-34",
+      "id": "komunalni-2022-554791-a-103",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-35",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-35",
+      "id": "komunalni-2022-554791-a-106",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-36",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-36",
+      "id": "komunalni-2022-554791-a-109",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-36",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-37",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-37"
+      "id": "komunalni-2022-554791-a-112",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-37"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-38",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-38",
+      "id": "komunalni-2022-554791-a-115",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-39",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-39",
+      "id": "komunalni-2022-554791-a-118",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-39",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-40",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-40",
+      "id": "komunalni-2022-554791-a-121",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-41",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-41",
+      "id": "komunalni-2022-554791-a-124",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-42",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-42",
+      "id": "komunalni-2022-554791-a-127",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-42",
       "answer": "yes",
       "comment": "s rozumem a spíše na nových střechách."
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-43",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-43",
+      "id": "komunalni-2022-554791-a-130",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-44",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-44",
+      "id": "komunalni-2022-554791-a-133",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-44",
       "answer": "no",
       "comment": "Mládež ano."
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-45",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-45",
+      "id": "komunalni-2022-554791-a-136",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-46",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-46",
+      "id": "komunalni-2022-554791-a-139",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-47",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-47",
+      "id": "komunalni-2022-554791-a-142",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-48",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-48"
+      "id": "komunalni-2022-554791-a-145",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-48"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-49",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-49",
+      "id": "komunalni-2022-554791-a-148",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-50",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-50",
+      "id": "komunalni-2022-554791-a-151",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-50",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-51",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-51",
+      "id": "komunalni-2022-554791-a-154",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-51",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-52",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-52",
+      "id": "komunalni-2022-554791-a-157",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-52",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-53",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-53",
+      "id": "komunalni-2022-554791-a-160",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-53",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-733929-54",
-      "candidate_id": "komunalni-2022-554791-candidate-733929",
-      "question_id": "komunalni-2022-554791-question-54"
+      "id": "komunalni-2022-554791-a-163",
+      "candidate_id": "komunalni-2022-554791-c-733929",
+      "question_id": "komunalni-2022-554791-q-54"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-1",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-1",
+      "id": "komunalni-2022-554791-a-4",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-1",
       "answer": "no",
       "comment": "město má rozšiřovat svůj bytový fond"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-2",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-2",
+      "id": "komunalni-2022-554791-a-7",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-3",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-3",
+      "id": "komunalni-2022-554791-a-10",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-4",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-4",
+      "id": "komunalni-2022-554791-a-13",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-4",
       "answer": "yes",
       "comment": "Jsou místa, kde snížení rychlosti dopravy na max 30 km/h zvyšuje plynulost provozu a hlavně zvyšuje bezpečnost. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-5",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-5",
+      "id": "komunalni-2022-554791-a-16",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-5",
       "answer": "yes",
       "comment": "Město by mělo být v propagaci akce Milostivé léto co nejaktivnější. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-6",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-6",
+      "id": "komunalni-2022-554791-a-19",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-6",
       "answer": "yes",
       "comment": "Je to prvek posilující bezpečnost a hlavně prevenci."
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-7",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-7",
+      "id": "komunalni-2022-554791-a-22",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-7",
       "answer": "yes",
       "comment": "Především máme na mysli úplný zákaz takzvaných technických her, tedy herních automatů a videoloterijních terminálů."
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-8",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-8",
+      "id": "komunalni-2022-554791-a-25",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-8",
       "answer": "no",
       "comment": "MHD nebudeme zdražovat. Chceme naopak prosadit zavedení jednotlivých jízdenek v MHD s 50 % slevou pro studenty ve věku 15 – 26 let, pro osoby na mateřské či rodičovské dovolené a pro válečné veterány. Srovnaly by se tak slevy, které už 4 roky platí v Plzeňském kraji s výjimkou města Plzně. Chceme, aby veřejnou dopravu využívalo co nejvíce lidí."
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-9",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-9",
+      "id": "komunalni-2022-554791-a-28",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-9",
       "answer": "yes",
       "comment": "To bereme za naprostou samozřejmost. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-10",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-10",
+      "id": "komunalni-2022-554791-a-31",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-11",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-11",
+      "id": "komunalni-2022-554791-a-34",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-12",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-12",
+      "id": "komunalni-2022-554791-a-37",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-12",
       "answer": "yes",
       "comment": "Výrazně omezíme možnost odpalu ohňostrojů na území města Plzně. Městská vyhláška by měla určit pár konkrétních termínů v roce (Silvestr, Slavnosti svobody), kdy je možno hlasité ohňostroje pořádat, po zbytek roku by měl platit jejich plošný zákaz."
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-13",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-13",
+      "id": "komunalni-2022-554791-a-40",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-13",
       "answer": "yes",
       "comment": "Doufáme, že takto kritická situace nenastane. Město je finančně stabilizované a mělo by mírnit dopady krize na své občany. Nebudeme zvyšovat cenu MHD, ani další poplatky. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-14",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-14",
+      "id": "komunalni-2022-554791-a-43",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-15",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-15",
+      "id": "komunalni-2022-554791-a-46",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-15",
       "answer": "yes",
       "comment": "Chceme postupně vyměňovat osvětlení za úspornější LED lampy, které navíc budou svítit v teplejších odstínech, místo bílého a pro nás nezdravého záření. V nočních hodinách budeme intenzitu svitu snižovat. To povede k lepšímu spánku obyvatel, menšímu světelnému smogu, větší životnosti infrastruktury a hlavně úspoře energií. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-16",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-16",
+      "id": "komunalni-2022-554791-a-49",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-16",
       "answer": "yes",
       "comment": "Pokud situace s energiemi bude natolik kritická, tak je toto řešení nasnadě. Výjimku tvoří samozřejmě sociální zařízení. Město by mělo jít příkladem a být ve svém provozu co neúspornější. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-17",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-17",
+      "id": "komunalni-2022-554791-a-52",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-18",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-18",
+      "id": "komunalni-2022-554791-a-55",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-19",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-19",
+      "id": "komunalni-2022-554791-a-58",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-19",
       "answer": "yes",
       "comment": "Participativní rozpočet pomáhá občany zapojit do veřejného dění a rozhodovat, kam se budou investovat i jejich daně. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-20",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-20",
+      "id": "komunalni-2022-554791-a-61",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-20",
       "answer": "yes",
       "comment": "Pro nás jedna z nejzásadnějších programových otázek. Celá léta v tomto směru Plzeň stagnovala a umožňovala převážně jen developerské projekty. Až v uplynulém roce se výstavba dostupného městského bydlení konečně rozběhla. Město v tom musí pokračovat a tempo ještě zrychlit. Naším cílem je vystavět 1 000 nových obecních bytů. Nikoliv jen pro sociálně nejslabší, ale i pro běžné žadatele. Díky tomu, že město posílí svůj bytový fond, stane se důležitým hráčem na lokálním trhu s byty a může ovlivnit výši komerčního nájemného i cen bytů v Plzni. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-21",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-21",
+      "id": "komunalni-2022-554791-a-64",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-22",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-22",
+      "id": "komunalni-2022-554791-a-67",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-22",
       "answer": "no",
       "comment": "Podporujeme projekt Obědy do škol, do kterého by mělo být zařazeno co nejvíce škol. Obědy zdarma pro děti, jejichž sociální situace je vážná a dlouhodobá. Pomoc má být adresná, ne plošná."
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-23",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-23",
+      "id": "komunalni-2022-554791-a-70",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-23",
       "answer": "yes",
       "comment": "Město by mělo vytvářet podmínky, aby tuto službu mohl poskytovat soukromý subjekt. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-24",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-24",
+      "id": "komunalni-2022-554791-a-73",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-24",
       "answer": "no",
       "comment": "Rozšiřovaní rezidentního parkování je klíčové opatření rozumné parkovací politiky. Nárůst návštěvnické dopravy znesnadňuje parkování místních obyvatel a je potřeba to řešit. Na to je samozřejmě nutné navázat komfortní sytém záchytných parkovišť na okraji Plzně s dobrou návazností na MHD. Sníží se tak potřeba mimoplzeňských zajíždět do centra města autem.\n\nPro některé, kteří v Plzni dlouhodobě žijí a mají stále trvalé bydliště jinde, to může být naopak motivací, aby si změnili trvalý pobyt a městu se tím zvedne roční daňový příděl."
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-25",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-25",
+      "id": "komunalni-2022-554791-a-76",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-26",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-26",
+      "id": "komunalni-2022-554791-a-79",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-26",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-27",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-27",
+      "id": "komunalni-2022-554791-a-82",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-27",
       "answer": "yes",
       "comment": "Pro developery musí začít platit jasná pravidla, kolik a kam mají městu přispívat. Z příspěvku, který investoři městu poskytnou, se mají financovat nové parky, školy nebo městské byty. V nových čtvrtích musí být odpovídající infrastruktura, ciž v současné chvíli neplatí. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-28",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-28",
+      "id": "komunalni-2022-554791-a-85",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-28",
       "answer": "yes",
       "comment": "Vše mát být v rovnováze. Nechceme dělit obyvatele na cyklisty a motoristy. Vše je o kompromisu a vzájemné shodě. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-29",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-29",
+      "id": "komunalni-2022-554791-a-88",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-29",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-30",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-30",
+      "id": "komunalni-2022-554791-a-91",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-30",
       "answer": "yes",
       "comment": "žádný dosud není"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-31",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-31",
+      "id": "komunalni-2022-554791-a-94",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-32",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-32",
+      "id": "komunalni-2022-554791-a-97",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-33",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-33",
+      "id": "komunalni-2022-554791-a-100",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-33",
       "answer": "no",
       "comment": "Chceme prosadit zavedení jednotlivých jízdenek v MHD s 50 % slevou pro studenty ve věku 15 – 26 let, pro osoby na mateřské či rodičovské dovolené a pro válečné veterány. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-34",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-34",
+      "id": "komunalni-2022-554791-a-103",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-34",
       "answer": "yes",
       "comment": "Město může být koordinátorem, vytipovávat vhodné lokality a zároveň jít příkladem u svého majetku. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-35",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-35",
+      "id": "komunalni-2022-554791-a-106",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-36",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-36",
+      "id": "komunalni-2022-554791-a-109",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-36",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-37",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-37",
+      "id": "komunalni-2022-554791-a-112",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-37",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-38",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-38",
+      "id": "komunalni-2022-554791-a-115",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-39",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-39",
+      "id": "komunalni-2022-554791-a-118",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-39",
       "answer": "yes",
       "comment": "S podporou sdílených kola a koloběžek souhlasíme. Nesmí se to ale zvrtnout podobně jako s koloběžkami v Praze. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-40",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-40",
+      "id": "komunalni-2022-554791-a-121",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-41",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-41",
+      "id": "komunalni-2022-554791-a-124",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-42",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-42",
+      "id": "komunalni-2022-554791-a-127",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-43",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-43",
+      "id": "komunalni-2022-554791-a-130",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-43",
       "answer": "yes",
       "comment": "V Plzni bohužel stále nejezdí na kole tolik lidí jako ve srovnatelných zahraničních ani českých městech a chceme to změnit. Naším cílem jsou nové cyklostezky a propojení těch stávajících. Vylepšovat infrastrukturu – cyklostojany, cykloboxy atd. Vytvářet pro cyklisty v dopravě bezpečné koridory a odstraňovat mnohdy nesmyslné překážky, které cyklistům znepříjemňují život. Chceme přehodnotit i současnou službu sdílených kol a modernizovat ji."
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-44",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-44",
+      "id": "komunalni-2022-554791-a-133",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-44",
       "answer": "yes",
       "comment": "S důrazem na mládež."
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-45",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-45",
+      "id": "komunalni-2022-554791-a-136",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-45",
       "answer": "no",
       "comment": "Má zůstat ve stávající výši."
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-46",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-46",
+      "id": "komunalni-2022-554791-a-139",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-46",
       "answer": "yes",
       "comment": "Důležitá je podpora sociální práce a spolupráce s organizacemi, které mají tuto činnost ve svém poslání. Naším cílem je, zaměřit se na prevenci, která je ve výsledku levnější a účinnější. Záchranná síť pro potřebné musí být pevná. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-47",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-47",
+      "id": "komunalni-2022-554791-a-142",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-48",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-48",
+      "id": "komunalni-2022-554791-a-145",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-49",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-49",
+      "id": "komunalni-2022-554791-a-148",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-50",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-50",
+      "id": "komunalni-2022-554791-a-151",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-50",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-51",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-51",
+      "id": "komunalni-2022-554791-a-154",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-51",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-52",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-52",
+      "id": "komunalni-2022-554791-a-157",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-52",
       "answer": "no",
       "comment": "Naopak chceme nevzhledné reklamní lavičky soukromých agentur postupně nahradit kvalitním městským mobiliářem. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-53",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-53",
+      "id": "komunalni-2022-554791-a-160",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-53",
       "answer": "yes",
       "comment": "Míst ve školkách je nedostatek a rodiče mladších dětí nemají šanci své dítě prakticky umístit. Pokud chtějí začít pracovat, třeba na zkrácený úvazek, měli by mít možnost výběru. "
     },
     {
-      "id": "komunalni-2022-554791-answer-995503-54",
-      "candidate_id": "komunalni-2022-554791-candidate-995503",
-      "question_id": "komunalni-2022-554791-question-54",
+      "id": "komunalni-2022-554791-a-163",
+      "candidate_id": "komunalni-2022-554791-c-995503",
+      "question_id": "komunalni-2022-554791-q-54",
       "comment": "Jste skvělý. Díky Michale. ;) "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-1",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-1",
+      "id": "komunalni-2022-554791-a-4",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-1",
       "answer": "no",
       "comment": "Nejsme zastánci cílené separace obyvatel na základě jejich financí. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-2",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-2",
+      "id": "komunalni-2022-554791-a-7",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-2",
       "answer": "yes",
       "comment": "Tvrdit, že tato služba může být zdarma je populistické. Nicméně bylo by vhodné poplatek snížit, a tím ušetřit lidem peníze. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-3",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-3",
+      "id": "komunalni-2022-554791-a-10",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-4",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-4",
+      "id": "komunalni-2022-554791-a-13",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-4",
       "answer": "no",
       "comment": "Tam, kde to dopravní situace vyžaduje, už limit jízdy 30 km/h zpravidla je. Odmítáme jakékoli zbytečné omezování řidičů. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-5",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-5",
+      "id": "komunalni-2022-554791-a-16",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-5",
       "answer": "yes",
       "comment": "Město by mělo maximálně pomoci v šíření důležitých informací. Respektujeme právo na informace všech Plzeňanů. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-6",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-6",
+      "id": "komunalni-2022-554791-a-19",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-6",
       "answer": "yes",
       "comment": "Díky propracovanému kamerovému systému bude možné monitorovat problémové lokality ve městě, předcházet kriminalitě, případně přispět k jejímu objasnění. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-7",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-7",
+      "id": "komunalni-2022-554791-a-22",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-7",
       "answer": "yes",
       "comment": "Jsme pro plošný zákaz všech heren na území města. Výjimku bychom umožnili v případě kurzového sázení, karetních her a loterií. Zákazem hazardu ve městě zvýšíme bezpečnost. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-8",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-8",
+      "id": "komunalni-2022-554791-a-25",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-8",
       "answer": "no",
       "comment": "Lidé, kteří by měli mít dopravu zdarma, ji zdarma již mají (senioři, malé děti). Hromadná doprava zdarma pro všechny rezidenty by byla enormní zátěží pro rozpočet města. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-9",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-9",
+      "id": "komunalni-2022-554791-a-28",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-9",
       "answer": "yes",
       "comment": "Naše město stále nedostatečně reflektuje potřeby lidí s omezenou pohyblivostí. Chceme to napravit. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-10",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-10",
+      "id": "komunalni-2022-554791-a-31",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-10",
       "answer": "yes",
       "comment": "Podporujeme transparentnost. Lidé by měli mít možnost zkontrolovat práci svých zastupitelů."
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-11",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-11",
+      "id": "komunalni-2022-554791-a-34",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-11",
       "answer": "yes",
       "comment": "Podporujeme transparentnost. Lidé by měli mít možnost zkontrolovat práci svých radních. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-12",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-12"
+      "id": "komunalni-2022-554791-a-37",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-12"
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-13",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-13",
+      "id": "komunalni-2022-554791-a-40",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-13",
       "answer": "no",
       "comment": "Město by mělo udělat vše pro to, aby lidé takovou službu vůbec nepotřebovali. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-14",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-14",
+      "id": "komunalni-2022-554791-a-43",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-14",
       "answer": "yes",
       "comment": "V období současné energetické krize by město mělo šetřit na zbytých výdajích. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-15",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-15",
+      "id": "komunalni-2022-554791-a-46",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-15",
       "answer": "no",
       "comment": "Naopak by město mělo rozšířit veřejné osvětlení, jelikož má prokazatelně vliv na vyšší bezpečnost. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-16",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-16",
+      "id": "komunalni-2022-554791-a-49",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-16",
       "answer": "no",
       "comment": "U určitých budov lze vytápění omezit, nesouhlasíme však s omezováním teplot v budovách typu mateřských a základních škol či domovů pro seniory. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-17",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-17",
+      "id": "komunalni-2022-554791-a-52",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-17",
       "answer": "yes",
       "comment": "Nechceme, aby děti začínaly svůj dospělý život s dluhem."
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-18",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-18",
+      "id": "komunalni-2022-554791-a-55",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-18",
       "answer": "yes",
       "comment": "Jsme zastánci transparentnosti, aby lidé mohli kontrolovat tok financí města. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-19",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-19",
+      "id": "komunalni-2022-554791-a-58",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-19",
       "answer": "yes",
       "comment": "Lidé by měli mít možnost zasahovat do lokálních investičních akcí, které se týkají jejich okolí (dětská hřiště, parky, okrasné zahrady, lavičky k sezení atd.)."
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-20",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-20",
+      "id": "komunalni-2022-554791-a-61",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-20",
       "answer": "yes",
       "comment": "Jsme zastánci obdobné cesty, kterou zvolila Vídeň, kde je k dispozici široký bytový fond. Větší počet bytů pomůže řešení bytové krize. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-21",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-21",
+      "id": "komunalni-2022-554791-a-64",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-21",
       "answer": "yes",
       "comment": "V období energetické krize by město mělo omezit zbytné výdaje. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-22",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-22",
+      "id": "komunalni-2022-554791-a-67",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-22",
       "answer": "no",
       "comment": "Jsme pro zlevnění, případně fixaci ceny obědů ve školách."
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-23",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-23",
+      "id": "komunalni-2022-554791-a-70",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-23",
       "answer": "no",
       "comment": "Carsharing je pro řadu lidí užitečnou službou, kterou ve městě vítáme. Nicméně není potřeba jej podporovat z rozpočtu města.  "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-24",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-24",
+      "id": "komunalni-2022-554791-a-73",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-24",
       "answer": "no",
       "comment": "Jsme pro zachování stávajících placených zón. Nicméně je nebudeme rozšiřovat. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-25",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-25",
+      "id": "komunalni-2022-554791-a-76",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-25",
       "answer": "yes",
       "comment": "Řidičům, kteří často parkují v placených zónách, by tato služba ulehčila každodenní život. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-26",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-26",
+      "id": "komunalni-2022-554791-a-79",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-26",
       "answer": "no",
       "comment": "Město by naopak mělo rozšiřovat svůj bytový fond. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-27",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-27",
+      "id": "komunalni-2022-554791-a-82",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-27",
       "answer": "yes",
       "comment": "Developer by se měl podílet na výstavbě základní infrastruktury."
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-28",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-28",
+      "id": "komunalni-2022-554791-a-85",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-28",
       "answer": "no",
       "comment": "Každý Plzeňan se může sám rozhodnout, jaký dopravní prostředek zvolí. Je potřeba rozvíjet funkční infrastrukturu pro všechny druhy dopravy. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-29",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-29",
+      "id": "komunalni-2022-554791-a-88",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-29",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-30",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-30",
+      "id": "komunalni-2022-554791-a-91",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-31",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-31",
+      "id": "komunalni-2022-554791-a-94",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-31",
       "answer": "yes",
       "comment": "Elektromobily jsou stále rozšířenějším dopravním prostředkem, což musí město reflektovat. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-32",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-32",
+      "id": "komunalni-2022-554791-a-97",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-33",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-33",
+      "id": "komunalni-2022-554791-a-100",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-33",
       "answer": "no",
       "comment": "Šlo by o nepřiměřený zásah do rozpočtu města, který si v době krize nemůžeme dovolit. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-34",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-34",
+      "id": "komunalni-2022-554791-a-103",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-34",
       "answer": "yes",
       "comment": "Všeobecně podporujeme energetickou soběstačnost a bezuhlíkové technologie. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-35",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-35",
+      "id": "komunalni-2022-554791-a-106",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-35",
       "answer": "yes",
       "comment": "Chceme, aby měla mládež přístup ke kulturnímu a sportovnímu vyžití bez ohledu na své socioekonomické zázemí. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-36",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-36",
+      "id": "komunalni-2022-554791-a-109",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-36",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-37",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-37",
+      "id": "komunalni-2022-554791-a-112",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-37",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-38",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-38",
+      "id": "komunalni-2022-554791-a-115",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-38",
       "answer": "yes",
       "comment": "Podporujeme energetickou soběstačnost."
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-39",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-39",
+      "id": "komunalni-2022-554791-a-118",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-39",
       "answer": "yes",
       "comment": "Ano, vybudováním širší sítě cyklostezek, které slouží i koloběžkám, či instalací dobíjecích míst.  "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-40",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-40",
+      "id": "komunalni-2022-554791-a-121",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-40",
       "answer": "yes",
       "comment": "Je potřeba, aby město integrovalo do naší společnosti cizince, kteří tu legálně pobývají. Jde o součást zvyšování bezpečnosti v našem městě. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-41",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-41",
+      "id": "komunalni-2022-554791-a-124",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-41",
       "answer": "yes",
       "comment": "Současný personální stav městské policie je velmi nebezpečně podhodnocen. Jsme pro znovuobnovení dvoučlenných městských hlídek a častější dohled nad problémovými lokalitami. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-42",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-42",
+      "id": "komunalni-2022-554791-a-127",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-43",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-43",
+      "id": "komunalni-2022-554791-a-130",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-43",
       "answer": "yes",
       "comment": "Ano, město by mělo nabídnout alternativu k autu a MHD v podobě široké sítě cyklostezek a stojanů na kolo. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-44",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-44",
+      "id": "komunalni-2022-554791-a-133",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-44",
       "answer": "no",
       "comment": "Profesionální sport by si na sebe měl vydělávat sám. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-45",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-45",
+      "id": "komunalni-2022-554791-a-136",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-45",
       "answer": "yes",
       "comment": "Město by mělo ulehčit svým lidem od daňové zátěže. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-46",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-46",
+      "id": "komunalni-2022-554791-a-139",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-46",
       "answer": "no",
       "comment": "Jde o úkol státu. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-47",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-47",
+      "id": "komunalni-2022-554791-a-142",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-47",
       "answer": "yes",
       "comment": "Jako vzor vnímáme Vídeň, která disponuje rozsáhlým bytovým fondem, jenž napomáhá zvýšení kvality života. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-48",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-48",
+      "id": "komunalni-2022-554791-a-145",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-49",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-49",
+      "id": "komunalni-2022-554791-a-148",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-50",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-50",
+      "id": "komunalni-2022-554791-a-151",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-50",
       "answer": "yes",
       "comment": "V dnešní době se jedná o standard."
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-51",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-51",
+      "id": "komunalni-2022-554791-a-154",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-51",
       "answer": "yes",
       "comment": "Tato otázka v současné krizi není na pořadu dne. "
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-52",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-52",
+      "id": "komunalni-2022-554791-a-157",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-52",
       "answer": "no",
       "comment": "Není logické demontovat lavičky."
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-53",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-53",
+      "id": "komunalni-2022-554791-a-160",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-53",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-187608-54",
-      "candidate_id": "komunalni-2022-554791-candidate-187608",
-      "question_id": "komunalni-2022-554791-question-54"
+      "id": "komunalni-2022-554791-a-163",
+      "candidate_id": "komunalni-2022-554791-c-187608",
+      "question_id": "komunalni-2022-554791-q-54"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-1",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-1",
+      "id": "komunalni-2022-554791-a-4",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-1",
       "answer": "no",
       "comment": "Dostupné bydlení bez ohledu na stav účtu."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-2",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-2",
+      "id": "komunalni-2022-554791-a-7",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-2",
       "answer": "yes",
       "comment": "Ale jen symbolický, který nezatíží rozpočet rodiny, peněz mají města dost, jen neplýtvat."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-3",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-3",
+      "id": "komunalni-2022-554791-a-10",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-3",
       "answer": "no",
       "comment": "Nemůžeme kvůli Fialově drahotě ohrozit seniory, odstupme z energetické burzy, zestátněme ČEZ a odmítněme Green Deal a máme energie za normální ceny."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-4",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-4",
+      "id": "komunalni-2022-554791-a-13",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-4",
       "answer": "no",
       "comment": "To jsou přesně požadavky Zelených Khmerů, které nesmyslné, ideologicky omezují automobilovou dopravu."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-5",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-5",
+      "id": "komunalni-2022-554791-a-16",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-6",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-6",
+      "id": "komunalni-2022-554791-a-19",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-6",
       "answer": "yes",
       "comment": "K posílení bezpečnosti a ne ke špehování lidí."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-7",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-7",
+      "id": "komunalni-2022-554791-a-22",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-7",
       "answer": "yes",
       "comment": "Bez výjimek, konec hazardu!"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-8",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-8",
+      "id": "komunalni-2022-554791-a-25",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-8",
       "answer": "no",
       "comment": "Nezdražovat jednotlivé jízdenky a celoroční jízdenku za paušál 1000 Kč."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-9",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-9",
+      "id": "komunalni-2022-554791-a-28",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-10",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-10",
+      "id": "komunalni-2022-554791-a-31",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-10",
       "answer": "yes",
       "comment": "Vždyť každý si musí své hlasování obhájit, neboť přece hlasuje ku prospěchu města a poctivě."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-11",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-11",
+      "id": "komunalni-2022-554791-a-34",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-11",
       "answer": "yes",
       "comment": "Vždyť každý si musí své hlasování obhájit, neboť přece hlasuje ku prospěchu města a poctivě."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-12",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-12",
+      "id": "komunalni-2022-554791-a-37",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-13",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-13",
+      "id": "komunalni-2022-554791-a-40",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-13",
       "answer": "yes",
       "comment": "Nemůžeme kvůli Fialově drahotě ohrozit občany, odstupme z energetické burzy, zestátněme ČEZ a odmítněme Green Deal a máme energie za normální ceny."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-14",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-14",
+      "id": "komunalni-2022-554791-a-43",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-14",
       "answer": "no",
       "comment": "Plzeň se má čím chlubit, tak ať to všichni vidí, přece nebudeme kvůli neschopné vládě SPOLU ve tmě."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-15",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-15",
+      "id": "komunalni-2022-554791-a-46",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-15",
       "answer": "no",
       "comment": "Bezpečnost především, nebudeme kvůli SPOLU vládě  ve tmě "
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-16",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-16",
+      "id": "komunalni-2022-554791-a-49",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-16",
       "answer": "yes",
       "comment": "Ale hledejme úspory na magistrátu a v městských částí. Peníze jsou, jen je najít."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-17",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-17",
+      "id": "komunalni-2022-554791-a-52",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-18",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-18",
+      "id": "komunalni-2022-554791-a-55",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-18",
       "answer": "yes",
       "comment": "Vždyť není co skrývat, že..."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-19",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-19",
+      "id": "komunalni-2022-554791-a-58",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-19",
       "answer": "yes",
       "comment": "A v úzké spolupráci se zastupiteli."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-20",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-20",
+      "id": "komunalni-2022-554791-a-61",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-20",
       "answer": "yes",
       "comment": "Napravit stav bezbřehé privatizace bytového fondu začátkem 90. let."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-21",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-21",
+      "id": "komunalni-2022-554791-a-64",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-21",
       "answer": "no",
       "comment": "Odstupme z energetické burzy, zestátněme ČEZ a odmítněme Green Deal a máme energie za normální ceny."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-22",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-22",
+      "id": "komunalni-2022-554791-a-67",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-22",
       "answer": "yes",
       "comment": "Děti nesmí hladovět, na to peníze být musí, i kdyby to měli zaplatit šíbři a magistrátní lobisté."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-23",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-23",
+      "id": "komunalni-2022-554791-a-70",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-23",
       "answer": "no",
       "comment": "Sdílením aut to začíná, přes sdílené bydlení to pokračuje a gulagy to končí. Odmítáme bolševismus EU "
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-24",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-24",
+      "id": "komunalni-2022-554791-a-73",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-25",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-25",
+      "id": "komunalni-2022-554791-a-76",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-25",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-26",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-26",
+      "id": "komunalni-2022-554791-a-79",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-26",
       "answer": "no",
       "comment": "Bezbřehá privatizace bytového fondu začátkem 90. let se nesmí opakovat."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-27",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-27",
+      "id": "komunalni-2022-554791-a-82",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-28",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-28",
+      "id": "komunalni-2022-554791-a-85",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-28",
       "answer": "no",
       "comment": "Podporovat MHD, ale ne na základě zeleného fanatismus."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-29",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-29",
+      "id": "komunalni-2022-554791-a-88",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-29",
       "answer": "no",
       "comment": "Netrestejme nikoho za vlastnictví, i když je podle bolševických intencí EU."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-30",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-30",
+      "id": "komunalni-2022-554791-a-91",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-30",
       "answer": "yes",
       "comment": "Ano, jejich zisky to unesou."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-31",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-31",
+      "id": "komunalni-2022-554791-a-94",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-31",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-32",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-32",
+      "id": "komunalni-2022-554791-a-97",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-33",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-33",
+      "id": "komunalni-2022-554791-a-100",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-33",
       "answer": "yes",
       "comment": "Od 15 let do 18 let za 500 Kč celoročně "
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-34",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-34",
+      "id": "komunalni-2022-554791-a-103",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-35",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-35",
+      "id": "komunalni-2022-554791-a-106",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-35",
       "answer": "yes",
       "comment": "Podpora mládeže musí být důsledná."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-36",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-36",
+      "id": "komunalni-2022-554791-a-109",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-36",
       "answer": "no",
       "comment": "Odmítněme levicový genderismus."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-37",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-37",
+      "id": "komunalni-2022-554791-a-112",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-37",
       "answer": "no",
       "comment": "Odmítněme levicový genderismus."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-38",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-38",
+      "id": "komunalni-2022-554791-a-115",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-39",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-39",
+      "id": "komunalni-2022-554791-a-118",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-39",
       "answer": "no",
       "comment": "Ať podporuje MHD a bezpečnost v ní."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-40",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-40",
+      "id": "komunalni-2022-554791-a-121",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-40",
       "answer": "no",
       "comment": "Čeští občané především! Ti jsou na prvním místě!"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-41",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-41",
+      "id": "komunalni-2022-554791-a-124",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-41",
       "answer": "yes",
       "comment": "Nedávat jen botičky, ale bdít nad bezpečností."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-42",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-42",
+      "id": "komunalni-2022-554791-a-127",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-43",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-43",
+      "id": "komunalni-2022-554791-a-130",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-43",
       "answer": "no",
       "comment": "Nechme svobodu občanům, jak budou jezdit, pro neomarxisty z Bruselu je to ale těžké."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-44",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-44",
+      "id": "komunalni-2022-554791-a-133",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-44",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-45",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-45",
+      "id": "komunalni-2022-554791-a-136",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-45",
       "answer": "yes",
       "comment": "Anebo pevně držet stávající poplatek."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-46",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-46",
+      "id": "komunalni-2022-554791-a-139",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-46",
       "answer": "yes",
       "comment": "Pomoc cílená, adresná a ne pro nepřizpůsobivé."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-47",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-47",
+      "id": "komunalni-2022-554791-a-142",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-48",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-48",
+      "id": "komunalni-2022-554791-a-145",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-48",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-49",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-49",
+      "id": "komunalni-2022-554791-a-148",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-50",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-50",
+      "id": "komunalni-2022-554791-a-151",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-50",
       "answer": "yes",
       "comment": "Ať se ale jezdí přesně a včas. Je tam bezpečno a pořádek. Pak klidně i WiFi."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-51",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-51",
+      "id": "komunalni-2022-554791-a-154",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-51",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-52",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-52",
+      "id": "komunalni-2022-554791-a-157",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-52",
       "answer": "no",
       "comment": "Stačí pravidelné hlídky, vykazování a důsledná policejní práce. Slušní lidé nemohou být omezováni bezdomovci a asociály."
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-53",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-53",
+      "id": "komunalni-2022-554791-a-160",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-53",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554791-answer-133857-54",
-      "candidate_id": "komunalni-2022-554791-candidate-133857",
-      "question_id": "komunalni-2022-554791-question-54",
+      "id": "komunalni-2022-554791-a-163",
+      "candidate_id": "komunalni-2022-554791-c-133857",
+      "question_id": "komunalni-2022-554791-q-54",
       "comment": "OK"
+    },
+    {
+      "id": "komunalni-2022-554791-a-4",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-1",
+      "answer": "no",
+      "comment": "Celá Plzeň je v současné době žádaná. Finančně dovolit si ji nemůže velká část obyvatel."
+    },
+    {
+      "id": "komunalni-2022-554791-a-7",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-10",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-13",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-16",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-19",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-22",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-25",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-28",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-31",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-34",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-37",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-40",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-43",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-46",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-49",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-52",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-55",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-58",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-61",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-64",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-67",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-70",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-73",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-76",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-79",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-82",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-85",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-88",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-91",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-94",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-97",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-100",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-103",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-106",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-109",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-36",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-112",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-37"
+    },
+    {
+      "id": "komunalni-2022-554791-a-115",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-118",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-121",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-124",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-127",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-130",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-133",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-136",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-139",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-142",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-145",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-148",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-151",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-154",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-157",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-160",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-163",
+      "candidate_id": "komunalni-2022-554791-c-400852",
+      "question_id": "komunalni-2022-554791-q-54"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/554804.json
+++ b/data/kalkulacka/komunalni-2022/554804.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-554804",
   "name": "Ústí nad Labem",
-  "description": "Ústí nad Labem - DESCRIPTION",
+  "description": "Ústí nad Labem",
   "district_code": "554804",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-554804-question-1",
+      "id": "komunalni-2022-554804-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-2",
+      "id": "komunalni-2022-554804-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-3",
+      "id": "komunalni-2022-554804-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-4",
+      "id": "komunalni-2022-554804-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-5",
+      "id": "komunalni-2022-554804-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-6",
+      "id": "komunalni-2022-554804-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-7",
+      "id": "komunalni-2022-554804-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-8",
+      "id": "komunalni-2022-554804-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-9",
+      "id": "komunalni-2022-554804-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-10",
+      "id": "komunalni-2022-554804-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-11",
+      "id": "komunalni-2022-554804-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-12",
+      "id": "komunalni-2022-554804-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-13",
+      "id": "komunalni-2022-554804-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-14",
+      "id": "komunalni-2022-554804-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-15",
+      "id": "komunalni-2022-554804-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-16",
+      "id": "komunalni-2022-554804-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-17",
+      "id": "komunalni-2022-554804-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-18",
+      "id": "komunalni-2022-554804-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-19",
+      "id": "komunalni-2022-554804-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-20",
+      "id": "komunalni-2022-554804-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-21",
+      "id": "komunalni-2022-554804-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-22",
+      "id": "komunalni-2022-554804-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-23",
+      "id": "komunalni-2022-554804-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-24",
+      "id": "komunalni-2022-554804-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-25",
+      "id": "komunalni-2022-554804-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-26",
+      "id": "komunalni-2022-554804-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-27",
+      "id": "komunalni-2022-554804-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-28",
+      "id": "komunalni-2022-554804-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-29",
+      "id": "komunalni-2022-554804-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-30",
+      "id": "komunalni-2022-554804-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-31",
+      "id": "komunalni-2022-554804-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-32",
+      "id": "komunalni-2022-554804-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-33",
+      "id": "komunalni-2022-554804-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-34",
+      "id": "komunalni-2022-554804-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-35",
+      "id": "komunalni-2022-554804-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-36",
+      "id": "komunalni-2022-554804-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-37",
+      "id": "komunalni-2022-554804-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-38",
+      "id": "komunalni-2022-554804-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-39",
+      "id": "komunalni-2022-554804-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-40",
+      "id": "komunalni-2022-554804-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-41",
+      "id": "komunalni-2022-554804-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-42",
+      "id": "komunalni-2022-554804-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-43",
+      "id": "komunalni-2022-554804-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-44",
+      "id": "komunalni-2022-554804-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-45",
+      "id": "komunalni-2022-554804-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-46",
+      "id": "komunalni-2022-554804-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-47",
+      "id": "komunalni-2022-554804-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-48",
+      "id": "komunalni-2022-554804-q-48",
       "name": "Bydlení především",
       "title": "Podporuji, aby Ústí nad Labem pokračovalo v projektu Housing First.",
       "gist": "Projekty Housing First zajišťují stabilní bydlení pro nejohroženější skupinu obyvatel. V Česku díky nim získalo bezpečný domov a podporu sociálních pracovníků více než 700 lidí, z toho 320 dětí. Do projektu se zapojují i další česká i světová města; např. ve Vídni si bydlení udrželo 98 % domácností. Pilotní Brno i přes úspěch i ocenění od projektu postupně ustoupilo. Vedení města argumentovalo vysokými náklady, zastánci projektu ale poukazovali, že je většina výdajů hrazená z fondů EU.",
@@ -395,7 +397,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554804-question-49",
+      "id": "komunalni-2022-554804-q-49",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -405,10 +407,11 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-554804-candidate-415562",
+      "id": "komunalni-2022-554804-c-415562",
       "name": "ÚSTECKÉ FÓRUM OBČANŮ",
       "type": "party",
       "description": "ÚSTECKÉ FÓRUM OBČANŮ - DESCRIPTION",
+      "img_url": "ufo",
       "contacts": {
         "web": [
           {
@@ -419,7 +422,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554804-415562-party",
+          "id": "komunalni-2022-554804-c-415562-p",
           "name": "ÚSTECKÉ FÓRUM OBČANŮ",
           "description": "ÚSTECKÉ FÓRUM OBČANŮ - DESCRIPTION",
           "contacts": {
@@ -435,10 +438,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554804-candidate-606320",
+      "id": "komunalni-2022-554804-c-606320",
       "name": "Vaše Ústí",
       "type": "party",
       "description": "Vaše Ústí - DESCRIPTION",
+      "img_url": "vú",
       "contacts": {
         "web": [
           {
@@ -450,7 +454,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554804-606320-party",
+          "id": "komunalni-2022-554804-c-606320-p",
           "name": "Vaše Ústí",
           "description": "Vaše Ústí - DESCRIPTION",
           "contacts": {
@@ -467,16 +471,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554804-candidate-265108",
+      "id": "komunalni-2022-554804-c-265108",
       "name": "Občanská demokratická strana",
       "type": "party",
       "description": "Občanská demokratická strana - DESCRIPTION",
+      "img_url": "ods",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554804-265108-party",
+          "id": "komunalni-2022-554804-c-265108-p",
           "name": "Občanská demokratická strana",
           "description": "Občanská demokratická strana - DESCRIPTION",
           "contacts": {
@@ -487,10 +492,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554804-candidate-986225",
+      "id": "komunalni-2022-554804-c-986225",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
       "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "img_url": "stan",
       "contacts": {
         "web": [
           {
@@ -501,7 +507,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554804-986225-party",
+          "id": "komunalni-2022-554804-c-986225-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
           "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
           "contacts": {
@@ -517,16 +523,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554804-candidate-287190",
+      "id": "komunalni-2022-554804-c-287190",
       "name": "Aliance pro Ústí",
       "type": "party",
       "description": "Aliance pro Ústí - DESCRIPTION",
+      "img_url": "manifest.cz-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554804-287190-party",
+          "id": "komunalni-2022-554804-c-287190-p",
           "name": "Aliance pro Ústí",
           "description": "Aliance pro Ústí - DESCRIPTION",
           "contacts": {
@@ -537,16 +544,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554804-candidate-554883",
+      "id": "komunalni-2022-554804-c-554883",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554804-554883-party",
+          "id": "komunalni-2022-554804-c-554883-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -557,16 +565,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554804-candidate-118556",
+      "id": "komunalni-2022-554804-c-118556",
       "name": "Zdraví Sport Prosperita",
       "type": "party",
       "description": "Zdraví Sport Prosperita - DESCRIPTION",
+      "img_url": "pro zdraví",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554804-118556-party",
+          "id": "komunalni-2022-554804-c-118556-p",
           "name": "Zdraví Sport Prosperita",
           "description": "Zdraví Sport Prosperita - DESCRIPTION",
           "contacts": {
@@ -577,16 +586,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554804-candidate-862129",
+      "id": "komunalni-2022-554804-c-862129",
       "name": "Svoboda a přímá demokracie (SPD) s podporou politické strany Trikolora",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) s podporou politické strany Trikolora - DESCRIPTION",
+      "img_url": "spd-trikolóra",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554804-862129-party",
+          "id": "komunalni-2022-554804-c-862129-p",
           "name": "Svoboda a přímá demokracie (SPD) s podporou politické strany Trikolora",
           "description": "Svoboda a přímá demokracie (SPD) s podporou politické strany Trikolora - DESCRIPTION",
           "contacts": {
@@ -597,10 +607,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554804-candidate-320927",
+      "id": "komunalni-2022-554804-c-320927",
       "name": "Za lepší Střekov",
       "type": "party",
       "description": "Za lepší Střekov - DESCRIPTION",
+      "img_url": "zls",
       "contacts": {
         "web": [
           {
@@ -611,7 +622,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554804-320927-party",
+          "id": "komunalni-2022-554804-c-320927-p",
           "name": "Za lepší Střekov",
           "description": "Za lepší Střekov - DESCRIPTION",
           "contacts": {
@@ -627,10 +638,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554804-candidate-418969",
+      "id": "komunalni-2022-554804-c-418969",
       "name": "PRO! Ústí",
       "type": "party",
       "description": "PRO! Ústí - DESCRIPTION",
+      "img_url": "zel.-piráti-nk",
       "contacts": {
         "web": [
           {
@@ -642,7 +654,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554804-418969-party",
+          "id": "komunalni-2022-554804-c-418969-p",
           "name": "PRO! Ústí",
           "description": "PRO! Ústí - DESCRIPTION",
           "contacts": {
@@ -659,16 +671,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554804-candidate-627274",
+      "id": "komunalni-2022-554804-c-627274",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554804-627274-party",
+          "id": "komunalni-2022-554804-c-627274-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -679,10 +692,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554804-candidate-894961",
+      "id": "komunalni-2022-554804-c-894961",
       "name": "SPOLEČNĚ Ústí nad Labem",
       "type": "party",
       "description": "SPOLEČNĚ Ústí nad Labem - DESCRIPTION",
+      "img_url": "kdučsl-top09-nk",
       "contacts": {
         "web": [
           {
@@ -699,7 +713,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554804-894961-party",
+          "id": "komunalni-2022-554804-c-894961-p",
           "name": "SPOLEČNĚ Ústí nad Labem",
           "description": "SPOLEČNĚ Ústí nad Labem - DESCRIPTION",
           "contacts": {
@@ -721,10 +735,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554804-candidate-775234",
+      "id": "komunalni-2022-554804-c-775234",
       "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
       "type": "party",
       "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
+      "img_url": "přísaha",
       "contacts": {
         "web": [
           {
@@ -736,7 +751,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554804-775234-party",
+          "id": "komunalni-2022-554804-c-775234-p",
           "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
           "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
           "contacts": {
@@ -755,946 +770,1882 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-554804-answer-775234-1",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-1",
+      "id": "komunalni-2022-554804-a-4",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-1",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-2",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-2",
+      "id": "komunalni-2022-554804-a-7",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-2",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-3",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-3",
+      "id": "komunalni-2022-554804-a-10",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-4",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-4",
+      "id": "komunalni-2022-554804-a-13",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-5",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-5"
+      "id": "komunalni-2022-554804-a-16",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-5"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-6",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-6",
+      "id": "komunalni-2022-554804-a-19",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-7",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-7",
+      "id": "komunalni-2022-554804-a-22",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-8",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-8",
+      "id": "komunalni-2022-554804-a-25",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-8",
       "answer": "no",
       "comment": "Lze se bavit ale o určité razantní slevě pro rezidenty apod. "
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-9",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-9",
+      "id": "komunalni-2022-554804-a-28",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-10",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-10",
+      "id": "komunalni-2022-554804-a-31",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-11",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-11",
+      "id": "komunalni-2022-554804-a-34",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-12",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-12",
+      "id": "komunalni-2022-554804-a-37",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-13",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-13"
+      "id": "komunalni-2022-554804-a-40",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-13"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-14",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-14",
+      "id": "komunalni-2022-554804-a-43",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-15",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-15"
+      "id": "komunalni-2022-554804-a-46",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-15"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-16",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-16",
+      "id": "komunalni-2022-554804-a-49",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-17",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-17",
+      "id": "komunalni-2022-554804-a-52",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-18",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-18",
+      "id": "komunalni-2022-554804-a-55",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-19",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-19",
+      "id": "komunalni-2022-554804-a-58",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-20",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-20",
+      "id": "komunalni-2022-554804-a-61",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-21",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-21"
+      "id": "komunalni-2022-554804-a-64",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-21"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-22",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-22",
+      "id": "komunalni-2022-554804-a-67",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-23",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-23",
+      "id": "komunalni-2022-554804-a-70",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-23",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-24",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-24"
+      "id": "komunalni-2022-554804-a-73",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-24"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-25",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-25",
+      "id": "komunalni-2022-554804-a-76",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-26",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-26",
+      "id": "komunalni-2022-554804-a-79",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-27",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-27",
+      "id": "komunalni-2022-554804-a-82",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-28",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-28",
+      "id": "komunalni-2022-554804-a-85",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-29",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-29",
+      "id": "komunalni-2022-554804-a-88",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-30",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-30",
+      "id": "komunalni-2022-554804-a-91",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-31",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-31",
+      "id": "komunalni-2022-554804-a-94",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-32",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-32",
+      "id": "komunalni-2022-554804-a-97",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-33",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-33",
+      "id": "komunalni-2022-554804-a-100",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-34",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-34",
+      "id": "komunalni-2022-554804-a-103",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-34",
       "answer": "yes",
       "comment": "Ano, ale jen pro rezidenty."
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-35",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-35",
+      "id": "komunalni-2022-554804-a-106",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-36",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-36",
+      "id": "komunalni-2022-554804-a-109",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-36",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-37",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-37",
+      "id": "komunalni-2022-554804-a-112",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-38",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-38",
+      "id": "komunalni-2022-554804-a-115",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-39",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-39"
+      "id": "komunalni-2022-554804-a-118",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-39"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-40",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-40",
+      "id": "komunalni-2022-554804-a-121",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-40",
       "answer": "yes",
       "comment": "Hlavní bod našeho programu spojený s peticí."
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-41",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-41",
+      "id": "komunalni-2022-554804-a-124",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-42",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-42",
+      "id": "komunalni-2022-554804-a-127",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-43",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-43",
+      "id": "komunalni-2022-554804-a-130",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-43",
       "comment": "Podpora mládeže a seniorů, komunitní sport. Profesionální sport si na sebe musíí v první řadě vydělat sám - měla by být i částečná podpora města. Nelze ale uměle držet ligu, na kterou město nemá hráče apod. "
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-44",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-44",
+      "id": "komunalni-2022-554804-a-133",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-45",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-45",
+      "id": "komunalni-2022-554804-a-136",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-45",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-46",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-46",
+      "id": "komunalni-2022-554804-a-139",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-47",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-47"
+      "id": "komunalni-2022-554804-a-142",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-47"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-48",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-48"
+      "id": "komunalni-2022-554804-a-145",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-48"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-49",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-49",
+      "id": "komunalni-2022-554804-a-148",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-775234-50",
-      "candidate_id": "komunalni-2022-554804-candidate-775234",
-      "question_id": "komunalni-2022-554804-question-50"
+      "id": "komunalni-2022-554804-a-151",
+      "candidate_id": "komunalni-2022-554804-c-775234",
+      "question_id": "komunalni-2022-554804-q-50"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-1",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-1",
+      "id": "komunalni-2022-554804-a-4",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-2",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-2",
+      "id": "komunalni-2022-554804-a-7",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-3",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-3",
+      "id": "komunalni-2022-554804-a-10",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-3",
       "answer": "no",
       "comment": "Musí hledat jiné zdroje vytápění."
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-4",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-4",
+      "id": "komunalni-2022-554804-a-13",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-5",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-5",
+      "id": "komunalni-2022-554804-a-16",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-6",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-6",
+      "id": "komunalni-2022-554804-a-19",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-6",
       "answer": "no",
       "comment": "Je potřeba plně zprovoznit stávající síť kamer."
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-7",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-7",
+      "id": "komunalni-2022-554804-a-22",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-8",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-8",
+      "id": "komunalni-2022-554804-a-25",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-9",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-9",
+      "id": "komunalni-2022-554804-a-28",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-10",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-10",
+      "id": "komunalni-2022-554804-a-31",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-11",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-11",
+      "id": "komunalni-2022-554804-a-34",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-12",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-12",
+      "id": "komunalni-2022-554804-a-37",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-12",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-13",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-13",
+      "id": "komunalni-2022-554804-a-40",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-13",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-14",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-14",
+      "id": "komunalni-2022-554804-a-43",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-15",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-15",
+      "id": "komunalni-2022-554804-a-46",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-15",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-16",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-16",
+      "id": "komunalni-2022-554804-a-49",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-17",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-17",
+      "id": "komunalni-2022-554804-a-52",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-17",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-18",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-18",
+      "id": "komunalni-2022-554804-a-55",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-19",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-19",
+      "id": "komunalni-2022-554804-a-58",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-20",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-20",
+      "id": "komunalni-2022-554804-a-61",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-21",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-21",
+      "id": "komunalni-2022-554804-a-64",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-21",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-22",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-22",
+      "id": "komunalni-2022-554804-a-67",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-23",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-23",
+      "id": "komunalni-2022-554804-a-70",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-24",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-24",
+      "id": "komunalni-2022-554804-a-73",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-25",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-25",
+      "id": "komunalni-2022-554804-a-76",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-26",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-26",
+      "id": "komunalni-2022-554804-a-79",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-27",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-27",
+      "id": "komunalni-2022-554804-a-82",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-28",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-28",
+      "id": "komunalni-2022-554804-a-85",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-28",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-29",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-29",
+      "id": "komunalni-2022-554804-a-88",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-30",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-30",
+      "id": "komunalni-2022-554804-a-91",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-31",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-31",
+      "id": "komunalni-2022-554804-a-94",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-32",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-32",
+      "id": "komunalni-2022-554804-a-97",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-33",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-33",
+      "id": "komunalni-2022-554804-a-100",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-34",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-34",
+      "id": "komunalni-2022-554804-a-103",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-35",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-35",
+      "id": "komunalni-2022-554804-a-106",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-36",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-36",
+      "id": "komunalni-2022-554804-a-109",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-37",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-37",
+      "id": "komunalni-2022-554804-a-112",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-38",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-38",
+      "id": "komunalni-2022-554804-a-115",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-39",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-39",
+      "id": "komunalni-2022-554804-a-118",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-39",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-40",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-40",
+      "id": "komunalni-2022-554804-a-121",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-41",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-41",
+      "id": "komunalni-2022-554804-a-124",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-42",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-42",
+      "id": "komunalni-2022-554804-a-127",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-43",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-43",
+      "id": "komunalni-2022-554804-a-130",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-44",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-44",
+      "id": "komunalni-2022-554804-a-133",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-44",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-45",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-45",
+      "id": "komunalni-2022-554804-a-136",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-46",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-46",
+      "id": "komunalni-2022-554804-a-139",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-47",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-47",
+      "id": "komunalni-2022-554804-a-142",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-48",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-48",
+      "id": "komunalni-2022-554804-a-145",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-49",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-49",
+      "id": "komunalni-2022-554804-a-148",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554804-answer-894961-50",
-      "candidate_id": "komunalni-2022-554804-candidate-894961",
-      "question_id": "komunalni-2022-554804-question-50"
+      "id": "komunalni-2022-554804-a-151",
+      "candidate_id": "komunalni-2022-554804-c-894961",
+      "question_id": "komunalni-2022-554804-q-50"
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-1",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-1",
+      "id": "komunalni-2022-554804-a-4",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-1",
       "answer": "no",
       "comment": "Na otázku nejde objektivně odpovědět. Každý občan může bydlet tam, kde se rozhodne, ale zároveň musí plnit své povinnosti - platit nájem, poplatky. Tzn. že musíme bydlet tam, kde si to můžeme z ekonomického hlediska dovolit.\n"
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-2",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-2",
+      "id": "komunalni-2022-554804-a-7",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-2",
       "answer": "yes",
       "comment": "Jedná se o běžnou službu, kterou bychom si měli platit sami. Pokud budou občané více třídit, je možné uvažovat o nízkém poplatku."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-3",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-3",
+      "id": "komunalni-2022-554804-a-10",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-3",
       "answer": "no",
       "comment": "Seniorům musí být zajištět max. komfort v DpS."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-4",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-4",
+      "id": "komunalni-2022-554804-a-13",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-4",
       "answer": "yes",
       "comment": "Je to jeden z nástrojů ke zvýšení dopravní bezpečnosti v panelových sídlištích či vilových čtvrtích."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-5",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-5",
+      "id": "komunalni-2022-554804-a-16",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-5",
       "answer": "no",
       "comment": "Město informuje občany dostatečně."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-6",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-6",
+      "id": "komunalni-2022-554804-a-19",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-6",
       "answer": "yes",
       "comment": "K zajištění bezpečnosti je nutné nejen rozšiřovat monitorování problémových míst, ale také modernizovat stávající systém."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-7",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-7",
+      "id": "komunalni-2022-554804-a-22",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-7",
       "answer": "yes",
       "comment": "Hazard je ve městě regulován dostatečně."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-8",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-8",
+      "id": "komunalni-2022-554804-a-25",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-8",
       "answer": "no",
       "comment": "Ekonomicky nereálné opatření, navíc není jisté, zda by toto opatření motivovalo občany jezdit méně auty a více využívat MHD.\n"
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-9",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-9",
+      "id": "komunalni-2022-554804-a-28",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-9",
       "answer": "yes",
       "comment": "Průběžně město realizuje."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-10",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-10",
+      "id": "komunalni-2022-554804-a-31",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-10",
       "answer": "yes",
       "comment": "Toto už probíhá."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-11",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-11",
+      "id": "komunalni-2022-554804-a-34",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-11",
       "answer": "no",
       "comment": "Jednání Rady města je ze zákona neveřejné."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-12",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-12",
+      "id": "komunalni-2022-554804-a-37",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-12",
       "answer": "no",
       "comment": "Město by mělo stanovit dny, kdy je možné pyrotechniku používat. Použití je každopádně nutné regulovat."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-13",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-13",
+      "id": "komunalni-2022-554804-a-40",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-13",
       "answer": "yes",
       "comment": "Vybrané budovy již zpřístupněny jsou."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-14",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-14",
+      "id": "komunalni-2022-554804-a-43",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-14",
       "answer": "yes",
       "comment": "Ano, je nutné šetřit.\n"
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-15",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-15",
+      "id": "komunalni-2022-554804-a-46",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-15",
       "answer": "yes",
       "comment": "Pokud opatření výrazně neohrozí bezpečnost občanů, je nutné šetřit."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-16",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-16",
+      "id": "komunalni-2022-554804-a-49",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-16",
       "answer": "yes",
       "comment": "V městských budovách nebo i ve školách se často přetápí, je nutné racionálně regulovat teplotu uvnitř budov."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-17",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-17",
+      "id": "komunalni-2022-554804-a-52",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-17",
       "answer": "yes",
       "comment": "Pohledávky za děti by měli hradit rodiče."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-18",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-18",
+      "id": "komunalni-2022-554804-a-55",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-18",
       "answer": "no",
       "comment": "Nelze jednoznačně odpovědět. Pokud hrozí ztráta ochrany osobních údajů, není možné upřednostnit transparentní účty užívat. Nakládání s veřejnými prostředky lze sledovat i jinými cestami, např. pomocí registru smluv."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-19",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-19",
+      "id": "komunalni-2022-554804-a-58",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-19",
       "answer": "yes",
       "comment": "Město to již podporuje."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-20",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-20",
+      "id": "komunalni-2022-554804-a-61",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-20",
       "answer": "no",
       "comment": "Počet bytů ve vlastnictví města (obvodů) je dostačující. Město by se mělo zaměřit především na zajištění startovacího bydlení nebo tzv. prostupného bydlení."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-21",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-21",
+      "id": "komunalni-2022-554804-a-64",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-21",
       "answer": "yes",
       "comment": "Je to jedno z menších opatření v oblasti úspor."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-22",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-22",
+      "id": "komunalni-2022-554804-a-67",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-22",
       "answer": "no",
       "comment": "Není možné diskriminovat žáky škol jiných zřizovatelů, navíc by se jednalo o velký zásah do městského rozpočtu.\n"
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-23",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-23",
+      "id": "komunalni-2022-554804-a-70",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-23",
       "answer": "no",
       "comment": "Není to pro město významná, ani lehce realizovatelná aktivita."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-24",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-24",
+      "id": "komunalni-2022-554804-a-73",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-24",
       "answer": "no",
       "comment": "Otázka není dobře položena. Parkování ve městě je nutné regulovat s ohledem na rostoucí počet aut."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-25",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-25",
+      "id": "komunalni-2022-554804-a-76",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-25",
       "answer": "no",
       "comment": "Město již nepotřebuje privatizovat byty.\n"
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-26",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-26",
+      "id": "komunalni-2022-554804-a-79",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-26",
       "answer": "yes",
       "comment": "Soukromí developeři by se měli podílet na financování občanské vybavenosti v souvislosti s jejich aktivitami, např. výstavba komunikací, chodníků, zastávek MHD nebo archeologického průzkumu."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-27",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-27",
+      "id": "komunalni-2022-554804-a-82",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-27",
       "answer": "yes",
       "comment": "Mělo by platit obecně v celé ČR."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-28",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-28",
+      "id": "komunalni-2022-554804-a-85",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-28",
       "answer": "no",
       "comment": "Nepřiměřený zásah do osobního práva občanů."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-29",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-29",
+      "id": "komunalni-2022-554804-a-88",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-29",
       "answer": "yes",
       "comment": "Nelze však zobecňovat, někde je finanční podpora developerů dostačující, jinde minimální."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-30",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-30",
+      "id": "komunalni-2022-554804-a-91",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-30",
       "answer": "yes",
       "comment": "S ohledem do budoucnosti je toto nezbytné."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-31",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-31",
+      "id": "komunalni-2022-554804-a-94",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-31",
       "answer": "yes",
       "comment": "Pro město je tento způsob podpory bydlení nejlepším vzhledem k občanům, kteří si nemůžou koupit vlastní byt."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-32",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-32",
+      "id": "komunalni-2022-554804-a-97",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-32",
       "answer": "no",
       "comment": "Slevy jsou dostatečné, věková hranice pro jízdu zdarma by měla být nižší."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-33",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-33",
+      "id": "komunalni-2022-554804-a-100",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-33",
       "answer": "no",
       "comment": "Vlastnící by si měli zajišťovat instalaci sami."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-34",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-34",
+      "id": "komunalni-2022-554804-a-103",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-34",
       "answer": "no",
       "comment": "Systém slev je dostatečný, ale dovedeme si představit, že by v budoucnu mohl být vstup do muzeí či galerií zdarma."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-35",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-35"
+      "id": "komunalni-2022-554804-a-106",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-35"
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-36",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-36",
+      "id": "komunalni-2022-554804-a-109",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-36",
       "answer": "no",
       "comment": "Systém sociální podpory je dostatečně štědrý a umožňuje pomůcky koupit."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-37",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-37",
+      "id": "komunalni-2022-554804-a-112",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-37",
       "answer": "yes",
       "comment": "Kde to bude z nejrůznějších důvodů možné, by mělo město fotovoltaiku podpořit. "
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-38",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-38",
+      "id": "komunalni-2022-554804-a-115",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-38",
       "answer": "yes",
       "comment": "Vhodný způsob snížení hustoty atomobilové dopravy."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-39",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-39",
+      "id": "komunalni-2022-554804-a-118",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-39",
       "answer": "yes",
       "comment": "Město integraci podporuje."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-40",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-40",
+      "id": "komunalni-2022-554804-a-121",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-40",
       "answer": "yes",
       "comment": "Zásadní priorita v oblasti bezpečnosti."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-41",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-41",
+      "id": "komunalni-2022-554804-a-124",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-41",
       "answer": "yes",
       "comment": "Do budoucna ano."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-42",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-42",
+      "id": "komunalni-2022-554804-a-127",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-42",
       "answer": "yes",
       "comment": "Město by mělo více podporovat cyklistiku."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-43",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-43",
+      "id": "komunalni-2022-554804-a-130",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-43",
       "answer": "yes",
       "comment": "Město podporuje profesionální sport přijatelnými nájmy svých sportovišť a finančně podporuje sportovní činnost mládeže."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-44",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-44",
+      "id": "komunalni-2022-554804-a-133",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-44",
       "answer": "no",
       "comment": "Daň z nemovitosti je na přijatelné výši v porovnání s jinými obcemi."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-45",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-45",
+      "id": "komunalni-2022-554804-a-136",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-45",
       "answer": "no",
       "comment": "Sociální systém v ČR je dostatečně štědrý."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-46",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-46",
+      "id": "komunalni-2022-554804-a-139",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-46",
       "answer": "yes",
       "comment": "Bytový fond by měl zahrnovat pouze přiměřený počet sociálních bytů, startovacích bytů či bytů k prostupnému bydlení."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-47",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-47",
+      "id": "komunalni-2022-554804-a-142",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-47",
       "answer": "yes",
       "comment": "Otázka je problematicky postavena. Děti by měly navštěvovat školu podle místa bydliště, to může vyvolat daný problém. Ale nutit děti ze sociálně znevýhodněných rodit jezdit do školy daleko od místa bydliště je nereálné."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-48",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-48",
+      "id": "komunalni-2022-554804-a-145",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-48",
       "answer": "yes",
       "comment": "Vhodná podpora systému sociálního bydlení."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-49",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-49",
+      "id": "komunalni-2022-554804-a-148",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-49",
       "answer": "yes",
       "comment": "Město již podporuje, zřizuje jesle a v MŠ je možné vzdělávat děti od 2 let."
     },
     {
-      "id": "komunalni-2022-554804-answer-265108-50",
-      "candidate_id": "komunalni-2022-554804-candidate-265108",
-      "question_id": "komunalni-2022-554804-question-50",
+      "id": "komunalni-2022-554804-a-151",
+      "candidate_id": "komunalni-2022-554804-c-265108",
+      "question_id": "komunalni-2022-554804-q-50",
       "comment": "Ústí by si zasloužilo v některých případech jiné otázky. Některé otázky nemají jednoznačné odpovědi."
+    },
+    {
+      "id": "komunalni-2022-554804-a-4",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-7",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-2",
+      "answer": "no",
+      "comment": "Ústí je spíše chudší město a neměli bychom slušné zatěžovat poplatky, které některé skupiny obyvatel stejně nezaplatí "
+    },
+    {
+      "id": "komunalni-2022-554804-a-10",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-13",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-4",
+      "answer": "yes",
+      "comment": "Hlavně v okolí škol, školek a v sídlištích."
+    },
+    {
+      "id": "komunalni-2022-554804-a-16",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-5",
+      "answer": "yes",
+      "comment": "Využít všechny svoje informační kanály k upozornění na tuto možnost."
+    },
+    {
+      "id": "komunalni-2022-554804-a-19",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-6",
+      "answer": "yes",
+      "comment": "Rozšířit počet kamer opět hlavně v okolí objektů, kde pohybují děti, školy, školky, parky, dětská hřiště pro zvýšení jejich bezpečnosti."
+    },
+    {
+      "id": "komunalni-2022-554804-a-22",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-7",
+      "answer": "no",
+      "comment": "Jednalo by se o velký výpadek financí do rozpočtu na potřebné investice. Navíc je ve městě již pouze 10 kasin, která jsou pod velkou kontrolou. "
+    },
+    {
+      "id": "komunalni-2022-554804-a-25",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-28",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-9",
+      "answer": "yes",
+      "comment": "Hlavně využít vždy vypsaných dotačních titulů."
+    },
+    {
+      "id": "komunalni-2022-554804-a-31",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-10",
+      "answer": "yes",
+      "comment": "Ke každému bodu jednání by mělo být přiloženo jmenné hlasování zastupitelů. "
+    },
+    {
+      "id": "komunalni-2022-554804-a-34",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-37",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-40",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-13",
+      "answer": "no",
+      "comment": "K tomuto účelu ve městě fungují charitativní organizace. "
+    },
+    {
+      "id": "komunalni-2022-554804-a-43",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-46",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-15",
+      "answer": "no",
+      "comment": "Mělo by instalovat úsporná svítidla a budovat tzv. chytrá osvětlení. "
+    },
+    {
+      "id": "komunalni-2022-554804-a-49",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-52",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-17",
+      "answer": "yes",
+      "comment": "Ale nastavit jasná pravidla. "
+    },
+    {
+      "id": "komunalni-2022-554804-a-55",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-18",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-58",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-19",
+      "answer": "yes",
+      "comment": "Občané by měli mít možnost navrhovat záměry a různá vylepšení, ale již nezasahovat do realizace. V našem městě se to děje aktivitami Místní agendy 21."
+    },
+    {
+      "id": "komunalni-2022-554804-a-61",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-20",
+      "answer": "yes",
+      "comment": "Ale pouze výkupem celých nemovitostí a výstavbou nových bytových domů formou družstevního bydlení, PPP projektů a podporou soukromých developerů."
+    },
+    {
+      "id": "komunalni-2022-554804-a-64",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-67",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-22",
+      "answer": "no",
+      "comment": "Děti ze sociálně slabších skupin využívají v Ústí projekt Women for Women."
+    },
+    {
+      "id": "komunalni-2022-554804-a-70",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-73",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-24",
+      "answer": "no",
+      "comment": "Město musí nejprve zajistit dostatek parkovacích míst a pak může řešit parkovací zóny, ale koncepčně v celé městě. "
+    },
+    {
+      "id": "komunalni-2022-554804-a-76",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-79",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-82",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-85",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-88",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-29",
+      "answer": "no",
+      "comment": "Ústí zatím není atraktivní pro developery. Mělo by je spíše podporovat. "
+    },
+    {
+      "id": "komunalni-2022-554804-a-91",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-94",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-97",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-32",
+      "answer": "yes",
+      "comment": "Určitě, aspoň nebudeme \"vyrábět\" dětské dlužníky a bude větší využití hromadné dopravy na úkor vožení dětí do škol auty."
+    },
+    {
+      "id": "komunalni-2022-554804-a-100",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-33",
+      "answer": "no",
+      "comment": "Jen na městských objektech."
+    },
+    {
+      "id": "komunalni-2022-554804-a-103",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-34",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-106",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-109",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-112",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-115",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-38"
+    },
+    {
+      "id": "komunalni-2022-554804-a-118",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-39"
+    },
+    {
+      "id": "komunalni-2022-554804-a-121",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-124",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-41"
+    },
+    {
+      "id": "komunalni-2022-554804-a-127",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-42",
+      "comment": "Problém našeho města je výrazně kopcovitý terén. "
+    },
+    {
+      "id": "komunalni-2022-554804-a-130",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-133",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-136",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-45",
+      "answer": "no",
+      "comment": "Toto je role státu. "
+    },
+    {
+      "id": "komunalni-2022-554804-a-139",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-142",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-145",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-148",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-151",
+      "candidate_id": "komunalni-2022-554804-c-415562",
+      "question_id": "komunalni-2022-554804-q-50"
+    },
+    {
+      "id": "komunalni-2022-554804-a-4",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-1"
+    },
+    {
+      "id": "komunalni-2022-554804-a-7",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-2",
+      "answer": "yes",
+      "comment": "Svoz odpadu není zadarmo ani nyní, občané za něj platí tím, že se jim nedostává jiných služeb."
+    },
+    {
+      "id": "komunalni-2022-554804-a-10",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-3",
+      "answer": "no",
+      "comment": "Senioři musí být chránění jako nejohroženější skupina obyvatel"
+    },
+    {
+      "id": "komunalni-2022-554804-a-13",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-4",
+      "answer": "yes",
+      "comment": "Určitě v okolí škol a školek"
+    },
+    {
+      "id": "komunalni-2022-554804-a-16",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-5",
+      "answer": "no",
+      "comment": "Propagace probíhá prostřednictvím všech informačních kanálů města"
+    },
+    {
+      "id": "komunalni-2022-554804-a-19",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-22",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-7",
+      "answer": "no",
+      "comment": "Už máme omezeno na minimum"
+    },
+    {
+      "id": "komunalni-2022-554804-a-25",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-8",
+      "answer": "no",
+      "comment": "Je to finančně nerealizovatelné"
+    },
+    {
+      "id": "komunalni-2022-554804-a-28",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-31",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-10",
+      "answer": "yes",
+      "comment": "Záznam ze zastupitelstva je veřejný a již nyní každý vidí hlasování"
+    },
+    {
+      "id": "komunalni-2022-554804-a-34",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-11",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-37",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-40",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-43",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-46",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-15",
+      "answer": "yes",
+      "comment": "Na míru neohrožující bezpečnost"
+    },
+    {
+      "id": "komunalni-2022-554804-a-49",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-52",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-17",
+      "comment": "Dluh dítěte jde za zákonným zástupcem, který nese odpovědnost."
+    },
+    {
+      "id": "komunalni-2022-554804-a-55",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-18",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-58",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-19",
+      "answer": "yes",
+      "comment": "Participativní rozpočet má město již několik let"
+    },
+    {
+      "id": "komunalni-2022-554804-a-61",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-20",
+      "answer": "yes",
+      "comment": "Ve městě je cca 40 000 bytů a město vlastní pouze zlomek"
+    },
+    {
+      "id": "komunalni-2022-554804-a-64",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-21",
+      "answer": "yes",
+      "comment": "V únosné míře"
+    },
+    {
+      "id": "komunalni-2022-554804-a-67",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-22",
+      "answer": "no",
+      "comment": "Otázka bezplatného stravování ve školách musí být záležitostí státu"
+    },
+    {
+      "id": "komunalni-2022-554804-a-70",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-73",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-24",
+      "answer": "yes",
+      "comment": "Již jsou v katastru města stanoveny zóny"
+    },
+    {
+      "id": "komunalni-2022-554804-a-76",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-79",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-82",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-85",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-88",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-91",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-30",
+      "comment": "Sázíme spíše na vodíkovou mobilitu"
+    },
+    {
+      "id": "komunalni-2022-554804-a-94",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-31",
+      "answer": "yes",
+      "comment": "Bytové družstvo již máme"
+    },
+    {
+      "id": "komunalni-2022-554804-a-97",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-100",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-33",
+      "answer": "yes",
+      "comment": "Metodicky"
+    },
+    {
+      "id": "komunalni-2022-554804-a-103",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-34",
+      "answer": "yes",
+      "comment": "Již je zavedeno"
+    },
+    {
+      "id": "komunalni-2022-554804-a-106",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-109",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-112",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-37",
+      "answer": "yes",
+      "comment": "Připravujeme projekty pro všechny městské budovy"
+    },
+    {
+      "id": "komunalni-2022-554804-a-115",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-118",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-39",
+      "answer": "yes",
+      "comment": "Město se podílí na integračních procesech"
+    },
+    {
+      "id": "komunalni-2022-554804-a-121",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-40",
+      "answer": "yes",
+      "comment": "S náborem je velký problém"
+    },
+    {
+      "id": "komunalni-2022-554804-a-124",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-127",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-42",
+      "answer": "yes",
+      "comment": "Podporujeme již nyní"
+    },
+    {
+      "id": "komunalni-2022-554804-a-130",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-43",
+      "answer": "no",
+      "comment": "Profesionální sport podporujeme, ale přednost by mělo být sportování dětí a mládeže"
+    },
+    {
+      "id": "komunalni-2022-554804-a-133",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-44",
+      "answer": "no",
+      "comment": "Je to významný příjem města"
+    },
+    {
+      "id": "komunalni-2022-554804-a-136",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-45",
+      "answer": "no",
+      "comment": "Je to úloha státu, ale přesto poskytujeme podporu neziskovým organizacím"
+    },
+    {
+      "id": "komunalni-2022-554804-a-139",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-142",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-145",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-148",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-49",
+      "answer": "yes",
+      "comment": "Podporujeme"
+    },
+    {
+      "id": "komunalni-2022-554804-a-151",
+      "candidate_id": "komunalni-2022-554804-c-554883",
+      "question_id": "komunalni-2022-554804-q-50"
+    },
+    {
+      "id": "komunalni-2022-554804-a-4",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-7",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-10",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-13",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-16",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-19",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-22",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-25",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-28",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-31",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-34",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-37",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-12",
+      "answer": "yes",
+      "comment": "Zcela zakázat!"
+    },
+    {
+      "id": "komunalni-2022-554804-a-40",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-43",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-46",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-15",
+      "answer": "yes",
+      "comment": "Využití chytrých lamp"
+    },
+    {
+      "id": "komunalni-2022-554804-a-49",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-52",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-55",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-58",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-61",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-64",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-67",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-70",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-73",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-76",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-79",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-82",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-85",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-88",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-91",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-30"
+    },
+    {
+      "id": "komunalni-2022-554804-a-94",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-97",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-100",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-103",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-106",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-109",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-36",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-112",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-115",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-118",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-121",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-124",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-127",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-130",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-133",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554804-a-136",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-139",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-142",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-145",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-148",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554804-a-151",
+      "candidate_id": "komunalni-2022-554804-c-418969",
+      "question_id": "komunalni-2022-554804-q-50"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/554821.json
+++ b/data/kalkulacka/komunalni-2022/554821.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-554821",
   "name": "Ostrava",
-  "description": "Ostrava - DESCRIPTION",
+  "description": "Ostrava",
   "district_code": "554821",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-554821-question-1",
+      "id": "komunalni-2022-554821-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-2",
+      "id": "komunalni-2022-554821-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-3",
+      "id": "komunalni-2022-554821-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-4",
+      "id": "komunalni-2022-554821-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-5",
+      "id": "komunalni-2022-554821-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-6",
+      "id": "komunalni-2022-554821-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-7",
+      "id": "komunalni-2022-554821-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-8",
+      "id": "komunalni-2022-554821-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-9",
+      "id": "komunalni-2022-554821-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-10",
+      "id": "komunalni-2022-554821-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-11",
+      "id": "komunalni-2022-554821-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-12",
+      "id": "komunalni-2022-554821-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-13",
+      "id": "komunalni-2022-554821-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-14",
+      "id": "komunalni-2022-554821-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-15",
+      "id": "komunalni-2022-554821-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-16",
+      "id": "komunalni-2022-554821-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-17",
+      "id": "komunalni-2022-554821-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-18",
+      "id": "komunalni-2022-554821-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-19",
+      "id": "komunalni-2022-554821-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-20",
+      "id": "komunalni-2022-554821-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-21",
+      "id": "komunalni-2022-554821-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-22",
+      "id": "komunalni-2022-554821-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-23",
+      "id": "komunalni-2022-554821-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-24",
+      "id": "komunalni-2022-554821-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-25",
+      "id": "komunalni-2022-554821-q-25",
       "name": "Jedna parkovací zóna pro celé město",
       "title": "Město má umožňovat rezidentům za jeden roční paušální poplatek parkovat kdekoli na svém území.",
       "gist": "Ve městě by existovala jen jedna rezidenční parkovací zóna, nedělená podle oblastí či městských částí. Kritikům více zón vadí, že předplatné rezidentům parkovací místo automaticky nezaručí. Podle nich by jedna zóna pomohla parkovat i v jiném bloku nebo ulici, jež například spadají do vedlejší městské části.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-26",
+      "id": "komunalni-2022-554821-q-26",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-27",
+      "id": "komunalni-2022-554821-q-27",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-28",
+      "id": "komunalni-2022-554821-q-28",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-29",
+      "id": "komunalni-2022-554821-q-29",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-30",
+      "id": "komunalni-2022-554821-q-30",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-31",
+      "id": "komunalni-2022-554821-q-31",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-32",
+      "id": "komunalni-2022-554821-q-32",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-33",
+      "id": "komunalni-2022-554821-q-33",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-34",
+      "id": "komunalni-2022-554821-q-34",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-35",
+      "id": "komunalni-2022-554821-q-35",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-36",
+      "id": "komunalni-2022-554821-q-36",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-37",
+      "id": "komunalni-2022-554821-q-37",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-38",
+      "id": "komunalni-2022-554821-q-38",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-39",
+      "id": "komunalni-2022-554821-q-39",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-40",
+      "id": "komunalni-2022-554821-q-40",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-41",
+      "id": "komunalni-2022-554821-q-41",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-42",
+      "id": "komunalni-2022-554821-q-42",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-43",
+      "id": "komunalni-2022-554821-q-43",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-44",
+      "id": "komunalni-2022-554821-q-44",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-45",
+      "id": "komunalni-2022-554821-q-45",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-46",
+      "id": "komunalni-2022-554821-q-46",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-47",
+      "id": "komunalni-2022-554821-q-47",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-48",
+      "id": "komunalni-2022-554821-q-48",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -395,7 +397,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-49",
+      "id": "komunalni-2022-554821-q-49",
       "name": "Nové byty",
       "title": "Souhlasím se zákazem staveb dalších spaloven nebezpečných odpadů na území Ostravy.",
       "gist": "Město zákaz zakotvilo v nově upraveném územním plánu, aby se v Ostravě v budoucnu nezhoršovala čistota ovzduší. Povolené jsou pouze modernizace už stávajících spaloven.",
@@ -403,7 +405,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-50",
+      "id": "komunalni-2022-554821-q-50",
       "name": "Vylidňování Ostravy",
       "title": "Zastavit úbytek populace může nabídka práce pro mladé navázaná na výzkum a moderní obory.",
       "gist": "Ostrava je město s nejrychleji klesající populaci z krajských měst – každých 10 let ji opustilo ca. 6 % obyvatel. Nejčastěji se z Ostravy stěhují mladí lidé za prací do Prahy nebo jiných regionů s nižší nezaměstnaností. Lidé ve středním věku naopak opouštějí Ostravu na předměstí. Hrozí situace, že zde zůstanou převážně starší lidé, což může mít vážný socio-ekonomický dopad na toto město.",
@@ -411,7 +413,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-51",
+      "id": "komunalni-2022-554821-q-51",
       "name": "Jednotné zdravotnictví",
       "title": "Ostrava potřebuje sjednocené řízení zdravotnických subjektů",
       "gist": "Zastánci sjednocení tvrdí, že dosavadní roztříštěné řízení ostravského zdravotnictví městu škodí. Fakultní nemocnice Ostrava patří pod ministerstvo zdravotnictví, Vítkovickou nemocnici vlastní soukromá společnost Agel a nemocnice na Fifejdách je městská. Zastánci sjednocení tvrdí, že zdravotnická zařízení si nemají konkurovat, ale vzájemně spolupracovat.",
@@ -419,7 +421,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-52",
+      "id": "komunalni-2022-554821-q-52",
       "name": "Vyšší počty lékařů",
       "title": "Priorita pro město je sehnat dost lékařů do městské nemocnice.",
       "gist": "Městská nemocnice Ostrava (MNO) dlouhodobě nemá dostatečné počty lékařů. Letos na jaře např. ohlásila, že musí omezit onkologickou péči.",
@@ -427,7 +429,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-53",
+      "id": "komunalni-2022-554821-q-53",
       "name": "Vlastnictví nemocnice",
       "title": "Městská nemocnice by se měla stát součástí krajské sítě nemocnic.",
       "gist": "Podle zastánců by město uspořilo obrovské finance a nemocnice by svými službami vhodně doplnila krajský zdravotní systém.",
@@ -435,7 +437,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-54",
+      "id": "komunalni-2022-554821-q-54",
       "name": "Grossmannova vila",
       "title": "Grossmannova vila by měla zůstat v majetku města.",
       "gist": "Město se vilu opakovaně pokoušelo prodat. Nyní architelktonická perla Ostravy prochází nákladnou rekonstrukcí. Zastánci prodeje argumentují, že budova nezatíží rozpočet města přepokládanými budoucími náklady na svůj provoz. Město plánuje, že by reprezentační prostory využívalo pro svou potřebu, a přiznává, že zatím nemá jasnější vizi, jak s objektem naložit. Odpůrci považují prodej po rekonstrukci za desítky milionů za nevýhodný.",
@@ -443,7 +445,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-55",
+      "id": "komunalni-2022-554821-q-55",
       "name": "Koncertní hala",
       "title": "Ostrava má postavit novou koncertní halu.",
       "gist": "Stavba koncertní haly na jedné straně symbolem nové Ostravy a mluví se o ní 160 let. Odhady stavebních nákladů jsou nyní zhruba 5 miliard. Kritici říkají, že tyhle prostředky jsou potřeba jinde. Zastánci ji považují za špičkový projekt světové úrovně a zřejmě neopakovatelnou možnost získání externích zdrojů. Nevyužít toho, by byla zmařená příležitost.",
@@ -451,7 +453,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-56",
+      "id": "komunalni-2022-554821-q-56",
       "name": "Parkovací domy",
       "title": "Podporuji výstavbu dalších parkovacích domů.",
       "gist": "Podle zastánců je velkým problémem města parkování, zejména ve větších obvodech – na Jihu, v Porubě, v centru Ostravy. Odpůrci namítají, že je třeba se soustředit na jiné formy dopravy než automobilovou.",
@@ -459,7 +461,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-57",
+      "id": "komunalni-2022-554821-q-57",
       "name": "Podchody na nádraží",
       "title": "Podporuji, aby byly nadchody ve stanici Ostrava hlavní nádraží nahrazeny podchody pod nástupišti.",
       "gist": "Projektanti se odvolávají na to, že tento požadavek přišel od vedení města. Kritici namítají, že většina cestujících mine výpravní budovy, protože vchod do podchodů bude ještě před ní, z přednádražního prostoru.",
@@ -467,7 +469,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-58",
+      "id": "komunalni-2022-554821-q-58",
       "name": "Nová obytná čtvrť",
       "title": "Podporuji výstavbu nové obytné čtvrti ve Svinově.",
       "gist": "V Ostravě za poslední dekádu stagnovala výstavba nových bytů. Nezastavěné území podél ulic Polská a Mongolská v městském obvodu Svinov patří do skupiny důležitých ostravských rozvojových lokalit. V budoucnu zde postupně má vzniknout nová obytná čtvrť až pro tři tisíce obyvatel.",
@@ -475,7 +477,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-59",
+      "id": "komunalni-2022-554821-q-59",
       "name": "Dotace pro lidi",
       "title": "Miliardové dotace pro velké znečišťovatele patří na modernizace lokálních topenišť v rodinných domcích.",
       "gist": "Kritici považují dotace pro velké koncerny za neúčinné v boji proti znečištění ovzduší. Zastánci navrhují diskusi s tím, že se znečišťovateli se musí férově, ale tvrdě jednat.",
@@ -483,7 +485,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-60",
+      "id": "komunalni-2022-554821-q-60",
       "name": "Rozšíření spalovny",
       "title": "Město se musí bránit rozšíření spalovny nebezpečných odpadů.",
       "gist": "Rozšíření spalovny nebezpečného odpadu v Ostravě-Mariánských Horách, proti kterému se postavily město Ostrava, městské obvody, Moravskoslezský kraj i obyvatelé, dostalo souhlas ministerstva životního prostředí.",
@@ -491,7 +493,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-61",
+      "id": "komunalni-2022-554821-q-61",
       "name": "Demontáž laviček",
       "title": "Souhlasím s tím, aby město demontovalo lavičky obsazované lidmi bez domova.",
       "gist": "",
@@ -499,7 +501,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-62",
+      "id": "komunalni-2022-554821-q-62",
       "name": "Bydlení především",
       "title": "Podporuji, aby Ostrava pokračovala v projektu Housing First.",
       "gist": "Projekty Housing First zajišťují stabilní bydlení pro nejohroženější skupinu obyvatel. V Česku díky nim získalo bezpečný domov a podporu sociálních pracovníků více než 700 lidí, z toho 320 dětí. Do projektu se zapojují i další česká i světová města; např. ve Vídni si bydlení udrželo 98 % domácností. Pilotní Brno i přes úspěch i ocenění od projektu postupně ustoupilo. Vedení města argumentovalo vysokými náklady, zastánci projektu ale poukazovali, že je většina výdajů hrazená z fondů EU.",
@@ -507,7 +509,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554821-question-63",
+      "id": "komunalni-2022-554821-q-63",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -517,10 +519,11 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-554821-candidate-770690",
+      "id": "komunalni-2022-554821-c-770690",
       "name": "Ostravak",
       "type": "party",
       "description": "Ostravak - DESCRIPTION",
+      "img_url": "ostravak",
       "contacts": {
         "web": [
           {
@@ -532,7 +535,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554821-770690-party",
+          "id": "komunalni-2022-554821-c-770690-p",
           "name": "Ostravak",
           "description": "Ostravak - DESCRIPTION",
           "contacts": {
@@ -549,10 +552,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554821-candidate-471835",
+      "id": "komunalni-2022-554821-c-471835",
       "name": "Švýcarská demokracie (www.svycarska-demokracie.cz)",
       "type": "party",
       "description": "Švýcarská demokracie (www.svycarska-demokracie.cz) - DESCRIPTION",
+      "img_url": "švýcar. demokr.",
       "contacts": {
         "web": [
           {
@@ -564,7 +568,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554821-471835-party",
+          "id": "komunalni-2022-554821-c-471835-p",
           "name": "Švýcarská demokracie (www.svycarska-demokracie.cz)",
           "description": "Švýcarská demokracie (www.svycarska-demokracie.cz) - DESCRIPTION",
           "contacts": {
@@ -581,16 +585,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554821-candidate-951793",
+      "id": "komunalni-2022-554821-c-951793",
       "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
       "type": "party",
       "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+      "img_url": "dsz-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554821-951793-party",
+          "id": "komunalni-2022-554821-c-951793-p",
           "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
           "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
           "contacts": {
@@ -601,10 +606,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554821-candidate-994317",
+      "id": "komunalni-2022-554821-c-994317",
       "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
       "type": "party",
       "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
+      "img_url": "přísaha",
       "contacts": {
         "web": [
           {
@@ -615,7 +621,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554821-994317-party",
+          "id": "komunalni-2022-554821-c-994317-p",
           "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
           "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
           "contacts": {
@@ -631,10 +637,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554821-candidate-893970",
+      "id": "komunalni-2022-554821-c-893970",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": [
           {
@@ -645,7 +652,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554821-893970-party",
+          "id": "komunalni-2022-554821-c-893970-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -661,16 +668,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554821-candidate-770362",
+      "id": "komunalni-2022-554821-c-770362",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554821-770362-party",
+          "id": "komunalni-2022-554821-c-770362-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -681,10 +689,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554821-candidate-391082",
+      "id": "komunalni-2022-554821-c-391082",
       "name": "STAROSTOVÉ pro OSTRAVU",
       "type": "party",
       "description": "STAROSTOVÉ pro OSTRAVU - DESCRIPTION",
+      "img_url": "stan-nk",
       "contacts": {
         "web": [
           {
@@ -700,7 +709,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554821-391082-party",
+          "id": "komunalni-2022-554821-c-391082-p",
           "name": "STAROSTOVÉ pro OSTRAVU",
           "description": "STAROSTOVÉ pro OSTRAVU - DESCRIPTION",
           "contacts": {
@@ -721,16 +730,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554821-candidate-889453",
+      "id": "komunalni-2022-554821-c-889453",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554821-889453-party",
+          "id": "komunalni-2022-554821-c-889453-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -741,16 +751,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554821-candidate-462687",
+      "id": "komunalni-2022-554821-c-462687",
       "name": "OSTRAVSKÁ LEVICE — sdružení KSČM a NK: Za VODÁRENSTVÍ VE VLASTNICTVÍ MĚSTA, ne cizinců; Za LEVNOU MHD…",
       "type": "party",
       "description": "OSTRAVSKÁ LEVICE — sdružení KSČM a NK: Za VODÁRENSTVÍ VE VLASTNICTVÍ MĚSTA, ne cizinců; Za LEVNOU MHD… - DESCRIPTION",
+      "img_url": "ksčm-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554821-462687-party",
+          "id": "komunalni-2022-554821-c-462687-p",
           "name": "OSTRAVSKÁ LEVICE — sdružení KSČM a NK: Za VODÁRENSTVÍ VE VLASTNICTVÍ MĚSTA, ne cizinců; Za LEVNOU MHD…",
           "description": "OSTRAVSKÁ LEVICE — sdružení KSČM a NK: Za VODÁRENSTVÍ VE VLASTNICTVÍ MĚSTA, ne cizinců; Za LEVNOU MHD… - DESCRIPTION",
           "contacts": {
@@ -761,17 +772,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-554821-candidate-557133",
+      "id": "komunalni-2022-554821-c-557133",
       "name": "Česká strana sociálně demokratická a hnutí LEČO - LEPŠÍ A ČISTÁ OSTRAVA",
       "type": "party",
       "description": "Česká strana sociálně demokratická a hnutí LEČO - LEPŠÍ A ČISTÁ OSTRAVA - DESCRIPTION",
+      "img_url": "čssd-lečo",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/cssdostrava/"
       },
       "parties": [
         {
-          "id": "komunalni-2022-554821-557133-party",
+          "id": "komunalni-2022-554821-c-557133-p",
           "name": "Česká strana sociálně demokratická a hnutí LEČO - LEPŠÍ A ČISTÁ OSTRAVA",
           "description": "Česká strana sociálně demokratická a hnutí LEČO - LEPŠÍ A ČISTÁ OSTRAVA - DESCRIPTION",
           "contacts": {
@@ -783,16 +795,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554821-candidate-563687",
+      "id": "komunalni-2022-554821-c-563687",
       "name": "Trikolora a hnutí Zdraví Sport Prosperita",
       "type": "party",
       "description": "Trikolora a hnutí Zdraví Sport Prosperita - DESCRIPTION",
+      "img_url": "prozd-trikol-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554821-563687-party",
+          "id": "komunalni-2022-554821-c-563687-p",
           "name": "Trikolora a hnutí Zdraví Sport Prosperita",
           "description": "Trikolora a hnutí Zdraví Sport Prosperita - DESCRIPTION",
           "contacts": {
@@ -803,16 +816,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554821-candidate-291500",
+      "id": "komunalni-2022-554821-c-291500",
       "name": "ANO, VRÁTÍME VODU LIDEM, MHD bude zdarma a nezvedneme daně ani poplatky",
       "type": "party",
       "description": "ANO, VRÁTÍME VODU LIDEM, MHD bude zdarma a nezvedneme daně ani poplatky - DESCRIPTION",
+      "img_url": "patrioti-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554821-291500-party",
+          "id": "komunalni-2022-554821-c-291500-p",
           "name": "ANO, VRÁTÍME VODU LIDEM, MHD bude zdarma a nezvedneme daně ani poplatky",
           "description": "ANO, VRÁTÍME VODU LIDEM, MHD bude zdarma a nezvedneme daně ani poplatky - DESCRIPTION",
           "contacts": {
@@ -823,10 +837,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554821-candidate-364233",
+      "id": "komunalni-2022-554821-c-364233",
       "name": "Koalice SPOLU (Občanská demokratická strana, KDU-ČSL, TOP 09)",
       "type": "party",
       "description": "Koalice SPOLU (Občanská demokratická strana, KDU-ČSL, TOP 09) - DESCRIPTION",
+      "img_url": "kdu-ods-top 09",
       "contacts": {
         "web": [
           {
@@ -837,7 +852,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554821-364233-party",
+          "id": "komunalni-2022-554821-c-364233-p",
           "name": "Koalice SPOLU (Občanská demokratická strana, KDU-ČSL, TOP 09)",
           "description": "Koalice SPOLU (Občanská demokratická strana, KDU-ČSL, TOP 09) - DESCRIPTION",
           "contacts": {
@@ -853,16 +868,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554821-candidate-432837",
+      "id": "komunalni-2022-554821-c-432837",
       "name": "Slezská lidem",
       "type": "party",
       "description": "Slezská lidem - DESCRIPTION",
+      "img_url": "slezská",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554821-432837-party",
+          "id": "komunalni-2022-554821-c-432837-p",
           "name": "Slezská lidem",
           "description": "Slezská lidem - DESCRIPTION",
           "contacts": {
@@ -875,387 +891,1545 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-554821-answer-432837-1",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-1",
+      "id": "komunalni-2022-554821-a-4",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-2",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-2",
+      "id": "komunalni-2022-554821-a-7",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-3",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-3",
+      "id": "komunalni-2022-554821-a-10",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-4",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-4",
+      "id": "komunalni-2022-554821-a-13",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-5",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-5",
+      "id": "komunalni-2022-554821-a-16",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-5",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-6",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-6",
+      "id": "komunalni-2022-554821-a-19",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-7",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-7",
+      "id": "komunalni-2022-554821-a-22",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-8",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-8",
+      "id": "komunalni-2022-554821-a-25",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-9",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-9",
+      "id": "komunalni-2022-554821-a-28",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-10",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-10",
+      "id": "komunalni-2022-554821-a-31",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-11",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-11",
+      "id": "komunalni-2022-554821-a-34",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-12",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-12",
+      "id": "komunalni-2022-554821-a-37",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-13",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-13",
+      "id": "komunalni-2022-554821-a-40",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-13",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-14",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-14",
+      "id": "komunalni-2022-554821-a-43",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-15",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-15",
+      "id": "komunalni-2022-554821-a-46",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-15",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-16",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-16",
+      "id": "komunalni-2022-554821-a-49",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-17",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-17",
+      "id": "komunalni-2022-554821-a-52",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-18",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-18",
+      "id": "komunalni-2022-554821-a-55",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-19",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-19",
+      "id": "komunalni-2022-554821-a-58",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-20",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-20",
+      "id": "komunalni-2022-554821-a-61",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-21",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-21",
+      "id": "komunalni-2022-554821-a-64",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-21",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-22",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-22",
+      "id": "komunalni-2022-554821-a-67",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-23",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-23",
+      "id": "komunalni-2022-554821-a-70",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-23",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-24",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-24",
+      "id": "komunalni-2022-554821-a-73",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-25",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-25",
+      "id": "komunalni-2022-554821-a-76",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-25",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-26",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-26",
+      "id": "komunalni-2022-554821-a-79",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-26",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-27",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-27",
+      "id": "komunalni-2022-554821-a-82",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-28",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-28",
+      "id": "komunalni-2022-554821-a-85",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-28",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-29",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-29",
+      "id": "komunalni-2022-554821-a-88",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-30",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-30",
+      "id": "komunalni-2022-554821-a-91",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-31",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-31",
+      "id": "komunalni-2022-554821-a-94",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-31",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-32",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-32",
+      "id": "komunalni-2022-554821-a-97",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-33",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-33",
+      "id": "komunalni-2022-554821-a-100",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-33",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-34",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-34",
+      "id": "komunalni-2022-554821-a-103",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-34",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-35",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-35",
+      "id": "komunalni-2022-554821-a-106",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-36",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-36",
+      "id": "komunalni-2022-554821-a-109",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-37",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-37",
+      "id": "komunalni-2022-554821-a-112",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-37",
       "answer": "no",
       "comment": "Jsme pro ekologičtější řešení menstruační chudoby, menstruční kalíšky, manstruační kalhotky apod."
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-38",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-38",
+      "id": "komunalni-2022-554821-a-115",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-39",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-39",
+      "id": "komunalni-2022-554821-a-118",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-39",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-40",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-40"
+      "id": "komunalni-2022-554821-a-121",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-40"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-41",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-41",
+      "id": "komunalni-2022-554821-a-124",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-42",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-42",
+      "id": "komunalni-2022-554821-a-127",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-43",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-43",
+      "id": "komunalni-2022-554821-a-130",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-44",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-44",
+      "id": "komunalni-2022-554821-a-133",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-45",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-45",
+      "id": "komunalni-2022-554821-a-136",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-45",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-46",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-46",
+      "id": "komunalni-2022-554821-a-139",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-46",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-47",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-47",
+      "id": "komunalni-2022-554821-a-142",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-48",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-48",
+      "id": "komunalni-2022-554821-a-145",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-49",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-49",
+      "id": "komunalni-2022-554821-a-148",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-50",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-50",
+      "id": "komunalni-2022-554821-a-151",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-50",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-51",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-51"
+      "id": "komunalni-2022-554821-a-154",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-51"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-52",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-52",
+      "id": "komunalni-2022-554821-a-157",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-52",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-53",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-53",
+      "id": "komunalni-2022-554821-a-160",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-53",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-54",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-54",
+      "id": "komunalni-2022-554821-a-163",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-54",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-55",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-55",
+      "id": "komunalni-2022-554821-a-166",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-55",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-56",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-56",
+      "id": "komunalni-2022-554821-a-169",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-56",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-57",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-57",
+      "id": "komunalni-2022-554821-a-172",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-57",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-58",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-58",
+      "id": "komunalni-2022-554821-a-175",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-58",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-59",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-59",
+      "id": "komunalni-2022-554821-a-178",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-59",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-60",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-60",
+      "id": "komunalni-2022-554821-a-181",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-60",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-61",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-61",
+      "id": "komunalni-2022-554821-a-184",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-61",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-62",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-62",
+      "id": "komunalni-2022-554821-a-187",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-62",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-63",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-63",
+      "id": "komunalni-2022-554821-a-190",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-63",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554821-answer-432837-64",
-      "candidate_id": "komunalni-2022-554821-candidate-432837",
-      "question_id": "komunalni-2022-554821-question-64",
+      "id": "komunalni-2022-554821-a-193",
+      "candidate_id": "komunalni-2022-554821-c-432837",
+      "question_id": "komunalni-2022-554821-q-64",
       "comment": "Uvítali bychom přesnější formulaci otázek (jednoznačnější)"
+    },
+    {
+      "id": "komunalni-2022-554821-a-4",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-1",
+      "comment": "Záleží zda investici provádí město či soukromý developer."
+    },
+    {
+      "id": "komunalni-2022-554821-a-7",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-10",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-13",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-4",
+      "comment": "Dle místní situace."
+    },
+    {
+      "id": "komunalni-2022-554821-a-16",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-5",
+      "answer": "yes",
+      "comment": "Ano, vhodnou formou."
+    },
+    {
+      "id": "komunalni-2022-554821-a-19",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-6",
+      "comment": "Ano, ale pouze v rizikových oblastech."
+    },
+    {
+      "id": "komunalni-2022-554821-a-22",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-7",
+      "answer": "yes",
+      "comment": "Jsme proti hazardu, jelikož je na něj často přímo navázána trestná činnost a sociální aspekt."
+    },
+    {
+      "id": "komunalni-2022-554821-a-25",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-28",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-31",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-34",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-37",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-40",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-43",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-46",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-15",
+      "comment": "Dle místní situace, například dle rizikovosti oblasti."
+    },
+    {
+      "id": "komunalni-2022-554821-a-49",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-16",
+      "comment": "Ano,  v nevyužívaných. V žádném případě ne ve veřejnosti přístupných budovách."
+    },
+    {
+      "id": "komunalni-2022-554821-a-52",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-55",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-58",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-61",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-64",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-67",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-22",
+      "comment": "Ano, ale jen děti ze sociálně slabších vrstev."
+    },
+    {
+      "id": "komunalni-2022-554821-a-70",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-23"
+    },
+    {
+      "id": "komunalni-2022-554821-a-73",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-24"
+    },
+    {
+      "id": "komunalni-2022-554821-a-76",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-25",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-79",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-82",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-85",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-88",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-91",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-94",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-97",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-100",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-103",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-106",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-109",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-112",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-115",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-118",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-39",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-121",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-124",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-41",
+      "answer": "no",
+      "comment": "Je potřeba efektivněji využívat jejich stávající počty."
+    },
+    {
+      "id": "komunalni-2022-554821-a-127",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-42",
+      "comment": "Individuálně dle náročnosti provedení."
+    },
+    {
+      "id": "komunalni-2022-554821-a-130",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-133",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-44",
+      "answer": "no",
+      "comment": "Pouze mládežnický."
+    },
+    {
+      "id": "komunalni-2022-554821-a-136",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-139",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-142",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-145",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-148",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-151",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-154",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-157",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-160",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-53",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-163",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-166",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-55",
+      "comment": "Jsme pro realizaci tohoto projektu, ne však v současné nestabilní době."
+    },
+    {
+      "id": "komunalni-2022-554821-a-169",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-172",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-175",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-58",
+      "comment": "Pokud by se jednalo o zástavbu na orné půdě, jsme proti."
+    },
+    {
+      "id": "komunalni-2022-554821-a-178",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-59",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-181",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-60",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-184",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-61",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-187",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-62",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-190",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-63",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-193",
+      "candidate_id": "komunalni-2022-554821-c-994317",
+      "question_id": "komunalni-2022-554821-q-64"
+    },
+    {
+      "id": "komunalni-2022-554821-a-4",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-7",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-2",
+      "comment": "Poplatek chápeme jako součást daňového mixu města. Dovedeme si představit, že by byl zrušen a zvýýšena daň z nemovitostí tak aby pro normální občany byla toto opatření neutrální. Na úhradě by se pak více podíleli velci vlastníci nemovitostí a podnikatelské subjekty. Takový model jsme již kdysi měli ve volebním programu a případně jsme připraveni o tom jednat. Zrušení poplatku bez náhrady však necháeme jako žádoucí. Poplatek chceme odpustit dětem do 10 let a také seniorům nad 75 let. Chceme rovněž vrátit výši poplatku a odmítáme jeho zvýšení na 720 Kč."
+    },
+    {
+      "id": "komunalni-2022-554821-a-10",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-3",
+      "answer": "no",
+      "comment": "Seniořiv domovech i děti ve školách mají mít komfortní prostředí. Je smutné, že jsou vůbec nastolovány takové otázkyv 21. století."
+    },
+    {
+      "id": "komunalni-2022-554821-a-13",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-4",
+      "comment": "v nepřehledných úsecích ano, generálně ne"
+    },
+    {
+      "id": "komunalni-2022-554821-a-16",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-5",
+      "answer": "yes",
+      "comment": "oddlužení maxima lidí je ve veřejném zájmu"
+    },
+    {
+      "id": "komunalni-2022-554821-a-19",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-6",
+      "answer": "yes",
+      "comment": "ano stále jsou lokality, kde je nutné zvýšit dohled z důvodu narušování veřejného pořádku nebo z důvodu přehledu o dopravní situaci"
+    },
+    {
+      "id": "komunalni-2022-554821-a-22",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-25",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-8",
+      "answer": "yes",
+      "comment": "je to náš dlouhodobá názor a dlouhodobá vize - ve střednědobém horizontu chceme snížit cenu měsíční jízdenky na 100 Kč a roční jízdenky na 1.000 Kč, což je symbolická cena."
+    },
+    {
+      "id": "komunalni-2022-554821-a-28",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-31",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-34",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-37",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-40",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-43",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-46",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-49",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-52",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-55",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-18",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-58",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-61",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-64",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-21"
+    },
+    {
+      "id": "komunalni-2022-554821-a-67",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-70",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-73",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-76",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-25"
+    },
+    {
+      "id": "komunalni-2022-554821-a-79",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-82",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-85",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-88",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-91",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-94",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-97",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-100",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-103",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-34",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-106",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-109",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-112",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-115",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-38"
+    },
+    {
+      "id": "komunalni-2022-554821-a-118",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-121",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-40"
+    },
+    {
+      "id": "komunalni-2022-554821-a-124",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-41"
+    },
+    {
+      "id": "komunalni-2022-554821-a-127",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-130",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-133",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-136",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-139",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-142",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-145",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-148",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-151",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-154",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-157",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-160",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-53",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-163",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-166",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-55",
+      "answer": "no",
+      "comment": "odpověď není obecná, platí pro současný návrh koncertní haly"
+    },
+    {
+      "id": "komunalni-2022-554821-a-169",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-172",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-57"
+    },
+    {
+      "id": "komunalni-2022-554821-a-175",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-58",
+      "answer": "yes",
+      "comment": "pokud bude stavět měso a ne developeři"
+    },
+    {
+      "id": "komunalni-2022-554821-a-178",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-59"
+    },
+    {
+      "id": "komunalni-2022-554821-a-181",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-60",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-184",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-61"
+    },
+    {
+      "id": "komunalni-2022-554821-a-187",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-62",
+      "comment": "máte přesné informace?"
+    },
+    {
+      "id": "komunalni-2022-554821-a-190",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-63",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-193",
+      "candidate_id": "komunalni-2022-554821-c-462687",
+      "question_id": "komunalni-2022-554821-q-64",
+      "comment": "otázky jsou velmi nepřesné a mnoho z nich se nedá jednoznačně odpovědět - koncertní hala? konkrétně ten současný návrh nebo obecně?; čtvrt ve svinově - developři nebo město, apod.Máte to letos velmi špatně postavené."
+    },
+    {
+      "id": "komunalni-2022-554821-a-4",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-1",
+      "answer": "no",
+      "comment": "To však neznamená, že i v těch žádaných městských částech nemůže existovat finančně dostupné bydlení. "
+    },
+    {
+      "id": "komunalni-2022-554821-a-7",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-10",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-3",
+      "answer": "no",
+      "comment": "Určitě ne, jsou jiné možnosti úspor. "
+    },
+    {
+      "id": "komunalni-2022-554821-a-13",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-16",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-19",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-22",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-25",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-28",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-31",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-34",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-37",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-12"
+    },
+    {
+      "id": "komunalni-2022-554821-a-40",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-13",
+      "answer": "yes",
+      "comment": "V případě potřeby ano, ale tato situace určitě nenastane."
+    },
+    {
+      "id": "komunalni-2022-554821-a-43",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-46",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-15",
+      "comment": "Lze hledat určité úspory, ale s ohledem na bezpečnost. "
+    },
+    {
+      "id": "komunalni-2022-554821-a-49",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-52",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-55",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-18",
+      "answer": "yes",
+      "comment": "To už dávno má."
+    },
+    {
+      "id": "komunalni-2022-554821-a-58",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-19",
+      "answer": "yes",
+      "comment": "Participativní rozpočet už u nás existuje."
+    },
+    {
+      "id": "komunalni-2022-554821-a-61",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-20",
+      "answer": "yes",
+      "comment": "I v zahraničí platí úzus, že má město vlastnit okolo 15% bytů, proto aby bylo město schopno disponovat bytovým fondem pro ty, kteří nejsou schopni získat byt na běžném trhu s byty (senioři atd.)"
+    },
+    {
+      "id": "komunalni-2022-554821-a-64",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-67",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-70",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-23",
+      "answer": "no",
+      "comment": "Podporujme sdílená kola a koloběžky, carsharing nechejme trhu, určitě ho nedotujme."
+    },
+    {
+      "id": "komunalni-2022-554821-a-73",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-76",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-25",
+      "comment": "Není to reálné vzhledem ke kapacitám a rozdílný struktuře městských obvodů a jejich možnostem. Jsme pro jednotnou parkovací kartu na placených parkovištích. Jeden systém. "
+    },
+    {
+      "id": "komunalni-2022-554821-a-79",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-82",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-27",
+      "answer": "yes",
+      "comment": "Nedá se to paušalizovat, protože jsou individuální podmínky pro zástavbu lokalit."
+    },
+    {
+      "id": "komunalni-2022-554821-a-85",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-28",
+      "answer": "no",
+      "comment": "Všechny dopravy si mají být rovny."
+    },
+    {
+      "id": "komunalni-2022-554821-a-88",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-91",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-30",
+      "comment": "Postupuje se v jednotlivých případech individuálně. "
+    },
+    {
+      "id": "komunalni-2022-554821-a-94",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-97",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-100",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-103",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-106",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-35",
+      "comment": "Záleží na typu místa a akce."
+    },
+    {
+      "id": "komunalni-2022-554821-a-109",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-36"
+    },
+    {
+      "id": "komunalni-2022-554821-a-112",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-115",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-118",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-121",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-124",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-127",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-130",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-133",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-44",
+      "answer": "yes",
+      "comment": "Důležité jsou pro nás investice především do infrastruktury."
+    },
+    {
+      "id": "komunalni-2022-554821-a-136",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-139",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-46",
+      "answer": "no",
+      "comment": "Od toho tu je stát."
+    },
+    {
+      "id": "komunalni-2022-554821-a-142",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-145",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-148",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-151",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-50",
+      "answer": "yes",
+      "comment": "Důležitý je pro nás rozvoj FBI na VŠB."
+    },
+    {
+      "id": "komunalni-2022-554821-a-154",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-51",
+      "comment": "Ostrava v rámci legislativy tyto věci neřídí. Je to v kompetenci kraje."
+    },
+    {
+      "id": "komunalni-2022-554821-a-157",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-160",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-163",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-166",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-169",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-172",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-57",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-175",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-178",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-59"
+    },
+    {
+      "id": "komunalni-2022-554821-a-181",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-60",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-184",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-61",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554821-a-187",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-62"
+    },
+    {
+      "id": "komunalni-2022-554821-a-190",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-63",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554821-a-193",
+      "candidate_id": "komunalni-2022-554821-c-364233",
+      "question_id": "komunalni-2022-554821-q-64"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/554961.json
+++ b/data/kalkulacka/komunalni-2022/554961.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-554961",
   "name": "Karlovy Vary",
-  "description": "Karlovy Vary - DESCRIPTION",
+  "description": "Karlovy Vary",
   "district_code": "554961",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-554961-question-1",
+      "id": "komunalni-2022-554961-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-2",
+      "id": "komunalni-2022-554961-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-3",
+      "id": "komunalni-2022-554961-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-4",
+      "id": "komunalni-2022-554961-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-5",
+      "id": "komunalni-2022-554961-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-6",
+      "id": "komunalni-2022-554961-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-7",
+      "id": "komunalni-2022-554961-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-8",
+      "id": "komunalni-2022-554961-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-9",
+      "id": "komunalni-2022-554961-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-10",
+      "id": "komunalni-2022-554961-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-11",
+      "id": "komunalni-2022-554961-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-12",
+      "id": "komunalni-2022-554961-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-13",
+      "id": "komunalni-2022-554961-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-14",
+      "id": "komunalni-2022-554961-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-15",
+      "id": "komunalni-2022-554961-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-16",
+      "id": "komunalni-2022-554961-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-17",
+      "id": "komunalni-2022-554961-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-18",
+      "id": "komunalni-2022-554961-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-19",
+      "id": "komunalni-2022-554961-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-20",
+      "id": "komunalni-2022-554961-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-21",
+      "id": "komunalni-2022-554961-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-22",
+      "id": "komunalni-2022-554961-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-23",
+      "id": "komunalni-2022-554961-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-24",
+      "id": "komunalni-2022-554961-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-25",
+      "id": "komunalni-2022-554961-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-26",
+      "id": "komunalni-2022-554961-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-27",
+      "id": "komunalni-2022-554961-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-28",
+      "id": "komunalni-2022-554961-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-29",
+      "id": "komunalni-2022-554961-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-30",
+      "id": "komunalni-2022-554961-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-31",
+      "id": "komunalni-2022-554961-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-32",
+      "id": "komunalni-2022-554961-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-33",
+      "id": "komunalni-2022-554961-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-34",
+      "id": "komunalni-2022-554961-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-35",
+      "id": "komunalni-2022-554961-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-36",
+      "id": "komunalni-2022-554961-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-37",
+      "id": "komunalni-2022-554961-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-38",
+      "id": "komunalni-2022-554961-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-39",
+      "id": "komunalni-2022-554961-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-40",
+      "id": "komunalni-2022-554961-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-41",
+      "id": "komunalni-2022-554961-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-42",
+      "id": "komunalni-2022-554961-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-43",
+      "id": "komunalni-2022-554961-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-44",
+      "id": "komunalni-2022-554961-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-45",
+      "id": "komunalni-2022-554961-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-46",
+      "id": "komunalni-2022-554961-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-47",
+      "id": "komunalni-2022-554961-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-554961-question-48",
+      "id": "komunalni-2022-554961-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,16 +399,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-554961-candidate-928456",
+      "id": "komunalni-2022-554961-c-928456",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554961-928456-party",
+          "id": "komunalni-2022-554961-c-928456-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -417,16 +420,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554961-candidate-973378",
+      "id": "komunalni-2022-554961-c-973378",
       "name": "Česká strana sociálně demokratická",
       "type": "party",
       "description": "Česká strana sociálně demokratická - DESCRIPTION",
+      "img_url": "čssd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554961-973378-party",
+          "id": "komunalni-2022-554961-c-973378-p",
           "name": "Česká strana sociálně demokratická",
           "description": "Česká strana sociálně demokratická - DESCRIPTION",
           "contacts": {
@@ -437,10 +441,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554961-candidate-298970",
+      "id": "komunalni-2022-554961-c-298970",
       "name": "Karlovarská občanská alternativa",
       "type": "party",
       "description": "Karlovarská občanská alternativa - DESCRIPTION",
+      "img_url": "koa",
       "contacts": {
         "web": [
           {
@@ -451,7 +456,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554961-298970-party",
+          "id": "komunalni-2022-554961-c-298970-p",
           "name": "Karlovarská občanská alternativa",
           "description": "Karlovarská občanská alternativa - DESCRIPTION",
           "contacts": {
@@ -467,16 +472,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554961-candidate-774329",
+      "id": "komunalni-2022-554961-c-774329",
       "name": "SRDCEM PRO VARY",
       "type": "party",
       "description": "SRDCEM PRO VARY - DESCRIPTION",
+      "img_url": "srdcem pro-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554961-774329-party",
+          "id": "komunalni-2022-554961-c-774329-p",
           "name": "SRDCEM PRO VARY",
           "description": "SRDCEM PRO VARY - DESCRIPTION",
           "contacts": {
@@ -487,16 +493,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554961-candidate-762265",
+      "id": "komunalni-2022-554961-c-762265",
       "name": "Spojené Síly",
       "type": "party",
       "description": "Spojené Síly - DESCRIPTION",
+      "img_url": "bez-ul-pes",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554961-762265-party",
+          "id": "komunalni-2022-554961-c-762265-p",
           "name": "Spojené Síly",
           "description": "Spojené Síly - DESCRIPTION",
           "contacts": {
@@ -507,10 +514,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554961-candidate-552603",
+      "id": "komunalni-2022-554961-c-552603",
       "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty, strana Právo Respekt Odbornost a nezávislí kandidáti",
       "type": "party",
       "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty, strana Právo Respekt Odbornost a nezávislí kandidáti - DESCRIPTION",
+      "img_url": "přís-pro2022-nk",
       "contacts": {
         "web": [
           {
@@ -521,7 +529,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554961-552603-party",
+          "id": "komunalni-2022-554961-c-552603-p",
           "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty, strana Právo Respekt Odbornost a nezávislí kandidáti",
           "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty, strana Právo Respekt Odbornost a nezávislí kandidáti - DESCRIPTION",
           "contacts": {
@@ -537,16 +545,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554961-candidate-971833",
+      "id": "komunalni-2022-554961-c-971833",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
       "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "img_url": "stan",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554961-971833-party",
+          "id": "komunalni-2022-554961-c-971833-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
           "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
           "contacts": {
@@ -557,17 +566,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-554961-candidate-838041",
+      "id": "komunalni-2022-554961-c-838041",
       "name": "SPOLU (ODS, KDU-ČSL, TOP 09)",
       "type": "party",
       "description": "SPOLU (ODS, KDU-ČSL, TOP 09) - DESCRIPTION",
+      "img_url": "kdu-ods-top 09",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/vanecek.jiri73/"
       },
       "parties": [
         {
-          "id": "komunalni-2022-554961-838041-party",
+          "id": "komunalni-2022-554961-c-838041-p",
           "name": "SPOLU (ODS, KDU-ČSL, TOP 09)",
           "description": "SPOLU (ODS, KDU-ČSL, TOP 09) - DESCRIPTION",
           "contacts": {
@@ -579,16 +589,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554961-candidate-478898",
+      "id": "komunalni-2022-554961-c-478898",
       "name": "Trikolora",
       "type": "party",
       "description": "Trikolora - DESCRIPTION",
+      "img_url": "trikolora",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554961-478898-party",
+          "id": "komunalni-2022-554961-c-478898-p",
           "name": "Trikolora",
           "description": "Trikolora - DESCRIPTION",
           "contacts": {
@@ -599,16 +610,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554961-candidate-876399",
+      "id": "komunalni-2022-554961-c-876399",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554961-876399-party",
+          "id": "komunalni-2022-554961-c-876399-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -619,10 +631,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554961-candidate-833611",
+      "id": "komunalni-2022-554961-c-833611",
       "name": "Karlovaráci",
       "type": "party",
       "description": "Karlovaráci - DESCRIPTION",
+      "img_url": "kvc",
       "contacts": {
         "web": [
           {
@@ -638,7 +651,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554961-833611-party",
+          "id": "komunalni-2022-554961-c-833611-p",
           "name": "Karlovaráci",
           "description": "Karlovaráci - DESCRIPTION",
           "contacts": {
@@ -659,16 +672,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-554961-candidate-518114",
+      "id": "komunalni-2022-554961-c-518114",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-554961-518114-party",
+          "id": "komunalni-2022-554961-c-518114-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -679,10 +693,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-554961-candidate-260016",
+      "id": "komunalni-2022-554961-c-260016",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": [
           {
@@ -698,7 +713,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-554961-260016-party",
+          "id": "komunalni-2022-554961-c-260016-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -721,956 +736,956 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-554961-answer-552603-1",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-1",
+      "id": "komunalni-2022-554961-a-4",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-1",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-2",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-2",
+      "id": "komunalni-2022-554961-a-7",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-2",
       "answer": "yes",
       "comment": "Co je zdarma, toho si nevážíme, navíc zrušení poplatků za svoz komunálního odpadu by logicky zvýšilo množství tříděného odpadu, který by skončil v komunálním odpadu, odpadla by ekonomická motivace občanů k třídění odpadů. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-3",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-3",
+      "id": "komunalni-2022-554961-a-10",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-3",
       "answer": "no",
       "comment": "Senioři jsou podobně jako malé děti a zdravotně postižení náchylnější k prochladnutí a následně onemocněním. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-4",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-4",
+      "id": "komunalni-2022-554961-a-13",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-4",
       "answer": "no",
       "comment": "Ani stávající omezení v obcích 50 km/h. není dodržováno a kontrolováno. Domnívám se, že rychlost 50 km/h. je bezpečná a například do pěších zón nepatří vozidla /krom zásobování a veřejné hromadné dopravy/ vůbec. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-5",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-5",
+      "id": "komunalni-2022-554961-a-16",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-5",
       "answer": "no",
       "comment": "Dlužníci jsou velice schopní si informace najít na dostupných portálech obcí a měst. V této oblasti skutečně není zapotřebí vynakládat další čas a prostředky na šíření potřebných informací každému jednotlivci. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-6",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-6",
+      "id": "komunalni-2022-554961-a-19",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-6",
       "answer": "no",
       "comment": "Ani stávající počet kamer MP nevyužívá. Osobní zkušenost, celá ulice, ve které bydlím je pod kamerovým systémem, před šesti lety jsem v noci volala MP k případu, kdy vandalové ničili ozdobné koše, když jsem následně vznesla dotaz, zda celý incident neviděli na kamerách, bylo mi odpovězeno, že vyjíždí až na základě oznámení. Nač tedy kamery ? "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-7",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-7",
+      "id": "komunalni-2022-554961-a-22",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-7",
       "answer": "yes",
       "comment": "Ekonomický výnos z hazardu v žádném případě nepokryje náklady, které jsou s ním spojené - exekuce, zadluženost rodin, léčba závislosti. Navíc hazard má velice negativní dopad na sociální oblast rodiny. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-8",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-8",
+      "id": "komunalni-2022-554961-a-25",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-8",
       "answer": "no",
       "comment": "Změnila by se v doupě občanů bez domova a nepřizpůsobivých, kteří by naprosto bezcílně jezdili. Jednalo by se o ekonomický zásah ve výši cca 183miliónů, které bychom v městské kase těžko hledali, zcela jistě na úkor jiných položek. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-9",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-9",
+      "id": "komunalni-2022-554961-a-28",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-9",
       "answer": "yes",
       "comment": "Osobní zkušenost z rodiny, bezbariérové přístupy jsou velice potřebně a prostředky na jejich vybudování by se rozhodně najít měly. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-10",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-10",
+      "id": "komunalni-2022-554961-a-31",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-10",
       "answer": "yes",
       "comment": "Naprosto jednoznačné ANO. Každý volič má právo vědět, jak se jeho kandidát i ostatní staví k bodům programu a jak hlasuje. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-11",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-11",
+      "id": "komunalni-2022-554961-a-34",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-11",
       "answer": "yes",
       "comment": "Shodně jako u zastupitelstva. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-12",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-12",
+      "id": "komunalni-2022-554961-a-37",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-12",
       "answer": "yes",
       "comment": "Rozhodně ANO. Nejen kvůli zvířatům, která trpí (sama mám doma čtyři, z toho dva totální bojáky), ale i kvůli starším lidem, osobně jsem byla přítomna situace, kdy \"obyčejná\" prskací kulička bouchla starší paní přímo před nohama a málem to odnesla na zdraví. Ve městech a obcích máme nárok na klid (zvláště pak ve městě lázeňském, kde klid je součástí léčby). Chápu, že lidé se na Slivestra chtějí bavit a někteří si zábavu bez pyrotechniky neumí představit, ale povolená by měla býti pouze na tento ten například od 23:00 do 03:00 dne 01.01.. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-13",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-13",
+      "id": "komunalni-2022-554961-a-40",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-13",
       "answer": "yes",
       "comment": "Při zajištění bezpečnosti těchto osob i okolí, tzn. vstup umožnit pouze lidem, kteří nebudou pod vlivem alkoholu (jiných návykových látek). Vůbec bych se nebránila i dovybavení těchto prostor z rozpočtu magistrátu sociálním zařízením s možností osprchování a podávání potravin a teplých nápojů zdarma. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-14",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-14",
+      "id": "komunalni-2022-554961-a-43",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-15",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-15",
+      "id": "komunalni-2022-554961-a-46",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-15",
       "answer": "no",
       "comment": "Bezpečnost obyvatel. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-16",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-16",
+      "id": "komunalni-2022-554961-a-49",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-16",
       "answer": "yes",
       "comment": "Všude je přetopeno, doslova a do písmene se vytápí chodby, jen vstoupíte do budovy, odkládáte svrchní části oděvu. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-17",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-17",
+      "id": "komunalni-2022-554961-a-52",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-17",
       "answer": "no",
       "comment": "To by měli dlužníci velice jednoduché a nevedlo by to k ekonomické zodpovědnosti obyvatel města. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-18",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-18",
+      "id": "komunalni-2022-554961-a-55",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-18",
       "answer": "yes",
       "comment": "Jedná se povětšinou o prostředky plynoucí z daní a poplatků, měli bychom tedy mít možnost vědět, jakým způsobem je s nimi nakládáno. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-19",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-19",
+      "id": "komunalni-2022-554961-a-58",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-19",
       "answer": "yes",
       "comment": "Občané sami nejlépe vědí, co v kterých lokalitách postrádají, případně jaké oblasti by rádi podpořili. Je nesmyslné podporovat například hokej a naopak krasobruslení ponechat naprosto mimo zájem radnice. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-20",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-20",
+      "id": "komunalni-2022-554961-a-61",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-20",
       "answer": "yes",
       "comment": "Možnost pronájmů formou sociálních (startovacích) bytů, prodej formou motivačního bydlení, nabídka ubytování profesím, které ve městě chybí. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-21",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-21",
+      "id": "komunalni-2022-554961-a-64",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-21",
       "answer": "yes",
       "comment": "Myslím, že stačí přeplácané výlohy obchodních řetězců, které s výzdobou začínají již od října a doma si určitě každý výzdobu zpracuje dle svého vkusu. Úspora prostředků v obecní kase by určitě byla značná. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-22",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-22",
+      "id": "komunalni-2022-554961-a-67",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-22",
       "answer": "no",
       "comment": "Citelný zásah do rozpočtu města. Většina rodin takovýto bonus nepotřebuje, děti ze sociálně slabších rodin již nyní mohou dosáhnout na dotaci z MŠMT formou \"Obědů do škol\", nebo dar společnosti women for women. Navíc pokud by obědy byly zdarma, nikdo by je neodhlašoval, docházelo by k velkému plýtvání surovinami, energiemi i prací zaměstnanců ŠJ. A zkuste se někdy zajít podívat do jídelen, teriny s polévkami zůstávají bez povšimnutí žáků, o ovoce a zeleninu není vůbec zájem a z hlavního jídla v 30% skončí více než polovina v nádobách na zbytky. Osvícené školy již kompostují, ostatní vyhazují do TKO, což vede k rozšíření hlodavců, ale to jsem trošku odbočila. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-23",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-23"
+      "id": "komunalni-2022-554961-a-70",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-23"
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-24",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-24",
+      "id": "komunalni-2022-554961-a-73",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-24",
       "answer": "no",
       "comment": "To už by obyvatelé, kteří ve středu města bydlí nezaparkovali vůbec. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-25",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-25",
+      "id": "komunalni-2022-554961-a-76",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-25",
       "answer": "no",
       "comment": "Naopak má míti snahu o odkup bytů-viz. odpověď na otázku číslo 20. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-26",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-26",
+      "id": "komunalni-2022-554961-a-79",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-26",
       "answer": "yes",
       "comment": "Rozhodně, nemohou z projektů chtít pouze zisky. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-27",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-27",
+      "id": "komunalni-2022-554961-a-82",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-27",
       "answer": "yes",
       "comment": "Ekologie, finanční dopad, zrychlení dopravy, zdraví občanů. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-28",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-28",
+      "id": "komunalni-2022-554961-a-85",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-28",
       "answer": "no",
       "comment": "Pokud jsou prázdné /nedochází k jejich pronajímání/ nevidím důvod, proč trestat majitele za jejich vlastnictví, samozřejmě s omezením počtu takto držených nemovitostí. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-29",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-29",
+      "id": "komunalni-2022-554961-a-88",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-30",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-30"
+      "id": "komunalni-2022-554961-a-91",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-30"
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-31",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-31",
+      "id": "komunalni-2022-554961-a-94",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-31",
       "answer": "yes",
       "comment": "Zastavení úbytku obyvatel, možnost získání bydlení i pro střední vrstvu. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-32",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-32",
+      "id": "komunalni-2022-554961-a-97",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-33",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-33",
+      "id": "komunalni-2022-554961-a-100",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-33",
       "answer": "no",
       "comment": "Stejně jako v případě kotlíkových dotací apod. by došlo k selekci a nerovnoprávnému přístupu k žadatelům. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-34",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-34",
+      "id": "komunalni-2022-554961-a-103",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-35",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-35",
+      "id": "komunalni-2022-554961-a-106",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-35",
       "answer": "no",
       "comment": "Naprostá neúcta k ženám /dívkám/ a jejich intimním potřebám. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-36",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-36",
+      "id": "komunalni-2022-554961-a-109",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-36",
       "answer": "no",
       "comment": "Viz. odpověď na otázku číslo 35. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-37",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-37",
+      "id": "komunalni-2022-554961-a-112",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-37",
       "answer": "yes",
       "comment": "Výběrová řízení musí být naprosto transparentní bez zadávání zakázek podnikatelům napojeným na městskou kasu. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-38",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-38",
+      "id": "komunalni-2022-554961-a-115",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-38",
       "answer": "no",
       "comment": "Jejich uživatelé nerespektují žádné předpisy ani obecně zažité normy /prohání se a parkují na chodnících, v případě, kdy se pohybují na silnicích jsou nebezpeční sobě i druhým/. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-39",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-39",
+      "id": "komunalni-2022-554961-a-118",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-39",
       "answer": "yes",
       "comment": "Město musí mít přehled o obyvatelích, které na svém území má (včetně cizinců) a jejich aktivitách. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-40",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-40",
+      "id": "komunalni-2022-554961-a-121",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-40",
       "answer": "no",
       "comment": "Pokud budou vykonávat svojí práci tak, jak mají, nemusí se zvyšovat jejich počet. Zapotřebí je zvýšit pěší hlídky, ztotožnit příslušníky tak, aby vykonávali činnost pokud možno ve stejných lokalitách dlouhodobě, získá se tak důvěra občanů, která je pro součinnost velice důležitá. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-41",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-41",
+      "id": "komunalni-2022-554961-a-124",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-41",
       "answer": "yes",
       "comment": "Bude se nám lépe dýchat a i z estetického hlediska je zelená střecha vhodnější, než plech. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-42",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-42",
+      "id": "komunalni-2022-554961-a-127",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-42",
       "answer": "no",
       "comment": "Rozhodně ne finančně, jednalo by se o \"vyhozené\" peníze oknem. Tuto oblast bych ponechala na osobním rozhodnutí každého z nás. Nebráním se výstavbě cyklostezek. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-43",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-43",
+      "id": "komunalni-2022-554961-a-130",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-43",
       "answer": "no",
       "comment": "Profesionální sportovci nechť se živí ze vstupného. V případě dosažení vynikajících výsledků, kdy budou ochotní reprezentovat město je možné uvažovat o individuálních bonusech. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-44",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-44",
+      "id": "komunalni-2022-554961-a-133",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-44",
       "answer": "no",
       "comment": "Nedomnívám se, že by šlo o závratné částky, které rozpočet rodiny pokládají na lopatky. Jsem ale proti jejich zvyšování. Stávající úroveň je tak akorát. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-45",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-45",
+      "id": "komunalni-2022-554961-a-136",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-45",
       "answer": "yes",
       "comment": "Ale s přísnou kontrolou využívání dávek, prověřením, proč se lidé do sociální tísně dostali, zda předtím přispívali do rozpočtu státu formou daní, nebo se jedná o občany s \"tulení\" nemocí. Pokud si rodina pořídí deset dětí jsem proti tomu, abychom je živili a rodinka se válela u televize a posmívala se ostatním, kteří na ně makají. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-46",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-46",
+      "id": "komunalni-2022-554961-a-139",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-46",
       "answer": "yes",
       "comment": "Viz. odpovědi na otázky číslo 20 a 25. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-47",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-47",
+      "id": "komunalni-2022-554961-a-142",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-47",
       "answer": "yes",
       "comment": "Je lepší děti integrovat do více zařízení, aby se získali sociální návyky, přizpůsobili se ostatním a měli vzor pro další život. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-48",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-48",
+      "id": "komunalni-2022-554961-a-145",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-48",
       "answer": "no",
       "comment": "Do dvou let by se matka měla možnost plně dítěti věnovat. Co po psychické stránce dítě ztratí ve věku do tří let už nikdy nedožene a mluvím z vlastní zkušenosti, jsem dítě \"odkojené\" týdenními jesličkami. "
     },
     {
-      "id": "komunalni-2022-554961-answer-552603-49",
-      "candidate_id": "komunalni-2022-554961-candidate-552603",
-      "question_id": "komunalni-2022-554961-question-49",
+      "id": "komunalni-2022-554961-a-148",
+      "candidate_id": "komunalni-2022-554961-c-552603",
+      "question_id": "komunalni-2022-554961-q-49",
       "comment": "Pod čísly 49 až 63 nejsou napsané otázky. "
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-1",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-1",
+      "id": "komunalni-2022-554961-a-4",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-1",
       "answer": "no",
       "comment": "Dávám přednost patriotům a starousedlíkům města, mají mnohem větší právo k bydlení v takových lokalitách, jakými jsou centra měst za běžné náklady na bydlení "
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-2",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-2",
+      "id": "komunalni-2022-554961-a-7",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-2",
       "answer": "yes",
       "comment": "Ale měla by být možnost platit komunální odpad i měsíčně, z důvodu třeba dlouhodobé nepřítomnosti v bytové jednotce"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-3",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-3",
+      "id": "komunalni-2022-554961-a-10",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-3",
       "answer": "no",
       "comment": "Pokud by se začalo omezovat teplo v domovech pro seniory, tak se akorát zvýší lékařská péče a náklady na léky "
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-4",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-4",
+      "id": "komunalni-2022-554961-a-13",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-4",
       "answer": "yes",
       "comment": "nejen rozšířit, ale také permanentně a to úsekově měřit"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-5",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-5",
+      "id": "komunalni-2022-554961-a-16",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-5",
       "answer": "no",
       "comment": "Tohle si musí hlídat každý sám, snad jen třeba dluhy delší jak 5,10 a více let"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-6",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-6",
+      "id": "komunalni-2022-554961-a-19",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-7",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-7",
+      "id": "komunalni-2022-554961-a-22",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-7",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-8",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-8",
+      "id": "komunalni-2022-554961-a-25",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-9",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-9",
+      "id": "komunalni-2022-554961-a-28",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-10",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-10",
+      "id": "komunalni-2022-554961-a-31",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-10",
       "answer": "yes",
       "comment": "Jednoznačně a to včetně hlasování i komisí"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-11",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-11",
+      "id": "komunalni-2022-554961-a-34",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-12",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-12",
+      "id": "komunalni-2022-554961-a-37",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-12",
       "comment": "Jde především o to, aby bylo včas oznámeno všem v nejbližším okolí kde se bude střílet den a čas"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-13",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-13",
+      "id": "komunalni-2022-554961-a-40",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-13",
       "answer": "yes",
       "comment": "Za jasných provozních a hygienických podmínek určitě"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-14",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-14",
+      "id": "komunalni-2022-554961-a-43",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-14",
       "answer": "yes",
       "comment": "To už mělo být od objevení el. energie dokonce zákonné"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-15",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-15",
+      "id": "komunalni-2022-554961-a-46",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-15",
       "answer": "yes",
       "comment": "Jednoznačně"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-16",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-16",
+      "id": "komunalni-2022-554961-a-49",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-16",
       "comment": "rozhodně se v takových budovách najdou místa, kde se dokonce přetápí, ale všeobecně by v kancelářích mělo být okolo 22-23°C a na chodbách do 20°C"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-17",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-17",
+      "id": "komunalni-2022-554961-a-52",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-17",
       "answer": "yes",
       "comment": "Pokud to město nevyřeší s rodiči do 1 roku, nemá smysl takové dluhy dětem navyšovat"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-18",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-18",
+      "id": "komunalni-2022-554961-a-55",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-18",
       "answer": "yes",
       "comment": "Jednoznačně ano"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-19",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-19",
+      "id": "komunalni-2022-554961-a-58",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-19",
       "answer": "yes",
       "comment": "Vždyť to jsou i jejich peníze"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-20",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-20",
+      "id": "komunalni-2022-554961-a-61",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-20",
       "answer": "yes",
       "comment": "A poskytovat na určitou dobu mladým rodinám a samoživitelkám"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-21",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-21",
+      "id": "komunalni-2022-554961-a-64",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-21",
       "answer": "yes",
       "comment": "Vánoce jsou hezké při svíčkách a město nemusí svítit jako ve dne za sluníčka, alespoň lépe vynikne Vánoční výzdoba města o budov"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-22",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-22",
+      "id": "komunalni-2022-554961-a-67",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-22",
       "answer": "yes",
       "comment": "Alespoň v takových situacích, jako je zásah třetí moci, nebo energetická krize"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-23",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-23"
+      "id": "komunalni-2022-554961-a-70",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-23"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-24",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-24",
+      "id": "komunalni-2022-554961-a-73",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-24",
       "answer": "no",
       "comment": "Parkování ve městě by mělo být především pro rezidenty a  pro turisty a návštěvníky by měla být vybudována záchytná parkoviště na okrajích měst"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-25",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-25",
+      "id": "komunalni-2022-554961-a-76",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-26",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-26",
+      "id": "komunalni-2022-554961-a-79",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-27",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-27"
+      "id": "komunalni-2022-554961-a-82",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-27"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-28",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-28",
+      "id": "komunalni-2022-554961-a-85",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-29",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-29"
+      "id": "komunalni-2022-554961-a-88",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-29"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-30",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-30"
+      "id": "komunalni-2022-554961-a-91",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-30"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-31",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-31",
+      "id": "komunalni-2022-554961-a-94",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-32",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-32",
+      "id": "komunalni-2022-554961-a-97",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-32",
       "comment": "Do 16-ti let ano"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-33",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-33",
+      "id": "komunalni-2022-554961-a-100",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-34",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-34",
+      "id": "komunalni-2022-554961-a-103",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-35",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-35",
+      "id": "komunalni-2022-554961-a-106",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-36",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-36",
+      "id": "komunalni-2022-554961-a-109",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-37",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-37",
+      "id": "komunalni-2022-554961-a-112",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-37",
       "answer": "yes",
       "comment": "Rozhodně ano"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-38",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-38"
+      "id": "komunalni-2022-554961-a-115",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-38"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-39",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-39",
+      "id": "komunalni-2022-554961-a-118",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-40",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-40",
+      "id": "komunalni-2022-554961-a-121",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-40",
       "comment": "Myslím si, že by stačilo více finančně motivat současný počet strážníků a poskytovat více školení k chování pro výkon služby"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-41",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-41"
+      "id": "komunalni-2022-554961-a-124",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-41"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-42",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-42",
+      "id": "komunalni-2022-554961-a-127",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-43",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-43",
+      "id": "komunalni-2022-554961-a-130",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-43",
       "answer": "yes",
       "comment": "Podporovat ano, vstupovat vlastnicky nikoliv"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-44",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-44",
+      "id": "komunalni-2022-554961-a-133",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-44",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-45",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-45",
+      "id": "komunalni-2022-554961-a-136",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-45",
       "answer": "yes",
       "comment": "Za jasných pravidel, kdy bude definována chudoba jedince"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-46",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-46",
+      "id": "komunalni-2022-554961-a-139",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-47",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-47"
+      "id": "komunalni-2022-554961-a-142",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-47"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-48",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-48",
+      "id": "komunalni-2022-554961-a-145",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-48",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554961-answer-774329-49",
-      "candidate_id": "komunalni-2022-554961-candidate-774329",
-      "question_id": "komunalni-2022-554961-question-49",
+      "id": "komunalni-2022-554961-a-148",
+      "candidate_id": "komunalni-2022-554961-c-774329",
+      "question_id": "komunalni-2022-554961-q-49",
       "comment": "Díky za témata a jsem moc rád, že jsem byl součástí dotazníku začínajícího politika, dělá te to prostě dobře :) "
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-1",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-1",
+      "id": "komunalni-2022-554961-a-4",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-2",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-2",
+      "id": "komunalni-2022-554961-a-7",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-2",
       "answer": "yes",
       "comment": "Spolufinancování je v pořádku. Ne pouze v případě  přebytkového rozpočtu jako služba veřejnosti."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-3",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-3",
+      "id": "komunalni-2022-554961-a-10",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-4",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-4",
+      "id": "komunalni-2022-554961-a-13",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-4",
       "answer": "no",
       "comment": "Obytné zóny jsou řešené vlastním dopravním značením a omezení rychlosti na 20 kilometrů v hodině, na  zavádění nevidím vhodnou lokalitu, obecně by to znamenalo zhuštění a zhoršení dopravy."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-5",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-5",
+      "id": "komunalni-2022-554961-a-16",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-5",
       "answer": "no",
       "comment": "Akce vytváří příležitost vyřešit problém, dlužník by měl v tomto směru projevit také vlastní ochotu věc řešit a být alespoň trochu aktivní. Informace o akci jsou veřejně známe."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-6",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-6",
+      "id": "komunalni-2022-554961-a-19",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-6",
       "answer": "yes",
       "comment": "V rizikových mistech maji své opodstatnění z hlediska prevenci i následné objasněnosti."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-7",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-7",
+      "id": "komunalni-2022-554961-a-22",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-7",
       "answer": "no",
       "comment": "Úplný zákaz vytváří prostor pro nelegální nekontrolované herny – viz Cheb."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-8",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-8",
+      "id": "komunalni-2022-554961-a-25",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-8",
       "answer": "no",
       "comment": "Ano pouze v případě  přebytkového rozpočtu jako služba veřejnosti."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-9",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-9",
+      "id": "komunalni-2022-554961-a-28",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-9",
       "answer": "no",
       "comment": "Tento problém nevnímám. Zastávky mají normovanou nastupní hranu a vozidla MHD jsou nízkopodlažní s plošinou pro nástup invalidů - řidiči mají za povinnost při nástupu a výstupu pomoci."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-10",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-10",
+      "id": "komunalni-2022-554961-a-31",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-11",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-11",
+      "id": "komunalni-2022-554961-a-34",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-12",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-12",
+      "id": "komunalni-2022-554961-a-37",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-12",
       "answer": "no",
       "comment": "Ne, ale podléhat schváleni."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-13",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-13",
+      "id": "komunalni-2022-554961-a-40",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-13",
       "answer": "yes",
       "comment": "Součastnost : Budova Vřidla + budova Dolního nádraží kde je město spolu vlastníkem."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-14",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-14",
+      "id": "komunalni-2022-554961-a-43",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-14",
       "answer": "no",
       "comment": "Tato konkrétní úspora by snížila turistickou atraktivitu. Samozřejmě existuje rozměr krize kdy by to bylo nezbytně nutné."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-15",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-15",
+      "id": "komunalni-2022-554961-a-46",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-15",
       "answer": "no",
       "comment": "U VO by se mělo investovat do úsporné technologie."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-16",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-16",
+      "id": "komunalni-2022-554961-a-49",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-16",
       "answer": "no",
       "comment": "Hledání energetických úspor ano, revize efektivity vytápěných prostor s ohledem na jejich účel a využití ano. Plošně - ne"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-17",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-17",
+      "id": "komunalni-2022-554961-a-52",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-18",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-18",
+      "id": "komunalni-2022-554961-a-55",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-19",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-19",
+      "id": "komunalni-2022-554961-a-58",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-19",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-20",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-20",
+      "id": "komunalni-2022-554961-a-61",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-20",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-21",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-21",
+      "id": "komunalni-2022-554961-a-64",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-21",
       "answer": "no",
       "comment": "Toto veřejné osvětlení by mělo být za použití moderních usporných technologii napr LED "
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-22",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-22",
+      "id": "komunalni-2022-554961-a-67",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-22",
       "answer": "no",
       "comment": "Zdarma ne ale měl by být cenově dostupné a reálné pro všechny sociální skupiny."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-23",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-23",
+      "id": "komunalni-2022-554961-a-70",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-24",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-24",
+      "id": "komunalni-2022-554961-a-73",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-25",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-25",
+      "id": "komunalni-2022-554961-a-76",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-25",
       "answer": "no",
       "comment": "Masivní privatizace již proběhla, stávající stav by neměl být dále privatizován."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-26",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-26",
+      "id": "komunalni-2022-554961-a-79",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-27",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-27",
+      "id": "komunalni-2022-554961-a-82",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-27",
       "answer": "no",
       "comment": "Nelze takto uplatňovat plošně na celé území. V lázeňském území tomu tak je."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-28",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-28",
+      "id": "komunalni-2022-554961-a-85",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-29",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-29",
+      "id": "komunalni-2022-554961-a-88",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-30",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-30",
+      "id": "komunalni-2022-554961-a-91",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-31",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-31",
+      "id": "komunalni-2022-554961-a-94",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-32",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-32",
+      "id": "komunalni-2022-554961-a-97",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-32",
       "answer": "no",
       "comment": "Jsem pro značně zvýhodněné tarify děti studenti důchodci. Není jediná varianta plná cena versus zadarmo."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-33",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-33",
+      "id": "komunalni-2022-554961-a-100",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-34",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-34",
+      "id": "komunalni-2022-554961-a-103",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-35",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-35"
+      "id": "komunalni-2022-554961-a-106",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-35"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-36",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-36"
+      "id": "komunalni-2022-554961-a-109",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-36"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-37",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-37",
+      "id": "komunalni-2022-554961-a-112",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-38",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-38",
+      "id": "komunalni-2022-554961-a-115",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-38",
       "answer": "no",
       "comment": "S ohledem na množství těchto dopravních prostředků mezi obyvateli je spíše aktuální začít nastavovat specifická pravidla pro jejich provoz."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-39",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-39",
+      "id": "komunalni-2022-554961-a-118",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-40",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-40",
+      "id": "komunalni-2022-554961-a-121",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-41",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-41",
+      "id": "komunalni-2022-554961-a-124",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-42",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-42",
+      "id": "komunalni-2022-554961-a-127",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-42",
       "answer": "no",
       "comment": "MHD"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-43",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-43",
+      "id": "komunalni-2022-554961-a-130",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-44",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-44",
+      "id": "komunalni-2022-554961-a-133",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-44",
       "answer": "no",
       "comment": "Daleko aktuálnější je dělat vše proto aby se nemusela zvyšovat."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-45",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-45",
+      "id": "komunalni-2022-554961-a-136",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-45",
       "answer": "no",
       "comment": "Nikoliv přímo ale prostřednictvím organizací typu Charita a Armáda spásy"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-46",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-46",
+      "id": "komunalni-2022-554961-a-139",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-46",
       "answer": "no",
       "comment": "Udržovat rozhodně ano, budovat prostřednictvím družstevní výstavby nikoliv vlastní investicí."
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-47",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-47",
+      "id": "komunalni-2022-554961-a-142",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-48",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-48",
+      "id": "komunalni-2022-554961-a-145",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554961-answer-838041-49",
-      "candidate_id": "komunalni-2022-554961-candidate-838041",
-      "question_id": "komunalni-2022-554961-question-49"
+      "id": "komunalni-2022-554961-a-148",
+      "candidate_id": "komunalni-2022-554961-c-838041",
+      "question_id": "komunalni-2022-554961-q-49"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/555088.json
+++ b/data/kalkulacka/komunalni-2022/555088.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-555088",
   "name": "Havířov",
-  "description": "Havířov - DESCRIPTION",
+  "description": "Havířov",
   "district_code": "555088",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-555088-question-1",
+      "id": "komunalni-2022-555088-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-2",
+      "id": "komunalni-2022-555088-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-3",
+      "id": "komunalni-2022-555088-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-4",
+      "id": "komunalni-2022-555088-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-5",
+      "id": "komunalni-2022-555088-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-6",
+      "id": "komunalni-2022-555088-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-7",
+      "id": "komunalni-2022-555088-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-8",
+      "id": "komunalni-2022-555088-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-9",
+      "id": "komunalni-2022-555088-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-10",
+      "id": "komunalni-2022-555088-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-11",
+      "id": "komunalni-2022-555088-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-12",
+      "id": "komunalni-2022-555088-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-13",
+      "id": "komunalni-2022-555088-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-14",
+      "id": "komunalni-2022-555088-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-15",
+      "id": "komunalni-2022-555088-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-16",
+      "id": "komunalni-2022-555088-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-17",
+      "id": "komunalni-2022-555088-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-18",
+      "id": "komunalni-2022-555088-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-19",
+      "id": "komunalni-2022-555088-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-20",
+      "id": "komunalni-2022-555088-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-21",
+      "id": "komunalni-2022-555088-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-22",
+      "id": "komunalni-2022-555088-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-23",
+      "id": "komunalni-2022-555088-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-24",
+      "id": "komunalni-2022-555088-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-25",
+      "id": "komunalni-2022-555088-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-26",
+      "id": "komunalni-2022-555088-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-27",
+      "id": "komunalni-2022-555088-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-28",
+      "id": "komunalni-2022-555088-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-29",
+      "id": "komunalni-2022-555088-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-30",
+      "id": "komunalni-2022-555088-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-31",
+      "id": "komunalni-2022-555088-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-32",
+      "id": "komunalni-2022-555088-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-33",
+      "id": "komunalni-2022-555088-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-34",
+      "id": "komunalni-2022-555088-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-35",
+      "id": "komunalni-2022-555088-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-36",
+      "id": "komunalni-2022-555088-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-37",
+      "id": "komunalni-2022-555088-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-38",
+      "id": "komunalni-2022-555088-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-39",
+      "id": "komunalni-2022-555088-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-40",
+      "id": "komunalni-2022-555088-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-41",
+      "id": "komunalni-2022-555088-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-42",
+      "id": "komunalni-2022-555088-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-43",
+      "id": "komunalni-2022-555088-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-44",
+      "id": "komunalni-2022-555088-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-45",
+      "id": "komunalni-2022-555088-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-46",
+      "id": "komunalni-2022-555088-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-47",
+      "id": "komunalni-2022-555088-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555088-question-48",
+      "id": "komunalni-2022-555088-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,16 +399,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-555088-candidate-302627",
+      "id": "komunalni-2022-555088-c-302627",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-555088-302627-party",
+          "id": "komunalni-2022-555088-c-302627-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -417,10 +420,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-555088-candidate-926764",
+      "id": "komunalni-2022-555088-c-926764",
       "name": "Partneři za Havířov",
       "type": "party",
       "description": "Partneři za Havířov - DESCRIPTION",
+      "img_url": "přísaha",
       "contacts": {
         "web": [
           {
@@ -431,7 +435,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-555088-926764-party",
+          "id": "komunalni-2022-555088-c-926764-p",
           "name": "Partneři za Havířov",
           "description": "Partneři za Havířov - DESCRIPTION",
           "contacts": {
@@ -447,10 +451,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-555088-candidate-824293",
+      "id": "komunalni-2022-555088-c-824293",
       "name": "HAVÍŘOV SOBĚ - sdružení hnutí NEZÁVISLÍ, strany Patrioti České republiky, spolku Životice Sobě a nezávislých kandidátů",
       "type": "party",
       "description": "HAVÍŘOV SOBĚ - sdružení hnutí NEZÁVISLÍ, strany Patrioti České republiky, spolku Životice Sobě a nezávislých kandidátů - DESCRIPTION",
+      "img_url": "nez-patričr-nk",
       "contacts": {
         "web": [
           {
@@ -461,7 +466,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-555088-824293-party",
+          "id": "komunalni-2022-555088-c-824293-p",
           "name": "HAVÍŘOV SOBĚ - sdružení hnutí NEZÁVISLÍ, strany Patrioti České republiky, spolku Životice Sobě a nezávislých kandidátů",
           "description": "HAVÍŘOV SOBĚ - sdružení hnutí NEZÁVISLÍ, strany Patrioti České republiky, spolku Životice Sobě a nezávislých kandidátů - DESCRIPTION",
           "contacts": {
@@ -477,17 +482,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-555088-candidate-659291",
+      "id": "komunalni-2022-555088-c-659291",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/piratihavirov"
       },
       "parties": [
         {
-          "id": "komunalni-2022-555088-659291-party",
+          "id": "komunalni-2022-555088-c-659291-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -499,16 +505,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-555088-candidate-665536",
+      "id": "komunalni-2022-555088-c-665536",
       "name": "Česká strana sociálně demokratická a osobnosti města",
       "type": "party",
       "description": "Česká strana sociálně demokratická a osobnosti města - DESCRIPTION",
+      "img_url": "čssd-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-555088-665536-party",
+          "id": "komunalni-2022-555088-c-665536-p",
           "name": "Česká strana sociálně demokratická a osobnosti města",
           "description": "Česká strana sociálně demokratická a osobnosti města - DESCRIPTION",
           "contacts": {
@@ -519,16 +526,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-555088-candidate-806350",
+      "id": "komunalni-2022-555088-c-806350",
       "name": "Hnutí pro Havířov",
       "type": "party",
       "description": "Hnutí pro Havířov - DESCRIPTION",
+      "img_url": "hph",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-555088-806350-party",
+          "id": "komunalni-2022-555088-c-806350-p",
           "name": "Hnutí pro Havířov",
           "description": "Hnutí pro Havířov - DESCRIPTION",
           "contacts": {
@@ -539,16 +547,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-555088-candidate-836700",
+      "id": "komunalni-2022-555088-c-836700",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-555088-836700-party",
+          "id": "komunalni-2022-555088-c-836700-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -559,16 +568,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-555088-candidate-356855",
+      "id": "komunalni-2022-555088-c-356855",
       "name": "Havířov náš domov",
       "type": "party",
       "description": "Havířov náš domov - DESCRIPTION",
+      "img_url": "domov-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-555088-356855-party",
+          "id": "komunalni-2022-555088-c-356855-p",
           "name": "Havířov náš domov",
           "description": "Havířov náš domov - DESCRIPTION",
           "contacts": {
@@ -579,16 +589,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-555088-candidate-197775",
+      "id": "komunalni-2022-555088-c-197775",
       "name": "SPOLU plus - ODS, KDU-ČSL, TOP 09, STAN",
       "type": "party",
       "description": "SPOLU plus - ODS, KDU-ČSL, TOP 09, STAN - DESCRIPTION",
+      "img_url": "kdu-ods-sta-top",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-555088-197775-party",
+          "id": "komunalni-2022-555088-c-197775-p",
           "name": "SPOLU plus - ODS, KDU-ČSL, TOP 09, STAN",
           "description": "SPOLU plus - ODS, KDU-ČSL, TOP 09, STAN - DESCRIPTION",
           "contacts": {
@@ -599,16 +610,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-555088-candidate-524394",
+      "id": "komunalni-2022-555088-c-524394",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-555088-524394-party",
+          "id": "komunalni-2022-555088-c-524394-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -619,5 +631,591 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "komunalni-2022-555088-a-4",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-1",
+      "answer": "no",
+      "comment": "Umím si představit odstupňovanou výši nájemného podle toho, zda dům prošel rekonstrukcí, má nová okna a zateplení pláště budovy, případně stojí na lukrativním místě. Nelze to však vztahovat na širší lokality nebo celé městské části."
+    },
+    {
+      "id": "komunalni-2022-555088-a-7",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-2",
+      "answer": "yes",
+      "comment": "Vytvoříme systém, který bude umět rozlišit místa, kde lidé důsledněji odpad třídí a poplatek by se jim díky tomu snižoval."
+    },
+    {
+      "id": "komunalni-2022-555088-a-10",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-13",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-4"
+    },
+    {
+      "id": "komunalni-2022-555088-a-16",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-19",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-22",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-25",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-8",
+      "comment": "Preferuji udržení ceny jízdného na současné výši, které není nijak vysoké. Jízdné zdarma pro děti, studenty a seniory podporuji. "
+    },
+    {
+      "id": "komunalni-2022-555088-a-28",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-31",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-34",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-37",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-12",
+      "comment": "Používání zábavní pyrotechniky by mělo být regulováno, jsou však i jiné příležitosti, kdy by mohlo být povoleno."
+    },
+    {
+      "id": "komunalni-2022-555088-a-40",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-13",
+      "comment": "Nerozumím otázce, jakých situací by se toto mělo týkat. Pokud jde o osoby bez přístřeší, mohou využívat denní centrum, noclehárnu, azylový dům."
+    },
+    {
+      "id": "komunalni-2022-555088-a-43",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-46",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-15",
+      "comment": "Omezení v některých případech možné je, ulice by však neměly zůstat úplně ve tmě. Raději bych viděl nahrazování svítidel za úspornější."
+    },
+    {
+      "id": "komunalni-2022-555088-a-49",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-16",
+      "answer": "yes",
+      "comment": "Mělo by to však být v souladu s hygienickými normami, pokud v nich lidé tráví více času."
+    },
+    {
+      "id": "komunalni-2022-555088-a-52",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-55",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-58",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-61",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-20",
+      "answer": "no",
+      "comment": "Počty bytů by však nemělo ani snižovat (např. odprodejem)."
+    },
+    {
+      "id": "komunalni-2022-555088-a-64",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-67",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-22",
+      "answer": "yes",
+      "comment": "Pokud se rodiny nacházejí v sociálně nepříznivé situaci."
+    },
+    {
+      "id": "komunalni-2022-555088-a-70",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-73",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-24",
+      "comment": "Systém parkování musíme nastavit a nějaká regulace je na místě. Není nadále únosné, aby se ve městě parkovalo neomezeně s libovolným počtem aut na domácnost."
+    },
+    {
+      "id": "komunalni-2022-555088-a-76",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-79",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-82",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-85",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-88",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-91",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-94",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-97",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-100",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-33",
+      "comment": "Podporujeme fotovoltaiku na střechách a budeme ji budovat na městských budovách. Systém podpory také soukromým vlastníkům je nutné nejprve spravedlivě nastavit (ideálně na základě analýzy konkrétních dopadů na obyvatele)."
+    },
+    {
+      "id": "komunalni-2022-555088-a-103",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-106",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-35",
+      "comment": "Jsem spíše pro, ovšem záleží na konkrétním nastavení a samotném provedení."
+    },
+    {
+      "id": "komunalni-2022-555088-a-109",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-36"
+    },
+    {
+      "id": "komunalni-2022-555088-a-112",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-115",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-38"
+    },
+    {
+      "id": "komunalni-2022-555088-a-118",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-121",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-40"
+    },
+    {
+      "id": "komunalni-2022-555088-a-124",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-127",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-130",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-43",
+      "answer": "yes",
+      "comment": "Na místě je určitá únosná podpora profesionálního sportu za reprezentaci města. Důležité je transparentní rozdělování finančních prostředků i nakládání s nimi. "
+    },
+    {
+      "id": "komunalni-2022-555088-a-133",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-136",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-45",
+      "comment": "Preferuji dostupnost kvalitních veřejných služeb před přímou finanční podporou. "
+    },
+    {
+      "id": "komunalni-2022-555088-a-139",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-142",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-145",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-148",
+      "candidate_id": "komunalni-2022-555088-c-659291",
+      "question_id": "komunalni-2022-555088-q-49"
+    },
+    {
+      "id": "komunalni-2022-555088-a-4",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-1",
+      "answer": "no",
+      "comment": "Bydlení má být dostupné pro všechny"
+    },
+    {
+      "id": "komunalni-2022-555088-a-7",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-10",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-13",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-16",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-19",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-6"
+    },
+    {
+      "id": "komunalni-2022-555088-a-22",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-25",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-28",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-31",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-34",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-37",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-40",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-43",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-46",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-49",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-52",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-17",
+      "answer": "no",
+      "comment": "Po individuálním posouzení"
+    },
+    {
+      "id": "komunalni-2022-555088-a-55",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-58",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-61",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-64",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-21"
+    },
+    {
+      "id": "komunalni-2022-555088-a-67",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-70",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-73",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-76",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-79",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-82",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-85",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-88",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-91",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-94",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-97",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-100",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-103",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-106",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-35"
+    },
+    {
+      "id": "komunalni-2022-555088-a-109",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-36"
+    },
+    {
+      "id": "komunalni-2022-555088-a-112",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-115",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-118",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-39"
+    },
+    {
+      "id": "komunalni-2022-555088-a-121",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-124",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-127",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-130",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-133",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555088-a-136",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-139",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-142",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-145",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555088-a-148",
+      "candidate_id": "komunalni-2022-555088-c-524394",
+      "question_id": "komunalni-2022-555088-q-49"
+    }
+  ]
 }

--- a/data/kalkulacka/komunalni-2022/555134.json
+++ b/data/kalkulacka/komunalni-2022/555134.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-555134",
   "name": "Pardubice",
-  "description": "Pardubice - DESCRIPTION",
+  "description": "Pardubice",
   "district_code": "555134",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-555134-question-1",
+      "id": "komunalni-2022-555134-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-2",
+      "id": "komunalni-2022-555134-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-3",
+      "id": "komunalni-2022-555134-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-4",
+      "id": "komunalni-2022-555134-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-5",
+      "id": "komunalni-2022-555134-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-6",
+      "id": "komunalni-2022-555134-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-7",
+      "id": "komunalni-2022-555134-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-8",
+      "id": "komunalni-2022-555134-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-9",
+      "id": "komunalni-2022-555134-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-10",
+      "id": "komunalni-2022-555134-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-11",
+      "id": "komunalni-2022-555134-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-12",
+      "id": "komunalni-2022-555134-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-13",
+      "id": "komunalni-2022-555134-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-14",
+      "id": "komunalni-2022-555134-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-15",
+      "id": "komunalni-2022-555134-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-16",
+      "id": "komunalni-2022-555134-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-17",
+      "id": "komunalni-2022-555134-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-18",
+      "id": "komunalni-2022-555134-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-19",
+      "id": "komunalni-2022-555134-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-20",
+      "id": "komunalni-2022-555134-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-21",
+      "id": "komunalni-2022-555134-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-22",
+      "id": "komunalni-2022-555134-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-23",
+      "id": "komunalni-2022-555134-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-24",
+      "id": "komunalni-2022-555134-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-25",
+      "id": "komunalni-2022-555134-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-26",
+      "id": "komunalni-2022-555134-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-27",
+      "id": "komunalni-2022-555134-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-28",
+      "id": "komunalni-2022-555134-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-29",
+      "id": "komunalni-2022-555134-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-30",
+      "id": "komunalni-2022-555134-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-31",
+      "id": "komunalni-2022-555134-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-32",
+      "id": "komunalni-2022-555134-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-33",
+      "id": "komunalni-2022-555134-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-34",
+      "id": "komunalni-2022-555134-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-35",
+      "id": "komunalni-2022-555134-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-36",
+      "id": "komunalni-2022-555134-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-37",
+      "id": "komunalni-2022-555134-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-38",
+      "id": "komunalni-2022-555134-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-39",
+      "id": "komunalni-2022-555134-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-40",
+      "id": "komunalni-2022-555134-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-41",
+      "id": "komunalni-2022-555134-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-42",
+      "id": "komunalni-2022-555134-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-43",
+      "id": "komunalni-2022-555134-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-44",
+      "id": "komunalni-2022-555134-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-45",
+      "id": "komunalni-2022-555134-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-46",
+      "id": "komunalni-2022-555134-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-47",
+      "id": "komunalni-2022-555134-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-555134-question-48",
+      "id": "komunalni-2022-555134-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,10 +399,11 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-555134-candidate-915355",
+      "id": "komunalni-2022-555134-c-915355",
       "name": "SPOLU (ODS, KDU-ČSL, TOP 09)",
       "type": "party",
       "description": "SPOLU (ODS, KDU-ČSL, TOP 09) - DESCRIPTION",
+      "img_url": "kdu-ods-top 09",
       "contacts": {
         "web": [
           {
@@ -417,7 +420,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-555134-915355-party",
+          "id": "komunalni-2022-555134-c-915355-p",
           "name": "SPOLU (ODS, KDU-ČSL, TOP 09)",
           "description": "SPOLU (ODS, KDU-ČSL, TOP 09) - DESCRIPTION",
           "contacts": {
@@ -439,10 +442,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-555134-candidate-349076",
+      "id": "komunalni-2022-555134-c-349076",
       "name": "Piráti: 42projektu.cz",
       "type": "party",
       "description": "Piráti: 42projektu.cz - DESCRIPTION",
+      "img_url": "zelení-piráti",
       "contacts": {
         "web": [
           {
@@ -458,7 +462,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-555134-349076-party",
+          "id": "komunalni-2022-555134-c-349076-p",
           "name": "Piráti: 42projektu.cz",
           "description": "Piráti: 42projektu.cz - DESCRIPTION",
           "contacts": {
@@ -479,10 +483,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-555134-candidate-280020",
+      "id": "komunalni-2022-555134-c-280020",
       "name": "Žijeme Pardubice",
       "type": "party",
       "description": "Žijeme Pardubice - DESCRIPTION",
+      "img_url": "čssd-pp21-nk",
       "contacts": {
         "web": [
           {
@@ -495,7 +500,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-555134-280020-party",
+          "id": "komunalni-2022-555134-c-280020-p",
           "name": "Žijeme Pardubice",
           "description": "Žijeme Pardubice - DESCRIPTION",
           "contacts": {
@@ -513,10 +518,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-555134-candidate-343643",
+      "id": "komunalni-2022-555134-c-343643",
       "name": "NAŠE PARDUBICE - \"Nechme město rozkvést\"",
       "type": "party",
       "description": "NAŠE PARDUBICE - \"Nechme město rozkvést\" - DESCRIPTION",
+      "img_url": "spdv-nk",
       "contacts": {
         "web": [
           {
@@ -528,7 +534,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-555134-343643-party",
+          "id": "komunalni-2022-555134-c-343643-p",
           "name": "NAŠE PARDUBICE - \"Nechme město rozkvést\"",
           "description": "NAŠE PARDUBICE - \"Nechme město rozkvést\" - DESCRIPTION",
           "contacts": {
@@ -545,10 +551,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-555134-candidate-694313",
+      "id": "komunalni-2022-555134-c-694313",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": [
           {
@@ -560,7 +567,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-555134-694313-party",
+          "id": "komunalni-2022-555134-c-694313-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -577,16 +584,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-555134-candidate-193762",
+      "id": "komunalni-2022-555134-c-193762",
       "name": "SPD a nezávislí s podporou Trikolory",
       "type": "party",
       "description": "SPD a nezávislí s podporou Trikolory - DESCRIPTION",
+      "img_url": "spd-trikol-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-555134-193762-party",
+          "id": "komunalni-2022-555134-c-193762-p",
           "name": "SPD a nezávislí s podporou Trikolory",
           "description": "SPD a nezávislí s podporou Trikolory - DESCRIPTION",
           "contacts": {
@@ -597,10 +605,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-555134-candidate-812723",
+      "id": "komunalni-2022-555134-c-812723",
       "name": "SPOLEČNĚ PRO PARDUBICE (Pardubáci společně, Sdružení pro Pardubice, Pardubice pro lidi)",
       "type": "party",
       "description": "SPOLEČNĚ PRO PARDUBICE (Pardubáci společně, Sdružení pro Pardubice, Pardubice pro lidi) - DESCRIPTION",
+      "img_url": "snk ed-vč-ppl",
       "contacts": {
         "web": [
           {
@@ -616,7 +625,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-555134-812723-party",
+          "id": "komunalni-2022-555134-c-812723-p",
           "name": "SPOLEČNĚ PRO PARDUBICE (Pardubáci společně, Sdružení pro Pardubice, Pardubice pro lidi)",
           "description": "SPOLEČNĚ PRO PARDUBICE (Pardubáci společně, Sdružení pro Pardubice, Pardubice pro lidi) - DESCRIPTION",
           "contacts": {
@@ -637,16 +646,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-555134-candidate-918217",
+      "id": "komunalni-2022-555134-c-918217",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-555134-918217-party",
+          "id": "komunalni-2022-555134-c-918217-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -657,10 +667,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-555134-candidate-188831",
+      "id": "komunalni-2022-555134-c-188831",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
       "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "img_url": "stan",
       "contacts": {
         "web": [
           {
@@ -672,7 +683,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-555134-188831-party",
+          "id": "komunalni-2022-555134-c-188831-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
           "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
           "contacts": {
@@ -691,299 +702,299 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-555134-answer-915355-1",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-1",
+      "id": "komunalni-2022-555134-a-4",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-2",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-2",
+      "id": "komunalni-2022-555134-a-7",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-3",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-3",
+      "id": "komunalni-2022-555134-a-10",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-4",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-4",
+      "id": "komunalni-2022-555134-a-13",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-5",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-5",
+      "id": "komunalni-2022-555134-a-16",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-5",
       "answer": "no",
       "comment": "Dlužníky město informuje prostřednictvím Radničního zpravodaje, webu města a dalších médií."
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-6",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-6",
+      "id": "komunalni-2022-555134-a-19",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-6",
       "answer": "yes",
       "comment": "U nových staveb v majetku města."
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-7",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-7",
+      "id": "komunalni-2022-555134-a-22",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-7",
       "answer": "no",
       "comment": "V případě úplného zákazu by začaly vznikat černé herny."
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-8",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-8",
+      "id": "komunalni-2022-555134-a-25",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-9",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-9",
+      "id": "komunalni-2022-555134-a-28",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-10",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-10",
+      "id": "komunalni-2022-555134-a-31",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-11",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-11",
+      "id": "komunalni-2022-555134-a-34",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-12",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-12",
+      "id": "komunalni-2022-555134-a-37",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-13",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-13",
+      "id": "komunalni-2022-555134-a-40",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-13",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-14",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-14",
+      "id": "komunalni-2022-555134-a-43",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-15",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-15",
+      "id": "komunalni-2022-555134-a-46",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-15",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-16",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-16",
+      "id": "komunalni-2022-555134-a-49",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-16",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-17",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-17",
+      "id": "komunalni-2022-555134-a-52",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-18",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-18",
+      "id": "komunalni-2022-555134-a-55",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-18",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-19",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-19",
+      "id": "komunalni-2022-555134-a-58",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-19",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-20",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-20",
+      "id": "komunalni-2022-555134-a-61",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-20",
       "comment": "Město musí především opravit byty, kterými již disponuje, ale nejsou obyvatelné."
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-21",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-21",
+      "id": "komunalni-2022-555134-a-64",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-21",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-22",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-22",
+      "id": "komunalni-2022-555134-a-67",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-23",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-23",
+      "id": "komunalni-2022-555134-a-70",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-24",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-24",
+      "id": "komunalni-2022-555134-a-73",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-25",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-25",
+      "id": "komunalni-2022-555134-a-76",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-26",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-26",
+      "id": "komunalni-2022-555134-a-79",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-27",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-27",
+      "id": "komunalni-2022-555134-a-82",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-27",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-28",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-28",
+      "id": "komunalni-2022-555134-a-85",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-29",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-29",
+      "id": "komunalni-2022-555134-a-88",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-29",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-30",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-30",
+      "id": "komunalni-2022-555134-a-91",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-30",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-31",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-31",
+      "id": "komunalni-2022-555134-a-94",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-31",
       "comment": "Město by mělo podporovat takové formy bydlení, kde je jeho účast nezbytná kvůli podpoře státu."
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-32",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-32",
+      "id": "komunalni-2022-555134-a-97",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-33",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-33",
+      "id": "komunalni-2022-555134-a-100",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-33",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-34",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-34",
+      "id": "komunalni-2022-555134-a-103",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-35",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-35",
+      "id": "komunalni-2022-555134-a-106",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-36",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-36",
+      "id": "komunalni-2022-555134-a-109",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-37",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-37",
+      "id": "komunalni-2022-555134-a-112",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-38",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-38",
+      "id": "komunalni-2022-555134-a-115",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-39",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-39",
+      "id": "komunalni-2022-555134-a-118",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-40",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-40",
+      "id": "komunalni-2022-555134-a-121",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-40",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-41",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-41",
+      "id": "komunalni-2022-555134-a-124",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-42",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-42"
+      "id": "komunalni-2022-555134-a-127",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-42"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-43",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-43",
+      "id": "komunalni-2022-555134-a-130",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-44",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-44",
+      "id": "komunalni-2022-555134-a-133",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-45",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-45",
+      "id": "komunalni-2022-555134-a-136",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-45",
       "answer": "no",
       "comment": "Město má vytvářet takové podmínky, aby občanům chudoba nehrozila."
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-46",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-46",
+      "id": "komunalni-2022-555134-a-139",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-47",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-47",
+      "id": "komunalni-2022-555134-a-142",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-48",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-48"
+      "id": "komunalni-2022-555134-a-145",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-48"
     },
     {
-      "id": "komunalni-2022-555134-answer-915355-49",
-      "candidate_id": "komunalni-2022-555134-candidate-915355",
-      "question_id": "komunalni-2022-555134-question-49"
+      "id": "komunalni-2022-555134-a-148",
+      "candidate_id": "komunalni-2022-555134-c-915355",
+      "question_id": "komunalni-2022-555134-q-49"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/561380.json
+++ b/data/kalkulacka/komunalni-2022/561380.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-561380",
   "name": "Česká Lípa",
-  "description": "Česká Lípa - DESCRIPTION",
+  "description": "Česká Lípa",
   "district_code": "561380",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-561380-question-1",
+      "id": "komunalni-2022-561380-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-2",
+      "id": "komunalni-2022-561380-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-3",
+      "id": "komunalni-2022-561380-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-4",
+      "id": "komunalni-2022-561380-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-5",
+      "id": "komunalni-2022-561380-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-6",
+      "id": "komunalni-2022-561380-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-7",
+      "id": "komunalni-2022-561380-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-8",
+      "id": "komunalni-2022-561380-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-9",
+      "id": "komunalni-2022-561380-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-10",
+      "id": "komunalni-2022-561380-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-11",
+      "id": "komunalni-2022-561380-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-12",
+      "id": "komunalni-2022-561380-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-13",
+      "id": "komunalni-2022-561380-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-14",
+      "id": "komunalni-2022-561380-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-15",
+      "id": "komunalni-2022-561380-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-16",
+      "id": "komunalni-2022-561380-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-17",
+      "id": "komunalni-2022-561380-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-18",
+      "id": "komunalni-2022-561380-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-19",
+      "id": "komunalni-2022-561380-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-20",
+      "id": "komunalni-2022-561380-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-21",
+      "id": "komunalni-2022-561380-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-22",
+      "id": "komunalni-2022-561380-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-23",
+      "id": "komunalni-2022-561380-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-24",
+      "id": "komunalni-2022-561380-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-25",
+      "id": "komunalni-2022-561380-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-26",
+      "id": "komunalni-2022-561380-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-27",
+      "id": "komunalni-2022-561380-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-28",
+      "id": "komunalni-2022-561380-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-29",
+      "id": "komunalni-2022-561380-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-30",
+      "id": "komunalni-2022-561380-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-31",
+      "id": "komunalni-2022-561380-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-32",
+      "id": "komunalni-2022-561380-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-33",
+      "id": "komunalni-2022-561380-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-34",
+      "id": "komunalni-2022-561380-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-35",
+      "id": "komunalni-2022-561380-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-36",
+      "id": "komunalni-2022-561380-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-37",
+      "id": "komunalni-2022-561380-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-38",
+      "id": "komunalni-2022-561380-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-39",
+      "id": "komunalni-2022-561380-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-40",
+      "id": "komunalni-2022-561380-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-41",
+      "id": "komunalni-2022-561380-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-42",
+      "id": "komunalni-2022-561380-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-43",
+      "id": "komunalni-2022-561380-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-44",
+      "id": "komunalni-2022-561380-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-45",
+      "id": "komunalni-2022-561380-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-46",
+      "id": "komunalni-2022-561380-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-47",
+      "id": "komunalni-2022-561380-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-561380-question-48",
+      "id": "komunalni-2022-561380-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,10 +399,11 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-561380-candidate-573275",
+      "id": "komunalni-2022-561380-c-573275",
       "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
       "type": "party",
       "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
+      "img_url": "přísaha",
       "contacts": {
         "web": [
           {
@@ -411,7 +414,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-561380-573275-party",
+          "id": "komunalni-2022-561380-c-573275-p",
           "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
           "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
           "contacts": {
@@ -427,16 +430,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-561380-candidate-862902",
+      "id": "komunalni-2022-561380-c-862902",
       "name": "Česká strana sociálně demokratická",
       "type": "party",
       "description": "Česká strana sociálně demokratická - DESCRIPTION",
+      "img_url": "čssd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-561380-862902-party",
+          "id": "komunalni-2022-561380-c-862902-p",
           "name": "Česká strana sociálně demokratická",
           "description": "Česká strana sociálně demokratická - DESCRIPTION",
           "contacts": {
@@ -447,10 +451,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-561380-candidate-383029",
+      "id": "komunalni-2022-561380-c-383029",
       "name": "ŽIVÁ LÍPA",
       "type": "party",
       "description": "ŽIVÁ LÍPA - DESCRIPTION",
+      "img_url": "slk-nk",
       "contacts": {
         "web": [
           {
@@ -463,7 +468,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-561380-383029-party",
+          "id": "komunalni-2022-561380-c-383029-p",
           "name": "ŽIVÁ LÍPA",
           "description": "ŽIVÁ LÍPA - DESCRIPTION",
           "contacts": {
@@ -481,16 +486,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-561380-candidate-180415",
+      "id": "komunalni-2022-561380-c-180415",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-561380-180415-party",
+          "id": "komunalni-2022-561380-c-180415-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -501,16 +507,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-561380-candidate-806707",
+      "id": "komunalni-2022-561380-c-806707",
       "name": "PRO Českou Lípu",
       "type": "party",
       "description": "PRO Českou Lípu - DESCRIPTION",
+      "img_url": "nestraníci-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-561380-806707-party",
+          "id": "komunalni-2022-561380-c-806707-p",
           "name": "PRO Českou Lípu",
           "description": "PRO Českou Lípu - DESCRIPTION",
           "contacts": {
@@ -521,16 +528,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-561380-candidate-905610",
+      "id": "komunalni-2022-561380-c-905610",
       "name": "DOMOV",
       "type": "party",
       "description": "DOMOV - DESCRIPTION",
+      "img_url": "domov",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-561380-905610-party",
+          "id": "komunalni-2022-561380-c-905610-p",
           "name": "DOMOV",
           "description": "DOMOV - DESCRIPTION",
           "contacts": {
@@ -541,16 +549,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-561380-candidate-746760",
+      "id": "komunalni-2022-561380-c-746760",
       "name": "Trikolora",
       "type": "party",
       "description": "Trikolora - DESCRIPTION",
+      "img_url": "trikolora",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-561380-746760-party",
+          "id": "komunalni-2022-561380-c-746760-p",
           "name": "Trikolora",
           "description": "Trikolora - DESCRIPTION",
           "contacts": {
@@ -561,16 +570,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-561380-candidate-400561",
+      "id": "komunalni-2022-561380-c-400561",
       "name": "Svobodní",
       "type": "party",
       "description": "Svobodní - DESCRIPTION",
+      "img_url": "svobodní",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-561380-400561-party",
+          "id": "komunalni-2022-561380-c-400561-p",
           "name": "Svobodní",
           "description": "Svobodní - DESCRIPTION",
           "contacts": {
@@ -581,16 +591,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-561380-candidate-899770",
+      "id": "komunalni-2022-561380-c-899770",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-561380-899770-party",
+          "id": "komunalni-2022-561380-c-899770-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -601,16 +612,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-561380-candidate-812903",
+      "id": "komunalni-2022-561380-c-812903",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-561380-812903-party",
+          "id": "komunalni-2022-561380-c-812903-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -621,16 +633,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-561380-candidate-253669",
+      "id": "komunalni-2022-561380-c-253669",
       "name": "SPOLU",
       "type": "party",
       "description": "SPOLU - DESCRIPTION",
+      "img_url": "kdu-ods-top 09",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-561380-253669-party",
+          "id": "komunalni-2022-561380-c-253669-p",
           "name": "SPOLU",
           "description": "SPOLU - DESCRIPTION",
           "contacts": {
@@ -641,10 +654,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-561380-candidate-323053",
+      "id": "komunalni-2022-561380-c-323053",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": [
           {
@@ -655,7 +669,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-561380-323053-party",
+          "id": "komunalni-2022-561380-c-323053-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -673,882 +687,882 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-561380-answer-383029-1",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-1",
+      "id": "komunalni-2022-561380-a-4",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-2",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-2",
+      "id": "komunalni-2022-561380-a-7",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-3",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-3",
+      "id": "komunalni-2022-561380-a-10",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-4",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-4",
+      "id": "komunalni-2022-561380-a-13",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-5",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-5",
+      "id": "komunalni-2022-561380-a-16",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-6",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-6",
+      "id": "komunalni-2022-561380-a-19",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-7",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-7"
+      "id": "komunalni-2022-561380-a-22",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-7"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-8",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-8",
+      "id": "komunalni-2022-561380-a-25",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-8",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-9",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-9",
+      "id": "komunalni-2022-561380-a-28",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-10",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-10",
+      "id": "komunalni-2022-561380-a-31",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-11",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-11",
+      "id": "komunalni-2022-561380-a-34",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-12",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-12",
+      "id": "komunalni-2022-561380-a-37",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-13",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-13",
+      "id": "komunalni-2022-561380-a-40",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-14",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-14",
+      "id": "komunalni-2022-561380-a-43",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-15",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-15"
+      "id": "komunalni-2022-561380-a-46",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-15"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-16",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-16",
+      "id": "komunalni-2022-561380-a-49",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-17",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-17",
+      "id": "komunalni-2022-561380-a-52",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-18",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-18",
+      "id": "komunalni-2022-561380-a-55",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-19",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-19",
+      "id": "komunalni-2022-561380-a-58",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-20",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-20"
+      "id": "komunalni-2022-561380-a-61",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-20"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-21",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-21",
+      "id": "komunalni-2022-561380-a-64",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-22",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-22",
+      "id": "komunalni-2022-561380-a-67",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-23",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-23",
+      "id": "komunalni-2022-561380-a-70",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-23",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-24",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-24",
+      "id": "komunalni-2022-561380-a-73",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-25",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-25",
+      "id": "komunalni-2022-561380-a-76",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-26",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-26",
+      "id": "komunalni-2022-561380-a-79",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-27",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-27",
+      "id": "komunalni-2022-561380-a-82",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-28",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-28",
+      "id": "komunalni-2022-561380-a-85",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-28",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-29",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-29",
+      "id": "komunalni-2022-561380-a-88",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-30",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-30"
+      "id": "komunalni-2022-561380-a-91",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-30"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-31",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-31",
+      "id": "komunalni-2022-561380-a-94",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-32",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-32",
+      "id": "komunalni-2022-561380-a-97",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-33",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-33",
+      "id": "komunalni-2022-561380-a-100",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-33",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-34",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-34",
+      "id": "komunalni-2022-561380-a-103",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-35",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-35",
+      "id": "komunalni-2022-561380-a-106",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-36",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-36",
+      "id": "komunalni-2022-561380-a-109",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-37",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-37",
+      "id": "komunalni-2022-561380-a-112",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-38",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-38"
+      "id": "komunalni-2022-561380-a-115",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-38"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-39",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-39",
+      "id": "komunalni-2022-561380-a-118",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-40",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-40",
+      "id": "komunalni-2022-561380-a-121",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-41",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-41",
+      "id": "komunalni-2022-561380-a-124",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-42",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-42",
+      "id": "komunalni-2022-561380-a-127",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-43",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-43",
+      "id": "komunalni-2022-561380-a-130",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-44",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-44",
+      "id": "komunalni-2022-561380-a-133",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-45",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-45"
+      "id": "komunalni-2022-561380-a-136",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-45"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-46",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-46",
+      "id": "komunalni-2022-561380-a-139",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-47",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-47",
+      "id": "komunalni-2022-561380-a-142",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-48",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-48"
+      "id": "komunalni-2022-561380-a-145",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-48"
     },
     {
-      "id": "komunalni-2022-561380-answer-383029-49",
-      "candidate_id": "komunalni-2022-561380-candidate-383029",
-      "question_id": "komunalni-2022-561380-question-49"
+      "id": "komunalni-2022-561380-a-148",
+      "candidate_id": "komunalni-2022-561380-c-383029",
+      "question_id": "komunalni-2022-561380-q-49"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-1",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-1",
+      "id": "komunalni-2022-561380-a-4",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-1",
       "answer": "no",
       "comment": "Vytváření ghet není výhodné pro nikoho. V probeémových lokalitách je nutno pracovat s místní komunitou a důsledně dbát na pořádek a klid."
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-2",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-2",
+      "id": "komunalni-2022-561380-a-7",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-3",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-3",
+      "id": "komunalni-2022-561380-a-10",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-4",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-4",
+      "id": "komunalni-2022-561380-a-13",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-5",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-5",
+      "id": "komunalni-2022-561380-a-16",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-6",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-6",
+      "id": "komunalni-2022-561380-a-19",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-6",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-7",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-7"
+      "id": "komunalni-2022-561380-a-22",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-7"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-8",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-8",
+      "id": "komunalni-2022-561380-a-25",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-9",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-9",
+      "id": "komunalni-2022-561380-a-28",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-10",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-10",
+      "id": "komunalni-2022-561380-a-31",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-11",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-11",
+      "id": "komunalni-2022-561380-a-34",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-12",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-12",
+      "id": "komunalni-2022-561380-a-37",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-13",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-13"
+      "id": "komunalni-2022-561380-a-40",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-13"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-14",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-14",
+      "id": "komunalni-2022-561380-a-43",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-15",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-15",
+      "id": "komunalni-2022-561380-a-46",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-15",
       "answer": "no",
       "comment": "Město má spíše urychleně modernizovat a používat smart LED svítidla, která např nesvítí stále na plný výkon a mají čidla na úroveň osvětlení či přítomnost chodců."
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-16",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-16",
+      "id": "komunalni-2022-561380-a-49",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-17",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-17",
+      "id": "komunalni-2022-561380-a-52",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-18",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-18",
+      "id": "komunalni-2022-561380-a-55",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-19",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-19",
+      "id": "komunalni-2022-561380-a-58",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-20",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-20",
+      "id": "komunalni-2022-561380-a-61",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-21",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-21"
+      "id": "komunalni-2022-561380-a-64",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-21"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-22",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-22",
+      "id": "komunalni-2022-561380-a-67",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-23",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-23",
+      "id": "komunalni-2022-561380-a-70",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-23",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-24",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-24",
+      "id": "komunalni-2022-561380-a-73",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-24",
       "answer": "no",
       "comment": "Jsme pro částečnou regulaci"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-25",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-25",
+      "id": "komunalni-2022-561380-a-76",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-26",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-26",
+      "id": "komunalni-2022-561380-a-79",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-27",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-27",
+      "id": "komunalni-2022-561380-a-82",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-28",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-28",
+      "id": "komunalni-2022-561380-a-85",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-28",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-29",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-29",
+      "id": "komunalni-2022-561380-a-88",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-30",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-30",
+      "id": "komunalni-2022-561380-a-91",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-31",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-31",
+      "id": "komunalni-2022-561380-a-94",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-32",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-32",
+      "id": "komunalni-2022-561380-a-97",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-33",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-33",
+      "id": "komunalni-2022-561380-a-100",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-33",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-34",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-34",
+      "id": "komunalni-2022-561380-a-103",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-34",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-35",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-35",
+      "id": "komunalni-2022-561380-a-106",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-36",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-36",
+      "id": "komunalni-2022-561380-a-109",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-36",
       "comment": "Jen pro potřebné, ne plošně."
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-37",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-37",
+      "id": "komunalni-2022-561380-a-112",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-38",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-38",
+      "id": "komunalni-2022-561380-a-115",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-39",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-39",
+      "id": "komunalni-2022-561380-a-118",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-40",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-40",
+      "id": "komunalni-2022-561380-a-121",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-40",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-41",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-41",
+      "id": "komunalni-2022-561380-a-124",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-42",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-42",
+      "id": "komunalni-2022-561380-a-127",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-43",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-43",
+      "id": "komunalni-2022-561380-a-130",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-43",
       "answer": "yes",
       "comment": "Musí existovat transparentní systém pro přerozdělení peněz s jasnými pravidly a jasně vymezenými účelovými náklady."
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-44",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-44",
+      "id": "komunalni-2022-561380-a-133",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-45",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-45",
+      "id": "komunalni-2022-561380-a-136",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-45",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-46",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-46",
+      "id": "komunalni-2022-561380-a-139",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-47",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-47",
+      "id": "komunalni-2022-561380-a-142",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-48",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-48",
+      "id": "komunalni-2022-561380-a-145",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-180415-49",
-      "candidate_id": "komunalni-2022-561380-candidate-180415",
-      "question_id": "komunalni-2022-561380-question-49"
+      "id": "komunalni-2022-561380-a-148",
+      "candidate_id": "komunalni-2022-561380-c-180415",
+      "question_id": "komunalni-2022-561380-q-49"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-1",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-1",
+      "id": "komunalni-2022-561380-a-4",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-1",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-2",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-2",
+      "id": "komunalni-2022-561380-a-7",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-2",
       "answer": "no",
       "comment": "Motivovat obyvatelé k třídění."
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-3",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-3",
+      "id": "komunalni-2022-561380-a-10",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-4",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-4",
+      "id": "komunalni-2022-561380-a-13",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-4",
       "answer": "yes",
       "comment": "Pouze u škol a školek "
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-5",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-5",
+      "id": "komunalni-2022-561380-a-16",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-6",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-6",
+      "id": "komunalni-2022-561380-a-19",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-7",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-7"
+      "id": "komunalni-2022-561380-a-22",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-7"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-8",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-8",
+      "id": "komunalni-2022-561380-a-25",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-9",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-9",
+      "id": "komunalni-2022-561380-a-28",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-10",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-10",
+      "id": "komunalni-2022-561380-a-31",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-11",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-11",
+      "id": "komunalni-2022-561380-a-34",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-12",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-12",
+      "id": "komunalni-2022-561380-a-37",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-13",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-13",
+      "id": "komunalni-2022-561380-a-40",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-14",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-14",
+      "id": "komunalni-2022-561380-a-43",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-15",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-15",
+      "id": "komunalni-2022-561380-a-46",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-15",
       "answer": "no",
       "comment": "Řešit systémově- pohybová čidla"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-16",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-16",
+      "id": "komunalni-2022-561380-a-49",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-16",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-17",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-17",
+      "id": "komunalni-2022-561380-a-52",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-18",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-18",
+      "id": "komunalni-2022-561380-a-55",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-19",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-19",
+      "id": "komunalni-2022-561380-a-58",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-20",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-20",
+      "id": "komunalni-2022-561380-a-61",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-21",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-21",
+      "id": "komunalni-2022-561380-a-64",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-21",
       "answer": "no",
       "comment": "Systematicky řešit led osvětlení"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-22",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-22",
+      "id": "komunalni-2022-561380-a-67",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-23",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-23",
+      "id": "komunalni-2022-561380-a-70",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-24",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-24",
+      "id": "komunalni-2022-561380-a-73",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-25",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-25",
+      "id": "komunalni-2022-561380-a-76",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-25",
       "answer": "no",
       "comment": "Podporovat výstavbu bytů v OV a DV"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-26",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-26",
+      "id": "komunalni-2022-561380-a-79",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-27",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-27",
+      "id": "komunalni-2022-561380-a-82",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-27",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-28",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-28",
+      "id": "komunalni-2022-561380-a-85",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-29",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-29",
+      "id": "komunalni-2022-561380-a-88",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-30",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-30",
+      "id": "komunalni-2022-561380-a-91",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-30",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-31",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-31",
+      "id": "komunalni-2022-561380-a-94",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-32",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-32",
+      "id": "komunalni-2022-561380-a-97",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-33",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-33",
+      "id": "komunalni-2022-561380-a-100",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-34",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-34",
+      "id": "komunalni-2022-561380-a-103",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-35",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-35",
+      "id": "komunalni-2022-561380-a-106",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-36",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-36",
+      "id": "komunalni-2022-561380-a-109",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-37",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-37",
+      "id": "komunalni-2022-561380-a-112",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-38",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-38",
+      "id": "komunalni-2022-561380-a-115",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-39",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-39",
+      "id": "komunalni-2022-561380-a-118",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-39",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-40",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-40",
+      "id": "komunalni-2022-561380-a-121",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-41",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-41",
+      "id": "komunalni-2022-561380-a-124",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-41",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-42",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-42",
+      "id": "komunalni-2022-561380-a-127",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-42",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-43",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-43",
+      "id": "komunalni-2022-561380-a-130",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-43",
       "answer": "no",
       "comment": "Podpora města pouze pro amatérské sportovce "
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-44",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-44",
+      "id": "komunalni-2022-561380-a-133",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-44",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-45",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-45",
+      "id": "komunalni-2022-561380-a-136",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-45",
       "answer": "no",
       "comment": "Nutno řešit systémově"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-46",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-46",
+      "id": "komunalni-2022-561380-a-139",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-47",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-47"
+      "id": "komunalni-2022-561380-a-142",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-47"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-48",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-48",
+      "id": "komunalni-2022-561380-a-145",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-561380-answer-323053-49",
-      "candidate_id": "komunalni-2022-561380-candidate-323053",
-      "question_id": "komunalni-2022-561380-question-49"
+      "id": "komunalni-2022-561380-a-148",
+      "candidate_id": "komunalni-2022-561380-c-323053",
+      "question_id": "komunalni-2022-561380-q-49"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/562335.json
+++ b/data/kalkulacka/komunalni-2022/562335.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-562335",
   "name": "Děčín",
-  "description": "Děčín - DESCRIPTION",
+  "description": "Děčín",
   "district_code": "562335",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-562335-question-1",
+      "id": "komunalni-2022-562335-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-2",
+      "id": "komunalni-2022-562335-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-3",
+      "id": "komunalni-2022-562335-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-4",
+      "id": "komunalni-2022-562335-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-5",
+      "id": "komunalni-2022-562335-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-6",
+      "id": "komunalni-2022-562335-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-7",
+      "id": "komunalni-2022-562335-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-8",
+      "id": "komunalni-2022-562335-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-9",
+      "id": "komunalni-2022-562335-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-10",
+      "id": "komunalni-2022-562335-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-11",
+      "id": "komunalni-2022-562335-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-12",
+      "id": "komunalni-2022-562335-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-13",
+      "id": "komunalni-2022-562335-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-14",
+      "id": "komunalni-2022-562335-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-15",
+      "id": "komunalni-2022-562335-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-16",
+      "id": "komunalni-2022-562335-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-17",
+      "id": "komunalni-2022-562335-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-18",
+      "id": "komunalni-2022-562335-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-19",
+      "id": "komunalni-2022-562335-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-20",
+      "id": "komunalni-2022-562335-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-21",
+      "id": "komunalni-2022-562335-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-22",
+      "id": "komunalni-2022-562335-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-23",
+      "id": "komunalni-2022-562335-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-24",
+      "id": "komunalni-2022-562335-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-25",
+      "id": "komunalni-2022-562335-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-26",
+      "id": "komunalni-2022-562335-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-27",
+      "id": "komunalni-2022-562335-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-28",
+      "id": "komunalni-2022-562335-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-29",
+      "id": "komunalni-2022-562335-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-30",
+      "id": "komunalni-2022-562335-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-31",
+      "id": "komunalni-2022-562335-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-32",
+      "id": "komunalni-2022-562335-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-33",
+      "id": "komunalni-2022-562335-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-34",
+      "id": "komunalni-2022-562335-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-35",
+      "id": "komunalni-2022-562335-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-36",
+      "id": "komunalni-2022-562335-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-37",
+      "id": "komunalni-2022-562335-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-38",
+      "id": "komunalni-2022-562335-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-39",
+      "id": "komunalni-2022-562335-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-40",
+      "id": "komunalni-2022-562335-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-41",
+      "id": "komunalni-2022-562335-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-42",
+      "id": "komunalni-2022-562335-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-43",
+      "id": "komunalni-2022-562335-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-44",
+      "id": "komunalni-2022-562335-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-45",
+      "id": "komunalni-2022-562335-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-46",
+      "id": "komunalni-2022-562335-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-47",
+      "id": "komunalni-2022-562335-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562335-question-48",
+      "id": "komunalni-2022-562335-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,10 +399,11 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-562335-candidate-395483",
+      "id": "komunalni-2022-562335-c-395483",
       "name": "Občanská demokratická strana",
       "type": "party",
       "description": "Občanská demokratická strana - DESCRIPTION",
+      "img_url": "ods",
       "contacts": {
         "web": [
           {
@@ -417,7 +420,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-562335-395483-party",
+          "id": "komunalni-2022-562335-c-395483-p",
           "name": "Občanská demokratická strana",
           "description": "Občanská demokratická strana - DESCRIPTION",
           "contacts": {
@@ -439,16 +442,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-562335-candidate-471202",
+      "id": "komunalni-2022-562335-c-471202",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-562335-471202-party",
+          "id": "komunalni-2022-562335-c-471202-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -459,16 +463,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-562335-candidate-232636",
+      "id": "komunalni-2022-562335-c-232636",
       "name": "Severočeši Děčín",
       "type": "party",
       "description": "Severočeši Děčín - DESCRIPTION",
+      "img_url": "dsss-bez-ul",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-562335-232636-party",
+          "id": "komunalni-2022-562335-c-232636-p",
           "name": "Severočeši Děčín",
           "description": "Severočeši Děčín - DESCRIPTION",
           "contacts": {
@@ -479,16 +484,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-562335-candidate-328876",
+      "id": "komunalni-2022-562335-c-328876",
       "name": "Živý Děčín - STAN",
       "type": "party",
       "description": "Živý Děčín - STAN - DESCRIPTION",
+      "img_url": "stan-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-562335-328876-party",
+          "id": "komunalni-2022-562335-c-328876-p",
           "name": "Živý Děčín - STAN",
           "description": "Živý Děčín - STAN - DESCRIPTION",
           "contacts": {
@@ -499,16 +505,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-562335-candidate-810714",
+      "id": "komunalni-2022-562335-c-810714",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-562335-810714-party",
+          "id": "komunalni-2022-562335-c-810714-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -519,10 +526,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-562335-candidate-666575",
+      "id": "komunalni-2022-562335-c-666575",
       "name": "Česká strana sociálně demokratická",
       "type": "party",
       "description": "Česká strana sociálně demokratická - DESCRIPTION",
+      "img_url": "čssd",
       "contacts": {
         "web": [
           {
@@ -538,7 +546,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-562335-666575-party",
+          "id": "komunalni-2022-562335-c-666575-p",
           "name": "Česká strana sociálně demokratická",
           "description": "Česká strana sociálně demokratická - DESCRIPTION",
           "contacts": {
@@ -559,10 +567,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-562335-candidate-381880",
+      "id": "komunalni-2022-562335-c-381880",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": [
           {
@@ -579,7 +588,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-562335-381880-party",
+          "id": "komunalni-2022-562335-c-381880-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -601,10 +610,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-562335-candidate-632156",
+      "id": "komunalni-2022-562335-c-632156",
       "name": "Náš Děčín",
       "type": "party",
       "description": "Náš Děčín - DESCRIPTION",
+      "img_url": "praha-prozdraví",
       "contacts": {
         "web": [
           {
@@ -616,7 +626,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-562335-632156-party",
+          "id": "komunalni-2022-562335-c-632156-p",
           "name": "Náš Děčín",
           "description": "Náš Děčín - DESCRIPTION",
           "contacts": {
@@ -633,16 +643,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-562335-candidate-272858",
+      "id": "komunalni-2022-562335-c-272858",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-562335-272858-party",
+          "id": "komunalni-2022-562335-c-272858-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -653,16 +664,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-562335-candidate-266644",
+      "id": "komunalni-2022-562335-c-266644",
       "name": "Volba pro Děčín",
       "type": "party",
       "description": "Volba pro Děčín - DESCRIPTION",
+      "img_url": "mhnhrm-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-562335-266644-party",
+          "id": "komunalni-2022-562335-c-266644-p",
           "name": "Volba pro Děčín",
           "description": "Volba pro Děčín - DESCRIPTION",
           "contacts": {
@@ -673,10 +685,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-562335-candidate-932150",
+      "id": "komunalni-2022-562335-c-932150",
       "name": "Trikolora a Svobodní",
       "type": "party",
       "description": "Trikolora a Svobodní - DESCRIPTION",
+      "img_url": "svobod-trikolor",
       "contacts": {
         "web": [
           {
@@ -687,7 +700,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-562335-932150-party",
+          "id": "komunalni-2022-562335-c-932150-p",
           "name": "Trikolora a Svobodní",
           "description": "Trikolora a Svobodní - DESCRIPTION",
           "contacts": {
@@ -705,646 +718,646 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-562335-answer-932150-1",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-1",
+      "id": "komunalni-2022-562335-a-4",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-1",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-2",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-2",
+      "id": "komunalni-2022-562335-a-7",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-2",
       "answer": "no",
       "comment": "- Děčín je jediným statuárním městem v kraji, kde za svoz odpadu občané, podotknu, že nikoli všichni, platí\n- Děčín má rozpočet cca miliardu ročně, náklady na svoz komunálního odpadu přitom netvoří ani 0,5% rozpočtu. Když je za občany platí ostatní statutární města v kraji, neexistuje hodnověrný důvod, aby tyto náklady nemohlo platit také město Děčín\n- Svoz odpadu zdarma je službou VŠEM občanům, nikoli jenom některým zájmovým skupinám"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-3",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-3",
+      "id": "komunalni-2022-562335-a-10",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-4",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-4",
+      "id": "komunalni-2022-562335-a-13",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-5",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-5",
+      "id": "komunalni-2022-562335-a-16",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-6",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-6",
+      "id": "komunalni-2022-562335-a-19",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-6",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-7",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-7",
+      "id": "komunalni-2022-562335-a-22",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-7",
       "answer": "no",
       "comment": "Lidé mají právo rozhodovat, jakým způsobem utratí vydělané peníze."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-8",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-8",
+      "id": "komunalni-2022-562335-a-25",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-8",
       "answer": "yes",
       "comment": "Výhledově ano. Záleží ale na ekonomických možnostech města. Je to podobné jako se svozem odpadu, je to služba pro všechny obyvatele města, nikoli pro jednotlivé zájmové skupiny. "
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-9",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-9",
+      "id": "komunalni-2022-562335-a-28",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-9",
       "answer": "yes",
       "comment": "Bezbariérově přístupná je již dnes většina zastávek v obou centrech města\ni významnější zastávky z hlediska poptávky v dalších místních částech. Rekonstrukce dalších\nzastávek do bezbariérové podoby bude probíhat i v návrhovém období 2021 – 2025 Plánu\ndopravní obslužnosti."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-10",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-10",
+      "id": "komunalni-2022-562335-a-31",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-10",
       "answer": "yes",
       "comment": "Existuje, přenosy ze zasedání zastupitelstva probíhají on-line."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-11",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-11",
+      "id": "komunalni-2022-562335-a-34",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-12",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-12",
+      "id": "komunalni-2022-562335-a-37",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-12",
       "answer": "yes",
       "comment": "Na žádost ale lze povolovat výjimky. "
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-13",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-13",
+      "id": "komunalni-2022-562335-a-40",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-13",
       "answer": "yes",
       "comment": "V případě akutního nedostatku plynu a dalších surovin pro vytápění domů."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-14",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-14",
+      "id": "komunalni-2022-562335-a-43",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-14",
       "answer": "no",
       "comment": "Výpadek energií se má týkat pouze plynu, nikoli elektřiny, které je u nás dostatek."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-15",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-15",
+      "id": "komunalni-2022-562335-a-46",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-15",
       "answer": "no",
       "comment": "Výpadek energií se má týkat pouze plynu, nikoli elektřiny, které je u nás dostatek."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-16",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-16",
+      "id": "komunalni-2022-562335-a-49",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-16",
       "comment": "Záleží na aktuální situaci v dodávce plynu. "
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-17",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-17",
+      "id": "komunalni-2022-562335-a-52",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-17",
       "answer": "yes",
       "comment": "Město má dluhy dětských dlužníků vymáhat po rodičích."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-18",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-18",
+      "id": "komunalni-2022-562335-a-55",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-19",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-19",
+      "id": "komunalni-2022-562335-a-58",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-19",
       "answer": "yes",
       "comment": "Již funguje participativní rozpočet města."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-20",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-20",
+      "id": "komunalni-2022-562335-a-61",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-20",
       "answer": "no",
       "comment": "Erár, tedy ani město, nikdy není dobrý hospodář. Vlastnictví nemovitostí je také administrativně náročné."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-21",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-21",
+      "id": "komunalni-2022-562335-a-64",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-21",
       "answer": "no",
       "comment": "Výpadek energií se má týkat pouze plynu, nikoli elektřiny, které je u nás dostatek."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-22",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-22",
+      "id": "komunalni-2022-562335-a-67",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-23",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-23",
+      "id": "komunalni-2022-562335-a-70",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-23",
       "answer": "no",
       "comment": "Vysoké nákjlady na provoz a administrativu."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-24",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-24",
+      "id": "komunalni-2022-562335-a-73",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-25",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-25",
+      "id": "komunalni-2022-562335-a-76",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-25",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-26",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-26",
+      "id": "komunalni-2022-562335-a-79",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-27",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-27",
+      "id": "komunalni-2022-562335-a-82",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-28",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-28",
+      "id": "komunalni-2022-562335-a-85",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-28",
       "answer": "no",
       "comment": "Je věcí majitele, jak rozhodne o svém majetku."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-29",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-29",
+      "id": "komunalni-2022-562335-a-88",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-30",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-30",
+      "id": "komunalni-2022-562335-a-91",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-30",
       "answer": "no",
       "comment": "Záležitost soukromého sektoru. Elektromobilita nepředstavuje dle našeho názoru budoucnost dopravy."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-31",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-31",
+      "id": "komunalni-2022-562335-a-94",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-31",
       "answer": "no",
       "comment": "Takováto podpora vytváří prostor pro protekci a korupci."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-32",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-32",
+      "id": "komunalni-2022-562335-a-97",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-33",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-33",
+      "id": "komunalni-2022-562335-a-100",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-33",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-34",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-34",
+      "id": "komunalni-2022-562335-a-103",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-34",
       "answer": "yes",
       "comment": "Bezplatné nikoli, symbolické ano."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-35",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-35",
+      "id": "komunalni-2022-562335-a-106",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-36",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-36",
+      "id": "komunalni-2022-562335-a-109",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-37",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-37"
+      "id": "komunalni-2022-562335-a-112",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-37"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-38",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-38",
+      "id": "komunalni-2022-562335-a-115",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-39",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-39",
+      "id": "komunalni-2022-562335-a-118",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-39",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-40",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-40",
+      "id": "komunalni-2022-562335-a-121",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-40",
       "answer": "no",
       "comment": "Dlouhodobě je problém naplnit stávající stav."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-41",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-41",
+      "id": "komunalni-2022-562335-a-124",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-41",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-42",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-42",
+      "id": "komunalni-2022-562335-a-127",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-42",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-43",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-43",
+      "id": "komunalni-2022-562335-a-130",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-43",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-44",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-44",
+      "id": "komunalni-2022-562335-a-133",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-44",
       "answer": "yes",
       "comment": "Daň z nemovitosti je nemravná daň a měla by se zrušit, zdaňuje něco, co již bylo několikrát zdaněno."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-45",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-45",
+      "id": "komunalni-2022-562335-a-136",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-45",
       "answer": "no",
       "comment": "Toto je v kompetenci státu."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-46",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-46",
+      "id": "komunalni-2022-562335-a-139",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-46",
       "answer": "no",
       "comment": "Příliš ekonomicky a administrativně nákladná záležitost, která navíc rozšiřuje prostor pro protekcionářství a korupci."
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-47",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-47",
+      "id": "komunalni-2022-562335-a-142",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-47",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-48",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-48",
+      "id": "komunalni-2022-562335-a-145",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-932150-49",
-      "candidate_id": "komunalni-2022-562335-candidate-932150",
-      "question_id": "komunalni-2022-562335-question-49",
+      "id": "komunalni-2022-562335-a-148",
+      "candidate_id": "komunalni-2022-562335-c-932150",
+      "question_id": "komunalni-2022-562335-q-49",
       "comment": "Díky za vaši nestrannou aktivitu"
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-1",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-1",
+      "id": "komunalni-2022-562335-a-4",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-1",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-2",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-2",
+      "id": "komunalni-2022-562335-a-7",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-3",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-3",
+      "id": "komunalni-2022-562335-a-10",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-3",
       "answer": "no",
       "comment": "I v době nouze bude o seniory postaráno přednostně."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-4",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-4",
+      "id": "komunalni-2022-562335-a-13",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-4",
       "answer": "no",
       "comment": "Zklidnění dopravy lze docílit i jinými prostředky než zákazy."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-5",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-5",
+      "id": "komunalni-2022-562335-a-16",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-5",
       "answer": "yes",
       "comment": "Otázka lidí v exekucích je jedna z nejbolestivějších, využijme k řešení všechny nástroje."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-6",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-6",
+      "id": "komunalni-2022-562335-a-19",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-6",
       "answer": "yes",
       "comment": "Město využije všechny možnosti k posílení bezpečnosti."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-7",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-7",
+      "id": "komunalni-2022-562335-a-22",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-7",
       "answer": "yes",
       "comment": "Zákaz hazardu je nezbytné udržet pro zlepšení bezpečnosti v městě."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-8",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-8",
+      "id": "komunalni-2022-562335-a-25",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-8",
       "answer": "no",
       "comment": "Jízdné bude nadále dotované, ale jízdné zdarma by spíše přineslo problémy."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-9",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-9",
+      "id": "komunalni-2022-562335-a-28",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-10",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-10",
+      "id": "komunalni-2022-562335-a-31",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-10",
       "answer": "yes",
       "comment": "Jedná se o veřejné jednání."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-11",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-11",
+      "id": "komunalni-2022-562335-a-34",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-11",
       "answer": "no",
       "comment": "Jedná se o uzavřené jednání."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-12",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-12",
+      "id": "komunalni-2022-562335-a-37",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-12",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-13",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-13",
+      "id": "komunalni-2022-562335-a-40",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-14",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-14",
+      "id": "komunalni-2022-562335-a-43",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-14",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-15",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-15",
+      "id": "komunalni-2022-562335-a-46",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-15",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-16",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-16",
+      "id": "komunalni-2022-562335-a-49",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-16",
       "answer": "yes",
       "comment": "V době extrémních cen energií se musí na vytápění šetřit, kde to jde."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-17",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-17",
+      "id": "komunalni-2022-562335-a-52",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-18",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-18",
+      "id": "komunalni-2022-562335-a-55",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-19",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-19",
+      "id": "komunalni-2022-562335-a-58",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-19",
       "answer": "yes",
       "comment": "Jde o tzv. participativní rozpočet, ten by se měl rozšířit."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-20",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-20",
+      "id": "komunalni-2022-562335-a-61",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-20",
       "answer": "yes",
       "comment": "Potřebujeme startovní tzv. startovní byty, dále byty pro přivedení důležitých profesí jako lékaři do města. "
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-21",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-21",
+      "id": "komunalni-2022-562335-a-64",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-21",
       "answer": "no",
       "comment": "Vánoční osvětlení není v ročních nákladech významné, ponechme ho."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-22",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-22",
+      "id": "komunalni-2022-562335-a-67",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-22",
       "answer": "no",
       "comment": "Ponechat dotované obědy, ale s finanční účastí rodičů."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-23",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-23",
+      "id": "komunalni-2022-562335-a-70",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-23",
       "answer": "no",
       "comment": "V měřítku Děčína jde o zanedbatelnou aktivitu, tuto je potřeba nechat na občanech."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-24",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-24",
+      "id": "komunalni-2022-562335-a-73",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-24",
       "answer": "no",
       "comment": "Bez parkovacích zón v centru se již neobejdeme."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-25",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-25",
+      "id": "komunalni-2022-562335-a-76",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-25",
       "answer": "no",
       "comment": "Město spíše potřebuje lépe řídit své bytové hospodářství."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-26",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-26",
+      "id": "komunalni-2022-562335-a-79",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-26",
       "answer": "yes",
       "comment": "Jde o náklady spojené s využitím těchto objektů, třeba parkování."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-27",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-27",
+      "id": "komunalni-2022-562335-a-82",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-27",
       "answer": "yes",
       "comment": "Město potřebujeme zprůjezdnit a oddělit cyklisty od aut. Každé sídliště by mělo být bezpečně dosažitelné na kole."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-28",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-28",
+      "id": "komunalni-2022-562335-a-85",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-28",
       "answer": "no",
       "comment": "Zdanění by mělo být jednotné. Spíše se chceme zaměřit jiné poplatky (odpad) u bytů, kde nikdo není přihlášen k pobytu."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-29",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-29",
+      "id": "komunalni-2022-562335-a-88",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-29",
       "comment": "Momentálně budeme spíše rádi, když developery do města dostaneme."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-30",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-30",
+      "id": "komunalni-2022-562335-a-91",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-30",
       "answer": "yes",
       "comment": "Při využití dotací budeme dobíjecí místa potřebovat, zejména na sídlištích."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-31",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-31",
+      "id": "komunalni-2022-562335-a-94",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-31",
       "answer": "yes",
       "comment": "Všechny formy výstavby bytů musí město podporovat."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-32",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-32",
+      "id": "komunalni-2022-562335-a-97",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-32",
       "answer": "no",
       "comment": "Jízdné pro děti i důchodce i nadále s výraznou slevou, ale nikoliv zdarma."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-33",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-33",
+      "id": "komunalni-2022-562335-a-100",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-33",
       "answer": "no",
       "comment": "Město bude instalovat fotovoltaiku přednostně na veřejné budovy."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-34",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-34",
+      "id": "komunalni-2022-562335-a-103",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-35",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-35",
+      "id": "komunalni-2022-562335-a-106",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-36",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-36",
+      "id": "komunalni-2022-562335-a-109",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-37",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-37",
+      "id": "komunalni-2022-562335-a-112",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-37",
       "answer": "yes",
       "comment": "Jde o investici s dobrou návratností, navíc s využitím dotací."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-38",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-38",
+      "id": "komunalni-2022-562335-a-115",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-38",
       "answer": "yes",
       "comment": "Zprůjezdnit město můžeme podporou cyklostezek, oddělením cyklistů a koloběžek od automobilů, propojení všech sídlišť s centrem. "
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-39",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-39",
+      "id": "komunalni-2022-562335-a-118",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-40",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-40",
+      "id": "komunalni-2022-562335-a-121",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-40",
       "answer": "yes",
       "comment": "Město by nemělo zvyšovat stavy úředníků, ale v případě strážníků mírné navýšení zlepší bezpečnost."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-41",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-41",
+      "id": "komunalni-2022-562335-a-124",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-41",
       "answer": "no",
       "comment": "Město má dostatek běžné zeleně, investice do zelených střech by byla nadbytečná."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-42",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-42",
+      "id": "komunalni-2022-562335-a-127",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-42",
       "answer": "yes",
       "comment": "Vybudování cyklostezek pro každé sídliště je nutnost."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-43",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-43",
+      "id": "komunalni-2022-562335-a-130",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-43",
       "answer": "yes",
       "comment": "Rozumná podpora basketbalu v Děčíně zlepšuje image města."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-44",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-44",
+      "id": "komunalni-2022-562335-a-133",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-44",
       "answer": "no",
       "comment": "Daň z nemovitostí je nyní nejnižší možná. "
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-45",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-45",
+      "id": "komunalni-2022-562335-a-136",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-45",
       "answer": "yes",
       "comment": "Zacílené, nikoliv plošné, programy pro pomoc sociálně slabším."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-46",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-46",
+      "id": "komunalni-2022-562335-a-139",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-46",
       "answer": "yes",
       "comment": "Město potřebuje startovní byty a také byty pro přicházející odborníky, např. lékaře."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-47",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-47",
+      "id": "komunalni-2022-562335-a-142",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-47",
       "answer": "no",
       "comment": "Nebudeme oddělovat děti nějakým stěhováním."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-48",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-48",
+      "id": "komunalni-2022-562335-a-145",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-48",
       "answer": "yes",
       "comment": "Podpora rodin a pracujících matek je jednou z našich priorit."
     },
     {
-      "id": "komunalni-2022-562335-answer-328876-49",
-      "candidate_id": "komunalni-2022-562335-candidate-328876",
-      "question_id": "komunalni-2022-562335-question-49"
+      "id": "komunalni-2022-562335-a-148",
+      "candidate_id": "komunalni-2022-562335-c-328876",
+      "question_id": "komunalni-2022-562335-q-49"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/562971.json
+++ b/data/kalkulacka/komunalni-2022/562971.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-562971",
   "name": "Chomutov",
-  "description": "Chomutov - DESCRIPTION",
+  "description": "Chomutov",
   "district_code": "562971",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-562971-question-1",
+      "id": "komunalni-2022-562971-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-2",
+      "id": "komunalni-2022-562971-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-3",
+      "id": "komunalni-2022-562971-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-4",
+      "id": "komunalni-2022-562971-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-5",
+      "id": "komunalni-2022-562971-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-6",
+      "id": "komunalni-2022-562971-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-7",
+      "id": "komunalni-2022-562971-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-8",
+      "id": "komunalni-2022-562971-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-9",
+      "id": "komunalni-2022-562971-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-10",
+      "id": "komunalni-2022-562971-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-11",
+      "id": "komunalni-2022-562971-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-12",
+      "id": "komunalni-2022-562971-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-13",
+      "id": "komunalni-2022-562971-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-14",
+      "id": "komunalni-2022-562971-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-15",
+      "id": "komunalni-2022-562971-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-16",
+      "id": "komunalni-2022-562971-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-17",
+      "id": "komunalni-2022-562971-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-18",
+      "id": "komunalni-2022-562971-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-19",
+      "id": "komunalni-2022-562971-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-20",
+      "id": "komunalni-2022-562971-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-21",
+      "id": "komunalni-2022-562971-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-22",
+      "id": "komunalni-2022-562971-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-23",
+      "id": "komunalni-2022-562971-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-24",
+      "id": "komunalni-2022-562971-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-25",
+      "id": "komunalni-2022-562971-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-26",
+      "id": "komunalni-2022-562971-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-27",
+      "id": "komunalni-2022-562971-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-28",
+      "id": "komunalni-2022-562971-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-29",
+      "id": "komunalni-2022-562971-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-30",
+      "id": "komunalni-2022-562971-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-31",
+      "id": "komunalni-2022-562971-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-32",
+      "id": "komunalni-2022-562971-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-33",
+      "id": "komunalni-2022-562971-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-34",
+      "id": "komunalni-2022-562971-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-35",
+      "id": "komunalni-2022-562971-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-36",
+      "id": "komunalni-2022-562971-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-37",
+      "id": "komunalni-2022-562971-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-38",
+      "id": "komunalni-2022-562971-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-39",
+      "id": "komunalni-2022-562971-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-40",
+      "id": "komunalni-2022-562971-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-41",
+      "id": "komunalni-2022-562971-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-42",
+      "id": "komunalni-2022-562971-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-43",
+      "id": "komunalni-2022-562971-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-44",
+      "id": "komunalni-2022-562971-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-45",
+      "id": "komunalni-2022-562971-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-46",
+      "id": "komunalni-2022-562971-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-47",
+      "id": "komunalni-2022-562971-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-562971-question-48",
+      "id": "komunalni-2022-562971-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,16 +399,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-562971-candidate-802989",
+      "id": "komunalni-2022-562971-c-802989",
       "name": "Moderní společnost",
       "type": "party",
       "description": "Moderní společnost - DESCRIPTION",
+      "img_url": "modes",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-562971-802989-party",
+          "id": "komunalni-2022-562971-c-802989-p",
           "name": "Moderní společnost",
           "description": "Moderní společnost - DESCRIPTION",
           "contacts": {
@@ -417,10 +420,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-562971-candidate-935978",
+      "id": "komunalni-2022-562971-c-935978",
       "name": "CHOMUTOVSKÁ KOALICE",
       "type": "party",
       "description": "CHOMUTOVSKÁ KOALICE - DESCRIPTION",
+      "img_url": "ls-nk",
       "contacts": {
         "web": [
           {
@@ -437,7 +441,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-562971-935978-party",
+          "id": "komunalni-2022-562971-c-935978-p",
           "name": "CHOMUTOVSKÁ KOALICE",
           "description": "CHOMUTOVSKÁ KOALICE - DESCRIPTION",
           "contacts": {
@@ -459,16 +463,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-562971-candidate-843823",
+      "id": "komunalni-2022-562971-c-843823",
       "name": "Svoboda a přímá demokracie (SPD) s podporou PRO",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) s podporou PRO - DESCRIPTION",
+      "img_url": "spd-pro 2022",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-562971-843823-party",
+          "id": "komunalni-2022-562971-c-843823-p",
           "name": "Svoboda a přímá demokracie (SPD) s podporou PRO",
           "description": "Svoboda a přímá demokracie (SPD) s podporou PRO - DESCRIPTION",
           "contacts": {
@@ -479,16 +484,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-562971-candidate-751007",
+      "id": "komunalni-2022-562971-c-751007",
       "name": "PRO Chomutov",
       "type": "party",
       "description": "PRO Chomutov - DESCRIPTION",
+      "img_url": "kdupirtopjsprnk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-562971-751007-party",
+          "id": "komunalni-2022-562971-c-751007-p",
           "name": "PRO Chomutov",
           "description": "PRO Chomutov - DESCRIPTION",
           "contacts": {
@@ -499,17 +505,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-562971-candidate-684379",
+      "id": "komunalni-2022-562971-c-684379",
       "name": "ZA BEZPEČNÝ DOMOV",
       "type": "party",
       "description": "ZA BEZPEČNÝ DOMOV - DESCRIPTION",
+      "img_url": "suver-bezul-dom",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/Paik01"
       },
       "parties": [
         {
-          "id": "komunalni-2022-562971-684379-party",
+          "id": "komunalni-2022-562971-c-684379-p",
           "name": "ZA BEZPEČNÝ DOMOV",
           "description": "ZA BEZPEČNÝ DOMOV - DESCRIPTION",
           "contacts": {
@@ -521,16 +528,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-562971-candidate-212153",
+      "id": "komunalni-2022-562971-c-212153",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-562971-212153-party",
+          "id": "komunalni-2022-562971-c-212153-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -541,16 +549,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-562971-candidate-771803",
+      "id": "komunalni-2022-562971-c-771803",
       "name": "Správná volba PRO Zdraví a Sport",
       "type": "party",
       "description": "Správná volba PRO Zdraví a Sport - DESCRIPTION",
+      "img_url": "sv pro zs",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-562971-771803-party",
+          "id": "komunalni-2022-562971-c-771803-p",
           "name": "Správná volba PRO Zdraví a Sport",
           "description": "Správná volba PRO Zdraví a Sport - DESCRIPTION",
           "contacts": {
@@ -561,16 +570,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-562971-candidate-244152",
+      "id": "komunalni-2022-562971-c-244152",
       "name": "NOVÝ SEVER",
       "type": "party",
       "description": "NOVÝ SEVER - DESCRIPTION",
+      "img_url": "ns",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-562971-244152-party",
+          "id": "komunalni-2022-562971-c-244152-p",
           "name": "NOVÝ SEVER",
           "description": "NOVÝ SEVER - DESCRIPTION",
           "contacts": {
@@ -581,16 +591,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-562971-candidate-740224",
+      "id": "komunalni-2022-562971-c-740224",
       "name": "Občanská demokratická strana",
       "type": "party",
       "description": "Občanská demokratická strana - DESCRIPTION",
+      "img_url": "ods",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-562971-740224-party",
+          "id": "komunalni-2022-562971-c-740224-p",
           "name": "Občanská demokratická strana",
           "description": "Občanská demokratická strana - DESCRIPTION",
           "contacts": {
@@ -601,16 +612,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-562971-candidate-229623",
+      "id": "komunalni-2022-562971-c-229623",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-562971-229623-party",
+          "id": "komunalni-2022-562971-c-229623-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -621,16 +633,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-562971-candidate-716252",
+      "id": "komunalni-2022-562971-c-716252",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
       "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "img_url": "stan",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-562971-716252-party",
+          "id": "komunalni-2022-562971-c-716252-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
           "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
           "contacts": {
@@ -643,321 +656,321 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-562971-answer-935978-1",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-1",
+      "id": "komunalni-2022-562971-a-4",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-1",
       "comment": "Je to rozhodnutí každého občana."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-2",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-2",
+      "id": "komunalni-2022-562971-a-7",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-2",
       "answer": "yes",
       "comment": "Je to služba. Poplatek však by neměl být vysoký, za nás vidíme ideální částku 500 Kč."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-3",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-3",
+      "id": "komunalni-2022-562971-a-10",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-3",
       "answer": "no",
       "comment": "Zásadně ne. Šetřit se dá jinde."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-4",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-4",
+      "id": "komunalni-2022-562971-a-13",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-5",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-5",
+      "id": "komunalni-2022-562971-a-16",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-5",
       "answer": "yes",
       "comment": "Je to naděje, která vede z chudoby."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-6",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-6",
+      "id": "komunalni-2022-562971-a-19",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-6",
       "answer": "yes",
       "comment": "a ideálně s inteligentní s predikcí konfliktů zejména v problémových lokalitách."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-7",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-7",
+      "id": "komunalni-2022-562971-a-22",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-7",
       "answer": "yes",
       "comment": "v našem městě hazard prohlubuje chudobu."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-8",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-8",
+      "id": "komunalni-2022-562971-a-25",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-8",
       "answer": "no",
       "comment": "Je to služba."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-9",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-9",
+      "id": "komunalni-2022-562971-a-28",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-9",
       "answer": "yes",
       "comment": "Ale také je třeba naučit řidiče, aby se do zastávek naučili jezdit, a projektanty, aby se do zálivů dalo zajet."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-10",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-10",
+      "id": "komunalni-2022-562971-a-31",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-10",
       "answer": "yes",
       "comment": "Možnost tajné volby ale musí být ponechána."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-11",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-11",
+      "id": "komunalni-2022-562971-a-34",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-11",
       "answer": "no",
       "comment": "Na toto existuje Zákon č. 106/1999 Sb."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-12",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-12"
+      "id": "komunalni-2022-562971-a-37",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-12"
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-13",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-13",
+      "id": "komunalni-2022-562971-a-40",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-13",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-14",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-14",
+      "id": "komunalni-2022-562971-a-43",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-14",
       "answer": "yes",
       "comment": "V odůvodněných případech."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-15",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-15",
+      "id": "komunalni-2022-562971-a-46",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-15",
       "answer": "no",
       "comment": "Kvůli bezpečnosti. "
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-16",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-16"
+      "id": "komunalni-2022-562971-a-49",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-16"
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-17",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-17",
+      "id": "komunalni-2022-562971-a-52",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-18",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-18",
+      "id": "komunalni-2022-562971-a-55",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-19",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-19",
+      "id": "komunalni-2022-562971-a-58",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-19",
       "answer": "yes",
       "comment": "v rámci participativního rozpočtu."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-20",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-20",
+      "id": "komunalni-2022-562971-a-61",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-20",
       "answer": "yes",
       "comment": "Vykupování bytů pomáhá situaci na sídlištích."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-21",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-21",
+      "id": "komunalni-2022-562971-a-64",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-21",
       "comment": "Nelze odpovědět, neumíme predikovat situaci za 3 měsíce."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-22",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-22",
+      "id": "komunalni-2022-562971-a-67",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-23",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-23",
+      "id": "komunalni-2022-562971-a-70",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-23",
       "answer": "no",
       "comment": "Je to záležitost soukromé sféry ne města."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-24",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-24",
+      "id": "komunalni-2022-562971-a-73",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-24",
       "answer": "no",
       "comment": "Parkování v centru musí být regulováno, jinak bude plné aut, čím budou znevýhodňování zejména rezidenti v centru."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-25",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-25",
+      "id": "komunalni-2022-562971-a-76",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-25",
       "answer": "no",
       "comment": "Plošně ne, protože zde hrozí vykoupení spekulanty, kteří si tam nastěhují nepřizpůsobivé. "
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-26",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-26"
+      "id": "komunalni-2022-562971-a-79",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-26"
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-27",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-27",
+      "id": "komunalni-2022-562971-a-82",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-27",
       "answer": "no",
       "comment": "Ke všem módům má být přistupováno se stejným měřítkem."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-28",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-28",
+      "id": "komunalni-2022-562971-a-85",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-28",
       "answer": "no",
       "comment": "Nezasahujeme do soukromého vlastnictví."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-29",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-29"
+      "id": "komunalni-2022-562971-a-88",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-29"
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-30",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-30",
+      "id": "komunalni-2022-562971-a-91",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-30",
       "answer": "yes",
       "comment": "Pouze z dotací."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-31",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-31",
+      "id": "komunalni-2022-562971-a-94",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-32",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-32",
+      "id": "komunalni-2022-562971-a-97",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-32",
       "answer": "no",
       "comment": "MHD je služba. "
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-33",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-33",
+      "id": "komunalni-2022-562971-a-100",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-33",
       "answer": "yes",
       "comment": "Dá se tak ušetřit za energie. To je podstatné v dnešní době."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-34",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-34",
+      "id": "komunalni-2022-562971-a-103",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-35",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-35",
+      "id": "komunalni-2022-562971-a-106",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-36",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-36",
+      "id": "komunalni-2022-562971-a-109",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-37",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-37",
+      "id": "komunalni-2022-562971-a-112",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-37",
       "answer": "yes",
       "comment": "Tím se dají ušetřit provozní náklady města."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-38",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-38",
+      "id": "komunalni-2022-562971-a-115",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-38",
       "answer": "no",
       "comment": "Město do těchto alternativních dopravních prostředků nemá zasahovat. Je to byznys soukromé sféry. Koloběžky nesmí ohrožovat občany."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-39",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-39",
+      "id": "komunalni-2022-562971-a-118",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-39",
       "comment": "Tendenční otázka."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-40",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-40",
+      "id": "komunalni-2022-562971-a-121",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-40",
       "answer": "yes",
       "comment": "Posiluje bezpečnost."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-41",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-41",
+      "id": "komunalni-2022-562971-a-124",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-41",
       "answer": "yes",
       "comment": "Ochlazování prostředí ve městě."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-42",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-42",
+      "id": "komunalni-2022-562971-a-127",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-42",
       "answer": "yes",
       "comment": "výstavbou příslušné infrastruktury."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-43",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-43",
+      "id": "komunalni-2022-562971-a-130",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-43",
       "answer": "no",
       "comment": "Tyto prostředky je třeba věnovat na podporu sportu pro děti a mladistvé."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-44",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-44",
+      "id": "komunalni-2022-562971-a-133",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-44",
       "answer": "no",
       "comment": "Současná hodnota je adekvátní."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-45",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-45"
+      "id": "komunalni-2022-562971-a-136",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-45"
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-46",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-46",
+      "id": "komunalni-2022-562971-a-139",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-46",
       "answer": "yes",
       "comment": "Aby město dokázalo mít přehled, kdo v jeho městě bydlí. Dokáže tak zamezit přílivu nepřizpůsobivých občanů."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-47",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-47",
+      "id": "komunalni-2022-562971-a-142",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-47",
       "answer": "no",
       "comment": "Držme se obvodu ZŠ."
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-48",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-48"
+      "id": "komunalni-2022-562971-a-145",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-48"
     },
     {
-      "id": "komunalni-2022-562971-answer-935978-49",
-      "candidate_id": "komunalni-2022-562971-candidate-935978",
-      "question_id": "komunalni-2022-562971-question-49",
+      "id": "komunalni-2022-562971-a-148",
+      "candidate_id": "komunalni-2022-562971-c-935978",
+      "question_id": "komunalni-2022-562971-q-49",
       "comment": "Přijde nám, že některé otázky se netýkají problémů, které reálně komunální politici řeší. Projekt volební kalkulačky ale kvitujeme a podporujeme to. Děkujeme za oslovení."
     }
   ]

--- a/data/kalkulacka/komunalni-2022/563510.json
+++ b/data/kalkulacka/komunalni-2022/563510.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-563510",
   "name": "Jablonec nad Nisou",
-  "description": "Jablonec nad Nisou - DESCRIPTION",
+  "description": "Jablonec nad Nisou",
   "district_code": "563510",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-563510-question-1",
+      "id": "komunalni-2022-563510-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-2",
+      "id": "komunalni-2022-563510-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-3",
+      "id": "komunalni-2022-563510-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-4",
+      "id": "komunalni-2022-563510-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-5",
+      "id": "komunalni-2022-563510-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-6",
+      "id": "komunalni-2022-563510-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-7",
+      "id": "komunalni-2022-563510-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-8",
+      "id": "komunalni-2022-563510-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-9",
+      "id": "komunalni-2022-563510-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-10",
+      "id": "komunalni-2022-563510-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-11",
+      "id": "komunalni-2022-563510-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-12",
+      "id": "komunalni-2022-563510-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-13",
+      "id": "komunalni-2022-563510-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-14",
+      "id": "komunalni-2022-563510-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-15",
+      "id": "komunalni-2022-563510-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-16",
+      "id": "komunalni-2022-563510-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-17",
+      "id": "komunalni-2022-563510-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-18",
+      "id": "komunalni-2022-563510-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-19",
+      "id": "komunalni-2022-563510-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-20",
+      "id": "komunalni-2022-563510-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-21",
+      "id": "komunalni-2022-563510-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-22",
+      "id": "komunalni-2022-563510-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-23",
+      "id": "komunalni-2022-563510-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-24",
+      "id": "komunalni-2022-563510-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-25",
+      "id": "komunalni-2022-563510-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-26",
+      "id": "komunalni-2022-563510-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-27",
+      "id": "komunalni-2022-563510-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-28",
+      "id": "komunalni-2022-563510-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-29",
+      "id": "komunalni-2022-563510-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-30",
+      "id": "komunalni-2022-563510-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-31",
+      "id": "komunalni-2022-563510-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-32",
+      "id": "komunalni-2022-563510-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-33",
+      "id": "komunalni-2022-563510-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-34",
+      "id": "komunalni-2022-563510-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-35",
+      "id": "komunalni-2022-563510-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-36",
+      "id": "komunalni-2022-563510-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-37",
+      "id": "komunalni-2022-563510-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-38",
+      "id": "komunalni-2022-563510-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-39",
+      "id": "komunalni-2022-563510-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-40",
+      "id": "komunalni-2022-563510-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-41",
+      "id": "komunalni-2022-563510-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-42",
+      "id": "komunalni-2022-563510-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-43",
+      "id": "komunalni-2022-563510-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-44",
+      "id": "komunalni-2022-563510-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-45",
+      "id": "komunalni-2022-563510-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-46",
+      "id": "komunalni-2022-563510-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-47",
+      "id": "komunalni-2022-563510-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563510-question-48",
+      "id": "komunalni-2022-563510-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,16 +399,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-563510-candidate-272135",
+      "id": "komunalni-2022-563510-c-272135",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-563510-272135-party",
+          "id": "komunalni-2022-563510-c-272135-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -417,16 +420,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-563510-candidate-883338",
+      "id": "komunalni-2022-563510-c-883338",
       "name": "Právo Respekt Odbornost",
       "type": "party",
       "description": "Právo Respekt Odbornost - DESCRIPTION",
+      "img_url": "pro 2022",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-563510-883338-party",
+          "id": "komunalni-2022-563510-c-883338-p",
           "name": "Právo Respekt Odbornost",
           "description": "Právo Respekt Odbornost - DESCRIPTION",
           "contacts": {
@@ -437,10 +441,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-563510-candidate-387010",
+      "id": "komunalni-2022-563510-c-387010",
       "name": "Starostové pro Liberecký kraj",
       "type": "party",
       "description": "Starostové pro Liberecký kraj - DESCRIPTION",
+      "img_url": "slk",
       "contacts": {
         "web": [
           {
@@ -452,7 +457,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-563510-387010-party",
+          "id": "komunalni-2022-563510-c-387010-p",
           "name": "Starostové pro Liberecký kraj",
           "description": "Starostové pro Liberecký kraj - DESCRIPTION",
           "contacts": {
@@ -469,10 +474,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-563510-candidate-547567",
+      "id": "komunalni-2022-563510-c-547567",
       "name": "Pro Jablonec",
       "type": "party",
       "description": "Pro Jablonec - DESCRIPTION",
+      "img_url": "nbplk-nk",
       "contacts": {
         "web": [
           {
@@ -488,7 +494,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-563510-547567-party",
+          "id": "komunalni-2022-563510-c-547567-p",
           "name": "Pro Jablonec",
           "description": "Pro Jablonec - DESCRIPTION",
           "contacts": {
@@ -509,16 +515,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-563510-candidate-140770",
+      "id": "komunalni-2022-563510-c-140770",
       "name": "Piráti a nezávislí",
       "type": "party",
       "description": "Piráti a nezávislí - DESCRIPTION",
+      "img_url": "piráti-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-563510-140770-party",
+          "id": "komunalni-2022-563510-c-140770-p",
           "name": "Piráti a nezávislí",
           "description": "Piráti a nezávislí - DESCRIPTION",
           "contacts": {
@@ -529,16 +536,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-563510-candidate-185818",
+      "id": "komunalni-2022-563510-c-185818",
       "name": "Občanská demokratická strana",
       "type": "party",
       "description": "Občanská demokratická strana - DESCRIPTION",
+      "img_url": "ods",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-563510-185818-party",
+          "id": "komunalni-2022-563510-c-185818-p",
           "name": "Občanská demokratická strana",
           "description": "Občanská demokratická strana - DESCRIPTION",
           "contacts": {
@@ -549,16 +557,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-563510-candidate-614056",
+      "id": "komunalni-2022-563510-c-614056",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-563510-614056-party",
+          "id": "komunalni-2022-563510-c-614056-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -569,16 +578,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-563510-candidate-261835",
+      "id": "komunalni-2022-563510-c-261835",
       "name": "DOMOV NAD NISOU",
       "type": "party",
       "description": "DOMOV NAD NISOU - DESCRIPTION",
+      "img_url": "nez-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-563510-261835-party",
+          "id": "komunalni-2022-563510-c-261835-p",
           "name": "DOMOV NAD NISOU",
           "description": "DOMOV NAD NISOU - DESCRIPTION",
           "contacts": {
@@ -589,17 +599,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-563510-candidate-662237",
+      "id": "komunalni-2022-563510-c-662237",
       "name": "Křížek pro LEVNÉ ENERGIE z městské elektrárny, ODPADY ZDARMA (kdo třídí, neplatí), dostupné PARKOVÁNÍ, POŘÁDEK a BEZP…",
       "type": "party",
       "description": "Křížek pro LEVNÉ ENERGIE z městské elektrárny, ODPADY ZDARMA (kdo třídí, neplatí), dostupné PARKOVÁNÍ, POŘÁDEK a BEZP… - DESCRIPTION",
+      "img_url": "top 09-nk",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/KrizekPro"
       },
       "parties": [
         {
-          "id": "komunalni-2022-563510-662237-party",
+          "id": "komunalni-2022-563510-c-662237-p",
           "name": "Křížek pro LEVNÉ ENERGIE z městské elektrárny, ODPADY ZDARMA (kdo třídí, neplatí), dostupné PARKOVÁNÍ, POŘÁDEK a BEZP…",
           "description": "Křížek pro LEVNÉ ENERGIE z městské elektrárny, ODPADY ZDARMA (kdo třídí, neplatí), dostupné PARKOVÁNÍ, POŘÁDEK a BEZP… - DESCRIPTION",
           "contacts": {
@@ -611,16 +622,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-563510-candidate-708081",
+      "id": "komunalni-2022-563510-c-708081",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-563510-708081-party",
+          "id": "komunalni-2022-563510-c-708081-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -631,10 +643,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-563510-candidate-479108",
+      "id": "komunalni-2022-563510-c-479108",
       "name": "Společně pro Jablonec",
       "type": "party",
       "description": "Společně pro Jablonec - DESCRIPTION",
+      "img_url": "kdučsl-zel.-nk",
       "contacts": {
         "web": [
           {
@@ -650,7 +663,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-563510-479108-party",
+          "id": "komunalni-2022-563510-c-479108-p",
           "name": "Společně pro Jablonec",
           "description": "Společně pro Jablonec - DESCRIPTION",
           "contacts": {

--- a/data/kalkulacka/komunalni-2022/563889.json
+++ b/data/kalkulacka/komunalni-2022/563889.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-563889",
   "name": "Liberec",
-  "description": "Liberec - DESCRIPTION",
+  "description": "Liberec",
   "district_code": "563889",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-563889-question-1",
+      "id": "komunalni-2022-563889-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-2",
+      "id": "komunalni-2022-563889-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-3",
+      "id": "komunalni-2022-563889-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-4",
+      "id": "komunalni-2022-563889-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-5",
+      "id": "komunalni-2022-563889-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-6",
+      "id": "komunalni-2022-563889-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-7",
+      "id": "komunalni-2022-563889-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-8",
+      "id": "komunalni-2022-563889-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-9",
+      "id": "komunalni-2022-563889-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-10",
+      "id": "komunalni-2022-563889-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-11",
+      "id": "komunalni-2022-563889-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-12",
+      "id": "komunalni-2022-563889-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-13",
+      "id": "komunalni-2022-563889-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-14",
+      "id": "komunalni-2022-563889-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-15",
+      "id": "komunalni-2022-563889-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-16",
+      "id": "komunalni-2022-563889-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-17",
+      "id": "komunalni-2022-563889-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-18",
+      "id": "komunalni-2022-563889-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-19",
+      "id": "komunalni-2022-563889-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-20",
+      "id": "komunalni-2022-563889-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-21",
+      "id": "komunalni-2022-563889-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-22",
+      "id": "komunalni-2022-563889-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-23",
+      "id": "komunalni-2022-563889-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-24",
+      "id": "komunalni-2022-563889-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-25",
+      "id": "komunalni-2022-563889-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-26",
+      "id": "komunalni-2022-563889-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-27",
+      "id": "komunalni-2022-563889-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-28",
+      "id": "komunalni-2022-563889-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-29",
+      "id": "komunalni-2022-563889-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-30",
+      "id": "komunalni-2022-563889-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-31",
+      "id": "komunalni-2022-563889-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-32",
+      "id": "komunalni-2022-563889-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-33",
+      "id": "komunalni-2022-563889-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-34",
+      "id": "komunalni-2022-563889-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-35",
+      "id": "komunalni-2022-563889-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-36",
+      "id": "komunalni-2022-563889-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-37",
+      "id": "komunalni-2022-563889-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-38",
+      "id": "komunalni-2022-563889-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-39",
+      "id": "komunalni-2022-563889-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-40",
+      "id": "komunalni-2022-563889-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-41",
+      "id": "komunalni-2022-563889-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-42",
+      "id": "komunalni-2022-563889-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-43",
+      "id": "komunalni-2022-563889-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-44",
+      "id": "komunalni-2022-563889-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-45",
+      "id": "komunalni-2022-563889-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-46",
+      "id": "komunalni-2022-563889-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-47",
+      "id": "komunalni-2022-563889-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-48",
+      "id": "komunalni-2022-563889-q-48",
       "name": "Lanovka na Ještěd",
       "title": "Podporuji, aby se prodloužila trasa lanovky na Ještěd",
       "gist": "Lanovku na Ještěd zastavila tragédie v říjnu 2021. Podle dosavadních zjištění vyšetřovatelů prasklo tažné lano a jedna z kabin lanovky se zřítila na zem.Kabinky by měly být pro 8 - 10 cestujících. Nejprve by lanovka byla obnovena ve stávající délce a do budoucna se prodloužila k centrálnímu parkovišti u stanice tramvaje Horní Hanychov. Kritici namítají, že odhadovaná cena 300 milionů korun je příliš vysoká a že si zatím nikdo netroufá odhadnout termín dokončení.",
@@ -395,7 +397,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-49",
+      "id": "komunalni-2022-563889-q-49",
       "name": "Oprava městského bazénu",
       "title": "Oprava městského bazénu musí výrazně zlevnit",
       "gist": "Minulé vedení města opravu připravovalo a bylo kritizováno, že rekonstrukce bude moc drahá. Tehdy se přitom náklady pohybovaly kolem 350 až 400 milionů korun. Za současného vedení a situace na stavebním trhu už se náklady blíží téměř jedné miliardě.",
@@ -403,7 +405,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-50",
+      "id": "komunalni-2022-563889-q-50",
       "name": "Demontáž laviček",
       "title": "Souhlasím s tím, aby město demontovalo lavičky obsazované lidmi bez domova.",
       "gist": "",
@@ -411,7 +413,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-51",
+      "id": "komunalni-2022-563889-q-51",
       "name": "Bydlení především",
       "title": "Podporuji, aby Liberec pokračoval v projektu Housing First.",
       "gist": "Projekty Housing First zajišťují stabilní bydlení pro nejohroženější skupinu obyvatel. V Česku díky nim získalo bezpečný domov a podporu sociálních pracovníků více než 700 lidí, z toho 320 dětí. Do projektu se zapojují i další česká i světová města; např. ve Vídni si bydlení udrželo 98 % domácností. Pilotní Brno i přes úspěch i ocenění od projektu postupně ustoupilo. Vedení města argumentovalo vysokými náklady, zastánci projektu ale poukazovali, že je většina výdajů hrazená z fondů EU.",
@@ -419,7 +421,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-563889-question-52",
+      "id": "komunalni-2022-563889-q-52",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -429,16 +431,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-563889-candidate-709264",
+      "id": "komunalni-2022-563889-c-709264",
       "name": "Trikolora a Soukromníci",
       "type": "party",
       "description": "Trikolora a Soukromníci - DESCRIPTION",
+      "img_url": "trikol-soukrom",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-563889-709264-party",
+          "id": "komunalni-2022-563889-c-709264-p",
           "name": "Trikolora a Soukromníci",
           "description": "Trikolora a Soukromníci - DESCRIPTION",
           "contacts": {
@@ -449,10 +452,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-563889-candidate-434921",
+      "id": "komunalni-2022-563889-c-434921",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": [
           {
@@ -463,7 +467,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-563889-434921-party",
+          "id": "komunalni-2022-563889-c-434921-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -479,10 +483,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-563889-candidate-184949",
+      "id": "komunalni-2022-563889-c-184949",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": [
           {
@@ -495,7 +500,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-563889-184949-party",
+          "id": "komunalni-2022-563889-c-184949-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -513,10 +518,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-563889-candidate-282146",
+      "id": "komunalni-2022-563889-c-282146",
       "name": "Starostové pro Liberecký kraj společně s TOP 09 a KDU-ČSL",
       "type": "party",
       "description": "Starostové pro Liberecký kraj společně s TOP 09 a KDU-ČSL - DESCRIPTION",
+      "img_url": "kdu-čsl-slk-top",
       "contacts": {
         "web": [
           {
@@ -532,7 +538,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-563889-282146-party",
+          "id": "komunalni-2022-563889-c-282146-p",
           "name": "Starostové pro Liberecký kraj společně s TOP 09 a KDU-ČSL",
           "description": "Starostové pro Liberecký kraj společně s TOP 09 a KDU-ČSL - DESCRIPTION",
           "contacts": {
@@ -553,10 +559,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-563889-candidate-188908",
+      "id": "komunalni-2022-563889-c-188908",
       "name": "Liberec otevřený lidem",
       "type": "party",
       "description": "Liberec otevřený lidem - DESCRIPTION",
+      "img_url": "zelení-nk",
       "contacts": {
         "web": [
           {
@@ -569,7 +576,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-563889-188908-party",
+          "id": "komunalni-2022-563889-c-188908-p",
           "name": "Liberec otevřený lidem",
           "description": "Liberec otevřený lidem - DESCRIPTION",
           "contacts": {
@@ -587,10 +594,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-563889-candidate-230742",
+      "id": "komunalni-2022-563889-c-230742",
       "name": "ODS společně se Sportovci",
       "type": "party",
       "description": "ODS společně se Sportovci - DESCRIPTION",
+      "img_url": "ods-usz-nk",
       "contacts": {
         "web": [
           {
@@ -606,7 +614,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-563889-230742-party",
+          "id": "komunalni-2022-563889-c-230742-p",
           "name": "ODS společně se Sportovci",
           "description": "ODS společně se Sportovci - DESCRIPTION",
           "contacts": {
@@ -627,16 +635,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-563889-candidate-843854",
+      "id": "komunalni-2022-563889-c-843854",
       "name": "Právo Respekt Odbornost",
       "type": "party",
       "description": "Právo Respekt Odbornost - DESCRIPTION",
+      "img_url": "pro 2022",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-563889-843854-party",
+          "id": "komunalni-2022-563889-c-843854-p",
           "name": "Právo Respekt Odbornost",
           "description": "Právo Respekt Odbornost - DESCRIPTION",
           "contacts": {
@@ -647,16 +656,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-563889-candidate-401265",
+      "id": "komunalni-2022-563889-c-401265",
       "name": "Komunistická strana Čech a Moravy a Podještědská levice",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy a Podještědská levice - DESCRIPTION",
+      "img_url": "ksčm-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-563889-401265-party",
+          "id": "komunalni-2022-563889-c-401265-p",
           "name": "Komunistická strana Čech a Moravy a Podještědská levice",
           "description": "Komunistická strana Čech a Moravy a Podještědská levice - DESCRIPTION",
           "contacts": {
@@ -667,16 +677,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-563889-candidate-323656",
+      "id": "komunalni-2022-563889-c-323656",
       "name": "Česká strana sociálně demokratická",
       "type": "party",
       "description": "Česká strana sociálně demokratická - DESCRIPTION",
+      "img_url": "čssd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-563889-323656-party",
+          "id": "komunalni-2022-563889-c-323656-p",
           "name": "Česká strana sociálně demokratická",
           "description": "Česká strana sociálně demokratická - DESCRIPTION",
           "contacts": {
@@ -687,10 +698,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-563889-candidate-690485",
+      "id": "komunalni-2022-563889-c-690485",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": [
           {
@@ -702,7 +714,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-563889-690485-party",
+          "id": "komunalni-2022-563889-c-690485-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -721,1291 +733,1625 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-563889-answer-401265-1",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-1",
+      "id": "komunalni-2022-563889-a-4",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-1",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-2",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-2",
+      "id": "komunalni-2022-563889-a-7",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-3",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-3",
+      "id": "komunalni-2022-563889-a-10",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-4",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-4",
+      "id": "komunalni-2022-563889-a-13",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-5",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-5",
+      "id": "komunalni-2022-563889-a-16",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-6",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-6",
+      "id": "komunalni-2022-563889-a-19",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-7",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-7",
+      "id": "komunalni-2022-563889-a-22",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-8",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-8",
+      "id": "komunalni-2022-563889-a-25",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-9",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-9",
+      "id": "komunalni-2022-563889-a-28",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-10",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-10",
+      "id": "komunalni-2022-563889-a-31",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-11",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-11",
+      "id": "komunalni-2022-563889-a-34",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-12",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-12",
+      "id": "komunalni-2022-563889-a-37",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-13",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-13",
+      "id": "komunalni-2022-563889-a-40",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-14",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-14",
+      "id": "komunalni-2022-563889-a-43",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-15",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-15",
+      "id": "komunalni-2022-563889-a-46",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-15",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-16",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-16",
+      "id": "komunalni-2022-563889-a-49",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-16",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-17",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-17",
+      "id": "komunalni-2022-563889-a-52",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-18",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-18",
+      "id": "komunalni-2022-563889-a-55",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-19",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-19",
+      "id": "komunalni-2022-563889-a-58",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-20",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-20",
+      "id": "komunalni-2022-563889-a-61",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-21",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-21",
+      "id": "komunalni-2022-563889-a-64",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-22",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-22",
+      "id": "komunalni-2022-563889-a-67",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-22",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-23",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-23",
+      "id": "komunalni-2022-563889-a-70",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-23",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-24",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-24",
+      "id": "komunalni-2022-563889-a-73",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-25",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-25",
+      "id": "komunalni-2022-563889-a-76",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-26",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-26",
+      "id": "komunalni-2022-563889-a-79",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-27",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-27",
+      "id": "komunalni-2022-563889-a-82",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-28",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-28",
+      "id": "komunalni-2022-563889-a-85",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-28",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-29",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-29",
+      "id": "komunalni-2022-563889-a-88",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-30",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-30",
+      "id": "komunalni-2022-563889-a-91",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-30",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-31",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-31",
+      "id": "komunalni-2022-563889-a-94",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-32",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-32",
+      "id": "komunalni-2022-563889-a-97",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-33",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-33",
+      "id": "komunalni-2022-563889-a-100",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-34",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-34",
+      "id": "komunalni-2022-563889-a-103",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-35",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-35",
+      "id": "komunalni-2022-563889-a-106",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-36",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-36",
+      "id": "komunalni-2022-563889-a-109",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-37",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-37",
+      "id": "komunalni-2022-563889-a-112",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-38",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-38",
+      "id": "komunalni-2022-563889-a-115",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-39",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-39"
+      "id": "komunalni-2022-563889-a-118",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-39"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-40",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-40",
+      "id": "komunalni-2022-563889-a-121",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-41",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-41",
+      "id": "komunalni-2022-563889-a-124",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-41",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-42",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-42",
+      "id": "komunalni-2022-563889-a-127",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-43",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-43"
+      "id": "komunalni-2022-563889-a-130",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-43"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-44",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-44",
+      "id": "komunalni-2022-563889-a-133",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-45",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-45"
+      "id": "komunalni-2022-563889-a-136",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-45"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-46",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-46",
+      "id": "komunalni-2022-563889-a-139",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-47",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-47"
+      "id": "komunalni-2022-563889-a-142",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-47"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-48",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-48",
+      "id": "komunalni-2022-563889-a-145",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-49",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-49",
+      "id": "komunalni-2022-563889-a-148",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-50",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-50",
+      "id": "komunalni-2022-563889-a-151",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-50",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-51",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-51"
+      "id": "komunalni-2022-563889-a-154",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-51"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-52",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-52",
+      "id": "komunalni-2022-563889-a-157",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-52",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-401265-53",
-      "candidate_id": "komunalni-2022-563889-candidate-401265",
-      "question_id": "komunalni-2022-563889-question-53"
+      "id": "komunalni-2022-563889-a-160",
+      "candidate_id": "komunalni-2022-563889-c-401265",
+      "question_id": "komunalni-2022-563889-q-53"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-1",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-1",
+      "id": "komunalni-2022-563889-a-4",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-2",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-2",
+      "id": "komunalni-2022-563889-a-7",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-2",
       "answer": "yes",
       "comment": "Ceny za odvoz netříděného odpadu musí být motivační k třídění, ne paušál "
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-3",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-3",
+      "id": "komunalni-2022-563889-a-10",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-3",
       "answer": "no",
       "comment": "Teplo je součástí kvalitního života pro seniory"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-4",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-4",
+      "id": "komunalni-2022-563889-a-13",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-4",
       "answer": "yes",
       "comment": "U škol, školek a zdravotnických zařízení "
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-5",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-5",
+      "id": "komunalni-2022-563889-a-16",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-6",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-6",
+      "id": "komunalni-2022-563889-a-19",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-7",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-7",
+      "id": "komunalni-2022-563889-a-22",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-8",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-8",
+      "id": "komunalni-2022-563889-a-25",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-8",
       "answer": "no",
       "comment": "Nechceme, aby v době energetické krize se cena navyšovala"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-9",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-9",
+      "id": "komunalni-2022-563889-a-28",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-10",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-10",
+      "id": "komunalni-2022-563889-a-31",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-11",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-11",
+      "id": "komunalni-2022-563889-a-34",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-12",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-12",
+      "id": "komunalni-2022-563889-a-37",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-13",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-13",
+      "id": "komunalni-2022-563889-a-40",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-14",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-14",
+      "id": "komunalni-2022-563889-a-43",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-15",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-15",
+      "id": "komunalni-2022-563889-a-46",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-15",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-16",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-16",
+      "id": "komunalni-2022-563889-a-49",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-16",
       "answer": "yes",
       "comment": "Ne ve zdravotnických zařízeních"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-17",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-17",
+      "id": "komunalni-2022-563889-a-52",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-18",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-18",
+      "id": "komunalni-2022-563889-a-55",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-19",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-19",
+      "id": "komunalni-2022-563889-a-58",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-20",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-20",
+      "id": "komunalni-2022-563889-a-61",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-21",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-21",
+      "id": "komunalni-2022-563889-a-64",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-22",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-22",
+      "id": "komunalni-2022-563889-a-67",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-22",
       "answer": "no",
       "comment": "Obědy zadarmo pro rodiny s přídavky na děti "
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-23",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-23"
+      "id": "komunalni-2022-563889-a-70",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-23"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-24",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-24",
+      "id": "komunalni-2022-563889-a-73",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-24",
       "answer": "yes",
       "comment": "Problematiku parkování máme nově pojatou ve volebním programu"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-25",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-25",
+      "id": "komunalni-2022-563889-a-76",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-26",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-26",
+      "id": "komunalni-2022-563889-a-79",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-27",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-27",
+      "id": "komunalni-2022-563889-a-82",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-28",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-28"
+      "id": "komunalni-2022-563889-a-85",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-28"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-29",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-29",
+      "id": "komunalni-2022-563889-a-88",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-30",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-30",
+      "id": "komunalni-2022-563889-a-91",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-30",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-31",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-31",
+      "id": "komunalni-2022-563889-a-94",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-31",
       "answer": "yes",
       "comment": "Liberec potřebuje byty pro mladé rodiny, samoživitelky a seniory"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-32",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-32",
+      "id": "komunalni-2022-563889-a-97",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-33",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-33",
+      "id": "komunalni-2022-563889-a-100",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-33",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-34",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-34",
+      "id": "komunalni-2022-563889-a-103",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-35",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-35",
+      "id": "komunalni-2022-563889-a-106",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-36",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-36",
+      "id": "komunalni-2022-563889-a-109",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-37",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-37",
+      "id": "komunalni-2022-563889-a-112",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-38",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-38",
+      "id": "komunalni-2022-563889-a-115",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-38",
       "answer": "no",
       "comment": "Pro elektrokoloběžky nemá Liberec vybudované bezpećné komunikace"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-39",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-39",
+      "id": "komunalni-2022-563889-a-118",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-40",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-40"
+      "id": "komunalni-2022-563889-a-121",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-40"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-41",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-41",
+      "id": "komunalni-2022-563889-a-124",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-41",
       "answer": "yes",
       "comment": "Kromě více zelených ploch je třeba i více vodních ploch, město je od betonu prehřáté"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-42",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-42",
+      "id": "komunalni-2022-563889-a-127",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-43",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-43",
+      "id": "komunalni-2022-563889-a-130",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-43",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-44",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-44",
+      "id": "komunalni-2022-563889-a-133",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-45",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-45",
+      "id": "komunalni-2022-563889-a-136",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-46",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-46",
+      "id": "komunalni-2022-563889-a-139",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-47",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-47",
+      "id": "komunalni-2022-563889-a-142",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-48",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-48",
+      "id": "komunalni-2022-563889-a-145",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-48",
       "answer": "no",
       "comment": "Lanovku je třeba ihned uvést zpět do provozu "
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-49",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-49",
+      "id": "komunalni-2022-563889-a-148",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-50",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-50",
+      "id": "komunalni-2022-563889-a-151",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-50",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-51",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-51"
+      "id": "komunalni-2022-563889-a-154",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-51"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-52",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-52",
+      "id": "komunalni-2022-563889-a-157",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-52",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-323656-53",
-      "candidate_id": "komunalni-2022-563889-candidate-323656",
-      "question_id": "komunalni-2022-563889-question-53",
+      "id": "komunalni-2022-563889-a-160",
+      "candidate_id": "komunalni-2022-563889-c-323656",
+      "question_id": "komunalni-2022-563889-q-53",
       "comment": "Zahrnout dlouhodobé vize stran a aktuální energetickou krizi"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-1",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-1",
+      "id": "komunalni-2022-563889-a-4",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-1",
       "answer": "no",
       "comment": "Občané jsou si rovni."
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-2",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-2",
+      "id": "komunalni-2022-563889-a-7",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-2",
       "answer": "yes",
       "comment": "Pokud lidé dostávají službu zcela zdarma, neváží si jí. Poplatkem je třeba motivovat k prospěšným aktivitám v oblasti odpadů."
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-3",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-3",
+      "id": "komunalni-2022-563889-a-10",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-3",
       "answer": "no",
       "comment": "Žijeme v 21. století !"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-4",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-4",
+      "id": "komunalni-2022-563889-a-13",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-5",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-5",
+      "id": "komunalni-2022-563889-a-16",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-6",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-6",
+      "id": "komunalni-2022-563889-a-19",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-6",
       "answer": "yes",
       "comment": "Jde o moderní metodu jak pomoci policii."
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-7",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-7",
+      "id": "komunalni-2022-563889-a-22",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-7",
       "answer": "no",
       "comment": "To jsme se nepoučili z dopadů prohibice v USA ?"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-8",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-8",
+      "id": "komunalni-2022-563889-a-25",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-9",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-9",
+      "id": "komunalni-2022-563889-a-28",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-10",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-10",
+      "id": "komunalni-2022-563889-a-31",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-10",
       "answer": "yes",
       "comment": "Nikdo by se neměl stydět za své činy."
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-11",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-11",
+      "id": "komunalni-2022-563889-a-34",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-11",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-12",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-12",
+      "id": "komunalni-2022-563889-a-37",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-12",
       "answer": "no",
       "comment": "Regulace ano, ale ne totální."
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-13",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-13",
+      "id": "komunalni-2022-563889-a-40",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-14",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-14",
+      "id": "komunalni-2022-563889-a-43",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-15",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-15",
+      "id": "komunalni-2022-563889-a-46",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-15",
       "answer": "yes",
       "comment": "Mohlo by to být formou instalací nové techniky s nižším příkonem při zachování svítivosti."
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-16",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-16",
+      "id": "komunalni-2022-563889-a-49",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-16",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-17",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-17",
+      "id": "komunalni-2022-563889-a-52",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-17",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-18",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-18",
+      "id": "komunalni-2022-563889-a-55",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-19",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-19",
+      "id": "komunalni-2022-563889-a-58",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-20",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-20",
+      "id": "komunalni-2022-563889-a-61",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-21",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-21",
+      "id": "komunalni-2022-563889-a-64",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-21",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-22",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-22",
+      "id": "komunalni-2022-563889-a-67",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-22",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-23",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-23",
+      "id": "komunalni-2022-563889-a-70",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-24",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-24",
+      "id": "komunalni-2022-563889-a-73",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-25",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-25",
+      "id": "komunalni-2022-563889-a-76",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-26",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-26",
+      "id": "komunalni-2022-563889-a-79",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-27",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-27",
+      "id": "komunalni-2022-563889-a-82",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-27",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-28",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-28",
+      "id": "komunalni-2022-563889-a-85",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-29",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-29",
+      "id": "komunalni-2022-563889-a-88",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-30",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-30"
+      "id": "komunalni-2022-563889-a-91",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-30"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-31",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-31",
+      "id": "komunalni-2022-563889-a-94",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-32",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-32",
+      "id": "komunalni-2022-563889-a-97",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-33",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-33",
+      "id": "komunalni-2022-563889-a-100",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-33",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-34",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-34",
+      "id": "komunalni-2022-563889-a-103",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-35",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-35",
+      "id": "komunalni-2022-563889-a-106",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-36",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-36",
+      "id": "komunalni-2022-563889-a-109",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-37",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-37",
+      "id": "komunalni-2022-563889-a-112",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-38",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-38",
+      "id": "komunalni-2022-563889-a-115",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-38",
       "answer": "no",
       "comment": "Koloběžky jsou nebezpečné, není k jejich provozu vhodná legislativa. Min. dopravy zaspalo."
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-39",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-39"
+      "id": "komunalni-2022-563889-a-118",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-39"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-40",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-40",
+      "id": "komunalni-2022-563889-a-121",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-40",
       "answer": "yes",
       "comment": "Občan by se měl ve městě cítit bezpečně."
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-41",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-41",
+      "id": "komunalni-2022-563889-a-124",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-41",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-42",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-42"
+      "id": "komunalni-2022-563889-a-127",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-42"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-43",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-43",
+      "id": "komunalni-2022-563889-a-130",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-43",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-44",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-44",
+      "id": "komunalni-2022-563889-a-133",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-45",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-45",
+      "id": "komunalni-2022-563889-a-136",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-46",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-46",
+      "id": "komunalni-2022-563889-a-139",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-47",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-47",
+      "id": "komunalni-2022-563889-a-142",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-48",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-48",
+      "id": "komunalni-2022-563889-a-145",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-48",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-49",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-49",
+      "id": "komunalni-2022-563889-a-148",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-50",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-50",
+      "id": "komunalni-2022-563889-a-151",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-50",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-51",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-51"
+      "id": "komunalni-2022-563889-a-154",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-51"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-52",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-52",
+      "id": "komunalni-2022-563889-a-157",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-52",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-690485-53",
-      "candidate_id": "komunalni-2022-563889-candidate-690485",
-      "question_id": "komunalni-2022-563889-question-53"
+      "id": "komunalni-2022-563889-a-160",
+      "candidate_id": "komunalni-2022-563889-c-690485",
+      "question_id": "komunalni-2022-563889-q-53"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-1",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-1",
+      "id": "komunalni-2022-563889-a-4",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-1",
       "answer": "no",
       "comment": "V každé části by měl být mix obyvatelstva (například skrze sociální bydlení), aby se zabránilo sociální diferenciaci."
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-2",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-2",
+      "id": "komunalni-2022-563889-a-7",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-2",
       "answer": "yes",
       "comment": "Jsme pro zvýhodnění obyvatel, kteří důsledně třídí odpad."
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-3",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-3",
+      "id": "komunalni-2022-563889-a-10",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-4",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-4",
+      "id": "komunalni-2022-563889-a-13",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-5",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-5",
+      "id": "komunalni-2022-563889-a-16",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-6",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-6",
+      "id": "komunalni-2022-563889-a-19",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-6",
       "answer": "no",
       "comment": "Stávající systém je dobrý. Naopak jsme pro zvýšení počtu městských strážníků a pracovníků prevence kriminality."
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-7",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-7",
+      "id": "komunalni-2022-563889-a-22",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-8",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-8",
+      "id": "komunalni-2022-563889-a-25",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-8",
       "answer": "no",
       "comment": "Není to priorita pro toto volební období. Nejdříve je potřeba zlepšit kvalitu MHD a četnost spojů."
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-9",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-9",
+      "id": "komunalni-2022-563889-a-28",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-9",
       "answer": "yes",
       "comment": "Důležité je i zastřešení zastávek. Je potřeba investice do bezbariérových spojů."
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-10",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-10",
+      "id": "komunalni-2022-563889-a-31",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-11",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-11",
+      "id": "komunalni-2022-563889-a-34",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-12",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-12",
+      "id": "komunalni-2022-563889-a-37",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-13",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-13",
+      "id": "komunalni-2022-563889-a-40",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-14",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-14",
+      "id": "komunalni-2022-563889-a-43",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-15",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-15",
+      "id": "komunalni-2022-563889-a-46",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-15",
       "answer": "no",
       "comment": "Jsme pro senzorové osvětlení města. Omezíme světelný smog města tím, že budeme instalovat nové úsporné lampy."
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-16",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-16",
+      "id": "komunalni-2022-563889-a-49",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-16",
       "answer": "yes",
       "comment": "Primárně myslíme úřady města. Ne domovy pro seniory a jiné sociální objekty."
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-17",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-17",
+      "id": "komunalni-2022-563889-a-52",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-18",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-18",
+      "id": "komunalni-2022-563889-a-55",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-19",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-19",
+      "id": "komunalni-2022-563889-a-58",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-20",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-20",
+      "id": "komunalni-2022-563889-a-61",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-21",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-21",
+      "id": "komunalni-2022-563889-a-64",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-22",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-22",
+      "id": "komunalni-2022-563889-a-67",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-22",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-23",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-23",
+      "id": "komunalni-2022-563889-a-70",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-23",
       "answer": "yes",
       "comment": "Je nutnost, aby si provozovatel zajistil parkovací místa, která nebudou blokovat rezidenční parkovací místa."
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-24",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-24",
+      "id": "komunalni-2022-563889-a-73",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-25",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-25",
+      "id": "komunalni-2022-563889-a-76",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-26",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-26",
+      "id": "komunalni-2022-563889-a-79",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-27",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-27",
+      "id": "komunalni-2022-563889-a-82",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-28",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-28",
+      "id": "komunalni-2022-563889-a-85",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-28",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-29",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-29",
+      "id": "komunalni-2022-563889-a-88",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-30",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-30",
+      "id": "komunalni-2022-563889-a-91",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-31",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-31",
+      "id": "komunalni-2022-563889-a-94",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-32",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-32",
+      "id": "komunalni-2022-563889-a-97",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-33",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-33",
+      "id": "komunalni-2022-563889-a-100",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-34",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-34",
+      "id": "komunalni-2022-563889-a-103",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-34",
       "answer": "yes",
       "comment": "Ne pouze pro mládež, ale i pro seniory."
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-35",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-35",
+      "id": "komunalni-2022-563889-a-106",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-36",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-36",
+      "id": "komunalni-2022-563889-a-109",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-36",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-37",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-37",
+      "id": "komunalni-2022-563889-a-112",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-38",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-38",
+      "id": "komunalni-2022-563889-a-115",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-39",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-39",
+      "id": "komunalni-2022-563889-a-118",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-40",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-40",
+      "id": "komunalni-2022-563889-a-121",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-41",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-41",
+      "id": "komunalni-2022-563889-a-124",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-42",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-42",
+      "id": "komunalni-2022-563889-a-127",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-43",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-43",
+      "id": "komunalni-2022-563889-a-130",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-43",
       "answer": "no",
       "comment": "Chceme podporovat amatérský sport a dětské skupiny. Profesionální kluby podporujeme pouze v zapojení mládeže."
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-44",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-44",
+      "id": "komunalni-2022-563889-a-133",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-45",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-45",
+      "id": "komunalni-2022-563889-a-136",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-46",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-46",
+      "id": "komunalni-2022-563889-a-139",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-47",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-47",
+      "id": "komunalni-2022-563889-a-142",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-48",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-48",
+      "id": "komunalni-2022-563889-a-145",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-48",
       "comment": "Záleží na finančních aspektech stavebního procesu."
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-49",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-49",
+      "id": "komunalni-2022-563889-a-148",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-50",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-50",
+      "id": "komunalni-2022-563889-a-151",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-50",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-51",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-51",
+      "id": "komunalni-2022-563889-a-154",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-51",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-52",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-52",
+      "id": "komunalni-2022-563889-a-157",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-52",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-563889-answer-184949-53",
-      "candidate_id": "komunalni-2022-563889-candidate-184949",
-      "question_id": "komunalni-2022-563889-question-53"
+      "id": "komunalni-2022-563889-a-160",
+      "candidate_id": "komunalni-2022-563889-c-184949",
+      "question_id": "komunalni-2022-563889-q-53"
+    },
+    {
+      "id": "komunalni-2022-563889-a-4",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-1"
+    },
+    {
+      "id": "komunalni-2022-563889-a-7",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-563889-a-10",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-3",
+      "answer": "no",
+      "comment": "Senioři jsou ti poslední, kteří by měli být omezováni."
+    },
+    {
+      "id": "komunalni-2022-563889-a-13",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-16",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-19",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-22",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-7",
+      "answer": "no",
+      "comment": "Nejsme pro zákaz, který by hazard jen přesunul do ilegality."
+    },
+    {
+      "id": "komunalni-2022-563889-a-25",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-28",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-9",
+      "answer": "no",
+      "comment": "Nevnímám zastávky jako problematické a bariérové."
+    },
+    {
+      "id": "komunalni-2022-563889-a-31",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-563889-a-34",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-563889-a-37",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-12",
+      "comment": "V centru a v hustě obydlených místech by mělo být regulováno i o Silvestru. Jinde při dodržení bezpečnostních zásad a úklidu nevidím problém."
+    },
+    {
+      "id": "komunalni-2022-563889-a-40",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-13",
+      "comment": "Jedině v případě totálního nedostatku energií pro vytápění. Ve většině objektů si to nedovedu funkčně představit"
+    },
+    {
+      "id": "komunalni-2022-563889-a-43",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-14",
+      "answer": "yes",
+      "comment": "Je to jediná šance, kde lze energii a prostředky za ní ušetřit bez velkého omezení."
+    },
+    {
+      "id": "komunalni-2022-563889-a-46",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-15",
+      "answer": "yes",
+      "comment": "Ale jen v případě energetické krize (nedostatek energie, případně neúnosné náklady - které bohužel kraji nyní hrozí)"
+    },
+    {
+      "id": "komunalni-2022-563889-a-49",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-16",
+      "comment": "Kde pracují úředníci celý den to není možné, ale na místech, kam lidé přicházejí oblečeni z venku a zdrží se jen krátce omezit teplotu určitě lze"
+    },
+    {
+      "id": "komunalni-2022-563889-a-52",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-17",
+      "comment": "Každý případ by měl být posuzován individuálně. Děti by se vůbec do situace dlužníků neměly dostat."
+    },
+    {
+      "id": "komunalni-2022-563889-a-55",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-563889-a-58",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-19",
+      "answer": "no",
+      "comment": "Zastupitelé by jejich názory měli zohledňovat a zodpovídat se za své jednání. Občané by měli mít možnost kontroly, kam peníze jdou."
+    },
+    {
+      "id": "komunalni-2022-563889-a-61",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-20",
+      "answer": "yes",
+      "comment": "nemusí zvyšovat, ale rozhodně nesnižovat"
+    },
+    {
+      "id": "komunalni-2022-563889-a-64",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-21",
+      "answer": "yes",
+      "comment": "Asi ne zcela, ale omezit by jej rozhodně mělo"
+    },
+    {
+      "id": "komunalni-2022-563889-a-67",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-22",
+      "answer": "no",
+      "comment": "Ne, ceny ve školních jídelnách jsou velmi příznivé. U sociálních případů existují dávky, které problém řeší."
+    },
+    {
+      "id": "komunalni-2022-563889-a-70",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-73",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-24",
+      "answer": "yes",
+      "comment": "Strážníci se místo kontroly lístků budou věnovat veřejnému pořádku. Parkovací zóny situaci dramaticky neřeší, je s tím spojená administrativa a náklady."
+    },
+    {
+      "id": "komunalni-2022-563889-a-76",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-79",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-26",
+      "answer": "yes",
+      "comment": "Městem vynaložené náklady musí být přiměřené a ve prospěch všech obyvatel, ne jen těch z developerského projektu."
+    },
+    {
+      "id": "komunalni-2022-563889-a-82",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-27",
+      "answer": "no",
+      "comment": "Ale podporovat rozhodně"
+    },
+    {
+      "id": "komunalni-2022-563889-a-85",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-88",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-29"
+    },
+    {
+      "id": "komunalni-2022-563889-a-91",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-94",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-31",
+      "answer": "yes",
+      "comment": "Soukromý investor bývá zpravidla daleko efektivnější, než ten veřejný."
+    },
+    {
+      "id": "komunalni-2022-563889-a-97",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-100",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-103",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-34",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-106",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-109",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-112",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-37",
+      "comment": "Pokud má varianta dobrou návratnost, tak ano."
+    },
+    {
+      "id": "komunalni-2022-563889-a-115",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-118",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-39",
+      "comment": "Rozhodně by nemělo přispívat k jejich segregaci a vzniku ghet."
+    },
+    {
+      "id": "komunalni-2022-563889-a-121",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-40",
+      "answer": "no",
+      "comment": "Stačí, když se budou věnovat veřejné bezpečnosti, ochraně zdraví, života a majetku, místo kontroly parkovacích lístků."
+    },
+    {
+      "id": "komunalni-2022-563889-a-124",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-41",
+      "answer": "no",
+      "comment": "Ne za každou cenu, jen kde to dává smysl (z titulu nákladů na rekonstrukci, údržbu, pořádek atd)"
+    },
+    {
+      "id": "komunalni-2022-563889-a-127",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-42",
+      "comment": "Může vytvořit podmínky, ale toho, kdo nechce, nebo nemůže (zdraví, absence sprchy, možnosti zaparkovat kolo atd) nelze nutit a omezovat jiné způsoby"
+    },
+    {
+      "id": "komunalni-2022-563889-a-130",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-43",
+      "answer": "no",
+      "comment": "Město by mělo podporovat amatérský sport a vytvořit k němu podpínky pro širokou veřejnost."
+    },
+    {
+      "id": "komunalni-2022-563889-a-133",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-44",
+      "answer": "no",
+      "comment": "neměla by se ani zvýšit"
+    },
+    {
+      "id": "komunalni-2022-563889-a-136",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-45",
+      "comment": "Ty, kteří se do těžké situace dostali bez vlastního zavinění a dříve pracovali ano, ti, kteří celý život nepracují ne."
+    },
+    {
+      "id": "komunalni-2022-563889-a-139",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-46",
+      "answer": "yes",
+      "comment": "Zejména udržovat a dohlížet na smysluplné využití. Případně jednat, pokud jej nájemník zneužívá, či ničí."
+    },
+    {
+      "id": "komunalni-2022-563889-a-142",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-145",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-48",
+      "comment": "Záleží na dohodě stran, nemělo by mít negativní dopad na přírodu, dopravní obslužnost atd, případně negativa musí nějak kompenzovati. Rozhodně by investici nemělo dělat město."
+    },
+    {
+      "id": "komunalni-2022-563889-a-148",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-49",
+      "answer": "yes",
+      "comment": "Zlevnit, zrychlit a celá investice musí být pečlivě kontrolována proti dalšímu zvýšení nákladů a zhoršení kvality zpracování"
+    },
+    {
+      "id": "komunalni-2022-563889-a-151",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-154",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-563889-a-157",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-52",
+      "comment": "Mělo by tlačit na legislativu, která umožní výhodný režim pro firmy, které chtějí rodiče s malými dětmi zaměstnávat."
+    },
+    {
+      "id": "komunalni-2022-563889-a-160",
+      "candidate_id": "komunalni-2022-563889-c-843854",
+      "question_id": "komunalni-2022-563889-q-53"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/567027.json
+++ b/data/kalkulacka/komunalni-2022/567027.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-567027",
   "name": "Most",
-  "description": "Most - DESCRIPTION",
+  "description": "Most",
   "district_code": "567027",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-567027-question-1",
+      "id": "komunalni-2022-567027-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-2",
+      "id": "komunalni-2022-567027-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-3",
+      "id": "komunalni-2022-567027-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-4",
+      "id": "komunalni-2022-567027-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-5",
+      "id": "komunalni-2022-567027-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-6",
+      "id": "komunalni-2022-567027-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-7",
+      "id": "komunalni-2022-567027-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-8",
+      "id": "komunalni-2022-567027-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-9",
+      "id": "komunalni-2022-567027-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-10",
+      "id": "komunalni-2022-567027-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-11",
+      "id": "komunalni-2022-567027-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-12",
+      "id": "komunalni-2022-567027-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-13",
+      "id": "komunalni-2022-567027-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-14",
+      "id": "komunalni-2022-567027-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-15",
+      "id": "komunalni-2022-567027-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-16",
+      "id": "komunalni-2022-567027-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-17",
+      "id": "komunalni-2022-567027-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-18",
+      "id": "komunalni-2022-567027-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-19",
+      "id": "komunalni-2022-567027-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-20",
+      "id": "komunalni-2022-567027-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-21",
+      "id": "komunalni-2022-567027-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-22",
+      "id": "komunalni-2022-567027-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-23",
+      "id": "komunalni-2022-567027-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-24",
+      "id": "komunalni-2022-567027-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-25",
+      "id": "komunalni-2022-567027-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-26",
+      "id": "komunalni-2022-567027-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-27",
+      "id": "komunalni-2022-567027-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-28",
+      "id": "komunalni-2022-567027-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-29",
+      "id": "komunalni-2022-567027-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-30",
+      "id": "komunalni-2022-567027-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-31",
+      "id": "komunalni-2022-567027-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-32",
+      "id": "komunalni-2022-567027-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-33",
+      "id": "komunalni-2022-567027-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-34",
+      "id": "komunalni-2022-567027-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-35",
+      "id": "komunalni-2022-567027-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-36",
+      "id": "komunalni-2022-567027-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-37",
+      "id": "komunalni-2022-567027-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-38",
+      "id": "komunalni-2022-567027-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-39",
+      "id": "komunalni-2022-567027-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-40",
+      "id": "komunalni-2022-567027-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-41",
+      "id": "komunalni-2022-567027-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-42",
+      "id": "komunalni-2022-567027-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-43",
+      "id": "komunalni-2022-567027-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-44",
+      "id": "komunalni-2022-567027-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-45",
+      "id": "komunalni-2022-567027-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-46",
+      "id": "komunalni-2022-567027-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-47",
+      "id": "komunalni-2022-567027-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-48",
+      "id": "komunalni-2022-567027-q-48",
       "name": "Bydlení především",
       "title": "Podporuji, aby Most pokračoval v projektu Housing First.",
       "gist": "Projekty Housing First zajišťují stabilní bydlení pro nejohroženější skupinu obyvatel. V Česku díky nim získalo bezpečný domov a podporu sociálních pracovníků více než 700 lidí, z toho 320 dětí. Do projektu se zapojují i další česká i světová města; např. ve Vídni si bydlení udrželo 98 % domácností. Pilotní Brno i přes úspěch i ocenění od projektu postupně ustoupilo. Vedení města argumentovalo vysokými náklady, zastánci projektu ale poukazovali, že je většina výdajů hrazená z fondů EU.",
@@ -395,7 +397,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567027-question-49",
+      "id": "komunalni-2022-567027-q-49",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -405,16 +407,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-567027-candidate-976572",
+      "id": "komunalni-2022-567027-c-976572",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-567027-976572-party",
+          "id": "komunalni-2022-567027-c-976572-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -425,16 +428,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-567027-candidate-678018",
+      "id": "komunalni-2022-567027-c-678018",
       "name": "Svoboda a přímá demokracie (SPD) s podporou Trikolory",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) s podporou Trikolory - DESCRIPTION",
+      "img_url": "spd-trikolora",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-567027-678018-party",
+          "id": "komunalni-2022-567027-c-678018-p",
           "name": "Svoboda a přímá demokracie (SPD) s podporou Trikolory",
           "description": "Svoboda a přímá demokracie (SPD) s podporou Trikolory - DESCRIPTION",
           "contacts": {
@@ -445,10 +449,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-567027-candidate-431322",
+      "id": "komunalni-2022-567027-c-431322",
       "name": "ProMOST",
       "type": "party",
       "description": "ProMOST - DESCRIPTION",
+      "img_url": "promost",
       "contacts": {
         "web": [
           {
@@ -460,7 +465,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-567027-431322-party",
+          "id": "komunalni-2022-567027-c-431322-p",
           "name": "ProMOST",
           "description": "ProMOST - DESCRIPTION",
           "contacts": {
@@ -477,16 +482,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-567027-candidate-174115",
+      "id": "komunalni-2022-567027-c-174115",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-567027-174115-party",
+          "id": "komunalni-2022-567027-c-174115-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -497,16 +503,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-567027-candidate-138280",
+      "id": "komunalni-2022-567027-c-138280",
       "name": "Občané městu, město občanům",
       "type": "party",
       "description": "Občané městu, město občanům - DESCRIPTION",
+      "img_url": "ommo",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-567027-138280-party",
+          "id": "komunalni-2022-567027-c-138280-p",
           "name": "Občané městu, město občanům",
           "description": "Občané městu, město občanům - DESCRIPTION",
           "contacts": {
@@ -517,16 +524,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-567027-candidate-454542",
+      "id": "komunalni-2022-567027-c-454542",
       "name": "Česká strana sociálně demokratická",
       "type": "party",
       "description": "Česká strana sociálně demokratická - DESCRIPTION",
+      "img_url": "čssd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-567027-454542-party",
+          "id": "komunalni-2022-567027-c-454542-p",
           "name": "Česká strana sociálně demokratická",
           "description": "Česká strana sociálně demokratická - DESCRIPTION",
           "contacts": {
@@ -537,16 +545,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-567027-candidate-645179",
+      "id": "komunalni-2022-567027-c-645179",
       "name": "ODS a NEZÁVISLÍ",
       "type": "party",
       "description": "ODS a NEZÁVISLÍ - DESCRIPTION",
+      "img_url": "ods-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-567027-645179-party",
+          "id": "komunalni-2022-567027-c-645179-p",
           "name": "ODS a NEZÁVISLÍ",
           "description": "ODS a NEZÁVISLÍ - DESCRIPTION",
           "contacts": {
@@ -557,10 +566,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-567027-candidate-750273",
+      "id": "komunalni-2022-567027-c-750273",
       "name": "Piráti a Zelení pro Most",
       "type": "party",
       "description": "Piráti a Zelení pro Most - DESCRIPTION",
+      "img_url": "zelení-piráti",
       "contacts": {
         "web": [
           {
@@ -572,7 +582,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-567027-750273-party",
+          "id": "komunalni-2022-567027-c-750273-p",
           "name": "Piráti a Zelení pro Most",
           "description": "Piráti a Zelení pro Most - DESCRIPTION",
           "contacts": {
@@ -589,10 +599,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-567027-candidate-152154",
+      "id": "komunalni-2022-567027-c-152154",
       "name": " ",
       "type": "party",
       "description": "  - DESCRIPTION",
+      "img_url": "ns-nk",
       "contacts": {
         "web": [
           {
@@ -603,7 +614,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-567027-152154-party",
+          "id": "komunalni-2022-567027-c-152154-p",
           "name": " ",
           "description": "  - DESCRIPTION",
           "contacts": {
@@ -619,16 +630,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-567027-candidate-399616",
+      "id": "komunalni-2022-567027-c-399616",
       "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
       "type": "party",
       "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+      "img_url": "dsz-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-567027-399616-party",
+          "id": "komunalni-2022-567027-c-399616-p",
           "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
           "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
           "contacts": {
@@ -641,621 +653,621 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-567027-answer-138280-1",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-1",
+      "id": "komunalni-2022-567027-a-4",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-2",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-2",
+      "id": "komunalni-2022-567027-a-7",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-3",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-3",
+      "id": "komunalni-2022-567027-a-10",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-4",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-4",
+      "id": "komunalni-2022-567027-a-13",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-5",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-5",
+      "id": "komunalni-2022-567027-a-16",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-6",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-6",
+      "id": "komunalni-2022-567027-a-19",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-7",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-7",
+      "id": "komunalni-2022-567027-a-22",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-8",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-8",
+      "id": "komunalni-2022-567027-a-25",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-9",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-9",
+      "id": "komunalni-2022-567027-a-28",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-10",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-10",
+      "id": "komunalni-2022-567027-a-31",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-11",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-11",
+      "id": "komunalni-2022-567027-a-34",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-12",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-12",
+      "id": "komunalni-2022-567027-a-37",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-13",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-13",
+      "id": "komunalni-2022-567027-a-40",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-13",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-14",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-14",
+      "id": "komunalni-2022-567027-a-43",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-15",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-15",
+      "id": "komunalni-2022-567027-a-46",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-15",
       "answer": "no",
       "comment": "Protože jsou místa, kde nasvícení je bezpečnostním prvkem"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-16",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-16",
+      "id": "komunalni-2022-567027-a-49",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-16",
       "answer": "yes",
       "comment": "protože řada veřejných je přetápěna"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-17",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-17",
+      "id": "komunalni-2022-567027-a-52",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-17",
       "answer": "no",
       "comment": "až po vyjasnění statutu dlužníka /např. zda a do jaké míry je \"ovládán\" např. jinou dospělou osobou, která za něj může skrývat svoje dluhy/"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-18",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-18",
+      "id": "komunalni-2022-567027-a-55",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-18",
       "answer": "yes",
       "comment": "zcela jistě v případě veřejných zakázek, investic, investic sociálního charakteru, výběrová řízení apod."
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-19",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-19",
+      "id": "komunalni-2022-567027-a-58",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-19",
       "answer": "yes",
       "comment": "viz participativní formy hospodaření a rozhodování"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-20",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-20",
+      "id": "komunalni-2022-567027-a-61",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-20",
       "answer": "yes",
       "comment": "zejména v oblasti sociálního bydlení by mělo dojít k co nejrychlejšímu přijetí zákona o soc. bydlení"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-21",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-21",
+      "id": "komunalni-2022-567027-a-64",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-22",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-22",
+      "id": "komunalni-2022-567027-a-67",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-22",
       "answer": "no",
       "comment": "záleží na lokalitách, a také v případě individuální situace rodiny"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-23",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-23",
+      "id": "komunalni-2022-567027-a-70",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-23",
       "comment": "za současné situace není příliš ujasněna legislativní úprava"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-24",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-24",
+      "id": "komunalni-2022-567027-a-73",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-25",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-25",
+      "id": "komunalni-2022-567027-a-76",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-26",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-26",
+      "id": "komunalni-2022-567027-a-79",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-27",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-27",
+      "id": "komunalni-2022-567027-a-82",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-28",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-28",
+      "id": "komunalni-2022-567027-a-85",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-28",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-29",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-29",
+      "id": "komunalni-2022-567027-a-88",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-30",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-30",
+      "id": "komunalni-2022-567027-a-91",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-31",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-31",
+      "id": "komunalni-2022-567027-a-94",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-32",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-32",
+      "id": "komunalni-2022-567027-a-97",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-32",
       "answer": "no",
       "comment": "ale mohou být výjimky s ohledem na sociální situaci"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-33",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-33",
+      "id": "komunalni-2022-567027-a-100",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-33",
       "answer": "yes",
       "comment": "na úrovni státu co nejdříve prosadit legislativu tohoto typu"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-34",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-34",
+      "id": "komunalni-2022-567027-a-103",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-35",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-35",
+      "id": "komunalni-2022-567027-a-106",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-36",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-36",
+      "id": "komunalni-2022-567027-a-109",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-36",
       "answer": "no",
       "comment": "mohou být výjimky, v případě úřadů sociálního a zdravotního charakteru"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-37",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-37",
+      "id": "komunalni-2022-567027-a-112",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-38",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-38",
+      "id": "komunalni-2022-567027-a-115",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-38",
       "answer": "yes",
       "comment": "je však třeba zvážit bezpečnost a efektivitu takového provozu ve velkém"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-39",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-39",
+      "id": "komunalni-2022-567027-a-118",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-40",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-40",
+      "id": "komunalni-2022-567027-a-121",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-40",
       "comment": "ale zcela jistě zkoumat efektivitu jejich nasazení"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-41",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-41",
+      "id": "komunalni-2022-567027-a-124",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-42",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-42"
+      "id": "komunalni-2022-567027-a-127",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-42"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-43",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-43",
+      "id": "komunalni-2022-567027-a-130",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-43",
       "answer": "yes",
       "comment": "na přijatelné úrovni a individuálně a za jasně stanovených podmínek"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-44",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-44",
+      "id": "komunalni-2022-567027-a-133",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-45",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-45",
+      "id": "komunalni-2022-567027-a-136",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-46",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-46",
+      "id": "komunalni-2022-567027-a-139",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-47",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-47",
+      "id": "komunalni-2022-567027-a-142",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-48",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-48",
+      "id": "komunalni-2022-567027-a-145",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-49",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-49",
+      "id": "komunalni-2022-567027-a-148",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-138280-50",
-      "candidate_id": "komunalni-2022-567027-candidate-138280",
-      "question_id": "komunalni-2022-567027-question-50",
+      "id": "komunalni-2022-567027-a-151",
+      "candidate_id": "komunalni-2022-567027-c-138280",
+      "question_id": "komunalni-2022-567027-q-50",
       "comment": "více podobných dotazníků nejen před volbami (např. o průběžném plnění volebních slibů)"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-1",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-1",
+      "id": "komunalni-2022-567027-a-4",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-1",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-2",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-2",
+      "id": "komunalni-2022-567027-a-7",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-3",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-3",
+      "id": "komunalni-2022-567027-a-10",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-4",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-4",
+      "id": "komunalni-2022-567027-a-13",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-4",
       "answer": "yes",
       "comment": "Jen v některých částech města, problém je pak ale se zajištěním dodržování."
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-5",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-5",
+      "id": "komunalni-2022-567027-a-16",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-5",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-6",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-6",
+      "id": "komunalni-2022-567027-a-19",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-7",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-7"
+      "id": "komunalni-2022-567027-a-22",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-7"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-8",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-8",
+      "id": "komunalni-2022-567027-a-25",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-9",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-9",
+      "id": "komunalni-2022-567027-a-28",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-9",
       "answer": "yes",
       "comment": "Ve většině jsou bezbariérové zastávky hotové."
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-10",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-10",
+      "id": "komunalni-2022-567027-a-31",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-10",
       "answer": "yes",
       "comment": "Hlasování je veřejné."
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-11",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-11",
+      "id": "komunalni-2022-567027-a-34",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-11",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-12",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-12",
+      "id": "komunalni-2022-567027-a-37",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-13",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-13",
+      "id": "komunalni-2022-567027-a-40",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-13",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-14",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-14",
+      "id": "komunalni-2022-567027-a-43",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-15",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-15",
+      "id": "komunalni-2022-567027-a-46",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-15",
       "answer": "yes",
       "comment": "Částečně."
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-16",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-16",
+      "id": "komunalni-2022-567027-a-49",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-16",
       "answer": "yes",
       "comment": "Ve večerních hodinách."
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-17",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-17"
+      "id": "komunalni-2022-567027-a-52",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-17"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-18",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-18",
+      "id": "komunalni-2022-567027-a-55",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-19",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-19",
+      "id": "komunalni-2022-567027-a-58",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-19",
       "answer": "yes",
       "comment": "To se již děje formou projektu “hejbni Mostem”."
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-20",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-20",
+      "id": "komunalni-2022-567027-a-61",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-20",
       "answer": "yes",
       "comment": "Výkup bytů od soukromých vlastníků vidíme jako stěžejní řešení problematiky boje s nepřizpůsobivými občany."
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-21",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-21",
+      "id": "komunalni-2022-567027-a-64",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-21",
       "answer": "yes",
       "comment": "Ve večerních hodinách."
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-22",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-22"
+      "id": "komunalni-2022-567027-a-67",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-22"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-23",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-23",
+      "id": "komunalni-2022-567027-a-70",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-24",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-24",
+      "id": "komunalni-2022-567027-a-73",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-25",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-25",
+      "id": "komunalni-2022-567027-a-76",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-26",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-26",
+      "id": "komunalni-2022-567027-a-79",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-27",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-27",
+      "id": "komunalni-2022-567027-a-82",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-28",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-28",
+      "id": "komunalni-2022-567027-a-85",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-29",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-29"
+      "id": "komunalni-2022-567027-a-88",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-29"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-30",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-30"
+      "id": "komunalni-2022-567027-a-91",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-30"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-31",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-31"
+      "id": "komunalni-2022-567027-a-94",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-31"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-32",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-32",
+      "id": "komunalni-2022-567027-a-97",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-32",
       "answer": "yes",
       "comment": "Děti do 18ti let v Mostě mají MHD zdarma."
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-33",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-33",
+      "id": "komunalni-2022-567027-a-100",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-33",
       "answer": "no",
       "comment": "Otázka je nevhodně položena, jakým způsobem by mělo město pomoc ?"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-34",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-34",
+      "id": "komunalni-2022-567027-a-103",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-35",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-35",
+      "id": "komunalni-2022-567027-a-106",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-36",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-36",
+      "id": "komunalni-2022-567027-a-109",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-37",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-37",
+      "id": "komunalni-2022-567027-a-112",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-38",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-38",
+      "id": "komunalni-2022-567027-a-115",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-39",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-39",
+      "id": "komunalni-2022-567027-a-118",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-39",
       "answer": "yes",
       "comment": "Souhlasíte s integrací bezproblémových cizinců."
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-40",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-40",
+      "id": "komunalni-2022-567027-a-121",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-41",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-41",
+      "id": "komunalni-2022-567027-a-124",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-41",
       "answer": "yes",
       "comment": "Důležitá je finanční náročnost, zda na to město bude mít finance."
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-42",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-42"
+      "id": "komunalni-2022-567027-a-127",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-42"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-43",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-43",
+      "id": "komunalni-2022-567027-a-130",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-43",
       "answer": "yes",
       "comment": "Město již podporuje."
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-44",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-44",
+      "id": "komunalni-2022-567027-a-133",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-45",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-45",
+      "id": "komunalni-2022-567027-a-136",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-45",
       "answer": "yes",
       "comment": "Pokud bude dostatek financí."
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-46",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-46",
+      "id": "komunalni-2022-567027-a-139",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-47",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-47",
+      "id": "komunalni-2022-567027-a-142",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-48",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-48",
+      "id": "komunalni-2022-567027-a-145",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-49",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-49",
+      "id": "komunalni-2022-567027-a-148",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567027-answer-174115-50",
-      "candidate_id": "komunalni-2022-567027-candidate-174115",
-      "question_id": "komunalni-2022-567027-question-50"
+      "id": "komunalni-2022-567027-a-151",
+      "candidate_id": "komunalni-2022-567027-c-174115",
+      "question_id": "komunalni-2022-567027-q-50"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/567442.json
+++ b/data/kalkulacka/komunalni-2022/567442.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-567442",
   "name": "Teplice",
-  "description": "Teplice - DESCRIPTION",
+  "description": "Teplice",
   "district_code": "567442",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-567442-question-1",
+      "id": "komunalni-2022-567442-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-2",
+      "id": "komunalni-2022-567442-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-3",
+      "id": "komunalni-2022-567442-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-4",
+      "id": "komunalni-2022-567442-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-5",
+      "id": "komunalni-2022-567442-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-6",
+      "id": "komunalni-2022-567442-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-7",
+      "id": "komunalni-2022-567442-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-8",
+      "id": "komunalni-2022-567442-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-9",
+      "id": "komunalni-2022-567442-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-10",
+      "id": "komunalni-2022-567442-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-11",
+      "id": "komunalni-2022-567442-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-12",
+      "id": "komunalni-2022-567442-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-13",
+      "id": "komunalni-2022-567442-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-14",
+      "id": "komunalni-2022-567442-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-15",
+      "id": "komunalni-2022-567442-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-16",
+      "id": "komunalni-2022-567442-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-17",
+      "id": "komunalni-2022-567442-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-18",
+      "id": "komunalni-2022-567442-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-19",
+      "id": "komunalni-2022-567442-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-20",
+      "id": "komunalni-2022-567442-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-21",
+      "id": "komunalni-2022-567442-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-22",
+      "id": "komunalni-2022-567442-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-23",
+      "id": "komunalni-2022-567442-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-24",
+      "id": "komunalni-2022-567442-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-25",
+      "id": "komunalni-2022-567442-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-26",
+      "id": "komunalni-2022-567442-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-27",
+      "id": "komunalni-2022-567442-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-28",
+      "id": "komunalni-2022-567442-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-29",
+      "id": "komunalni-2022-567442-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-30",
+      "id": "komunalni-2022-567442-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-31",
+      "id": "komunalni-2022-567442-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-32",
+      "id": "komunalni-2022-567442-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-33",
+      "id": "komunalni-2022-567442-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-34",
+      "id": "komunalni-2022-567442-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-35",
+      "id": "komunalni-2022-567442-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-36",
+      "id": "komunalni-2022-567442-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-37",
+      "id": "komunalni-2022-567442-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-38",
+      "id": "komunalni-2022-567442-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-39",
+      "id": "komunalni-2022-567442-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-40",
+      "id": "komunalni-2022-567442-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-41",
+      "id": "komunalni-2022-567442-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-42",
+      "id": "komunalni-2022-567442-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-43",
+      "id": "komunalni-2022-567442-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-44",
+      "id": "komunalni-2022-567442-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-45",
+      "id": "komunalni-2022-567442-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-46",
+      "id": "komunalni-2022-567442-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-47",
+      "id": "komunalni-2022-567442-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-567442-question-48",
+      "id": "komunalni-2022-567442-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,16 +399,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-567442-candidate-593168",
+      "id": "komunalni-2022-567442-c-593168",
       "name": "ODS spolu s TOP 09",
       "type": "party",
       "description": "ODS spolu s TOP 09 - DESCRIPTION",
+      "img_url": "ods-top 09",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-567442-593168-party",
+          "id": "komunalni-2022-567442-c-593168-p",
           "name": "ODS spolu s TOP 09",
           "description": "ODS spolu s TOP 09 - DESCRIPTION",
           "contacts": {
@@ -417,16 +420,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-567442-candidate-472474",
+      "id": "komunalni-2022-567442-c-472474",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-567442-472474-party",
+          "id": "komunalni-2022-567442-c-472474-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -437,16 +441,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-567442-candidate-843481",
+      "id": "komunalni-2022-567442-c-843481",
       "name": "Zdraví Sport Prosperita",
       "type": "party",
       "description": "Zdraví Sport Prosperita - DESCRIPTION",
+      "img_url": "pro zdraví",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-567442-843481-party",
+          "id": "komunalni-2022-567442-c-843481-p",
           "name": "Zdraví Sport Prosperita",
           "description": "Zdraví Sport Prosperita - DESCRIPTION",
           "contacts": {
@@ -457,16 +462,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-567442-candidate-209742",
+      "id": "komunalni-2022-567442-c-209742",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-567442-209742-party",
+          "id": "komunalni-2022-567442-c-209742-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -477,16 +483,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-567442-candidate-731451",
+      "id": "komunalni-2022-567442-c-731451",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-567442-731451-party",
+          "id": "komunalni-2022-567442-c-731451-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -497,10 +504,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-567442-candidate-119103",
+      "id": "komunalni-2022-567442-c-119103",
       "name": "VOLBA PRO! TEPLICE",
       "type": "party",
       "description": "VOLBA PRO! TEPLICE - DESCRIPTION",
+      "img_url": "kdu-zel-pir-nk",
       "contacts": {
         "web": [
           {
@@ -513,7 +521,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-567442-119103-party",
+          "id": "komunalni-2022-567442-c-119103-p",
           "name": "VOLBA PRO! TEPLICE",
           "description": "VOLBA PRO! TEPLICE - DESCRIPTION",
           "contacts": {
@@ -533,583 +541,583 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-567442-answer-731451-1",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-1",
+      "id": "komunalni-2022-567442-a-4",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-1",
       "answer": "yes",
       "comment": "Obecně vzato, každý byli tam, kde si to může dovolit. "
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-2",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-2",
+      "id": "komunalni-2022-567442-a-7",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-2",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-3",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-3"
+      "id": "komunalni-2022-567442-a-10",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-3"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-4",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-4",
+      "id": "komunalni-2022-567442-a-13",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-5",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-5",
+      "id": "komunalni-2022-567442-a-16",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-5",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-6",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-6",
+      "id": "komunalni-2022-567442-a-19",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-7",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-7",
+      "id": "komunalni-2022-567442-a-22",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-8",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-8",
+      "id": "komunalni-2022-567442-a-25",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-9",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-9",
+      "id": "komunalni-2022-567442-a-28",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-10",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-10",
+      "id": "komunalni-2022-567442-a-31",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-11",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-11",
+      "id": "komunalni-2022-567442-a-34",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-12",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-12"
+      "id": "komunalni-2022-567442-a-37",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-12"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-13",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-13",
+      "id": "komunalni-2022-567442-a-40",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-13",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-14",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-14"
+      "id": "komunalni-2022-567442-a-43",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-14"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-15",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-15",
+      "id": "komunalni-2022-567442-a-46",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-15",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-16",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-16"
+      "id": "komunalni-2022-567442-a-49",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-16"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-17",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-17",
+      "id": "komunalni-2022-567442-a-52",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-18",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-18",
+      "id": "komunalni-2022-567442-a-55",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-19",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-19"
+      "id": "komunalni-2022-567442-a-58",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-19"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-20",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-20",
+      "id": "komunalni-2022-567442-a-61",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-21",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-21"
+      "id": "komunalni-2022-567442-a-64",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-21"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-22",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-22"
+      "id": "komunalni-2022-567442-a-67",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-22"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-23",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-23"
+      "id": "komunalni-2022-567442-a-70",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-23"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-24",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-24",
+      "id": "komunalni-2022-567442-a-73",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-25",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-25",
+      "id": "komunalni-2022-567442-a-76",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-26",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-26",
+      "id": "komunalni-2022-567442-a-79",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-27",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-27",
+      "id": "komunalni-2022-567442-a-82",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-28",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-28"
+      "id": "komunalni-2022-567442-a-85",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-28"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-29",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-29",
+      "id": "komunalni-2022-567442-a-88",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-30",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-30",
+      "id": "komunalni-2022-567442-a-91",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-31",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-31"
+      "id": "komunalni-2022-567442-a-94",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-31"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-32",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-32"
+      "id": "komunalni-2022-567442-a-97",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-32"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-33",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-33",
+      "id": "komunalni-2022-567442-a-100",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-33",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-34",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-34",
+      "id": "komunalni-2022-567442-a-103",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-35",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-35"
+      "id": "komunalni-2022-567442-a-106",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-35"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-36",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-36",
+      "id": "komunalni-2022-567442-a-109",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-37",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-37",
+      "id": "komunalni-2022-567442-a-112",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-38",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-38",
+      "id": "komunalni-2022-567442-a-115",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-39",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-39",
+      "id": "komunalni-2022-567442-a-118",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-39",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-40",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-40",
+      "id": "komunalni-2022-567442-a-121",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-40",
       "answer": "yes",
       "comment": "V některých částech města se lidé necítí bezpečně, což by bylo dobré změnit. "
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-41",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-41",
+      "id": "komunalni-2022-567442-a-124",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-42",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-42",
+      "id": "komunalni-2022-567442-a-127",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-43",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-43",
+      "id": "komunalni-2022-567442-a-130",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-44",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-44",
+      "id": "komunalni-2022-567442-a-133",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-45",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-45"
+      "id": "komunalni-2022-567442-a-136",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-45"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-46",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-46",
+      "id": "komunalni-2022-567442-a-139",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-47",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-47",
+      "id": "komunalni-2022-567442-a-142",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-47",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-48",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-48",
+      "id": "komunalni-2022-567442-a-145",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-731451-49",
-      "candidate_id": "komunalni-2022-567442-candidate-731451",
-      "question_id": "komunalni-2022-567442-question-49",
+      "id": "komunalni-2022-567442-a-148",
+      "candidate_id": "komunalni-2022-567442-c-731451",
+      "question_id": "komunalni-2022-567442-q-49",
       "comment": "Lépe rozebrat otázky. U řady otázek velmi záleží na tom, co se tím řešením problémů konkrétně myslí a potom je těžké odpovědět. "
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-1",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-1",
+      "id": "komunalni-2022-567442-a-4",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-1",
       "answer": "yes",
       "comment": "Pokud v oblasti není sociální bydlení "
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-2",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-2",
+      "id": "komunalni-2022-567442-a-7",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-2",
       "answer": "no",
       "comment": "Má však nadstandardně podporovat třídění odpadu a edukace o přínosu této aktivity."
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-3",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-3",
+      "id": "komunalni-2022-567442-a-10",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-4",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-4"
+      "id": "komunalni-2022-567442-a-13",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-4"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-5",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-5",
+      "id": "komunalni-2022-567442-a-16",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-5",
       "answer": "no",
       "comment": "Tato aktivita je koordinována efektivně centrálně "
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-6",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-6",
+      "id": "komunalni-2022-567442-a-19",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-6",
       "answer": "yes",
       "comment": "Měla by se zvolit modernější technologie toho bezpečnostního prvku"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-7",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-7",
+      "id": "komunalni-2022-567442-a-22",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-7",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-8",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-8",
+      "id": "komunalni-2022-567442-a-25",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-9",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-9"
+      "id": "komunalni-2022-567442-a-28",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-9"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-10",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-10",
+      "id": "komunalni-2022-567442-a-31",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-11",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-11",
+      "id": "komunalni-2022-567442-a-34",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-12",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-12"
+      "id": "komunalni-2022-567442-a-37",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-12"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-13",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-13",
+      "id": "komunalni-2022-567442-a-40",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-13",
       "answer": "no",
       "comment": "Toto není řešení !"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-14",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-14",
+      "id": "komunalni-2022-567442-a-43",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-14",
       "answer": "yes",
       "comment": "Mělo by tak činit zejména pro omezeni světelného smogu"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-15",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-15",
+      "id": "komunalni-2022-567442-a-46",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-15",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-16",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-16",
+      "id": "komunalni-2022-567442-a-49",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-16",
       "answer": "no",
       "comment": "Toto není řešení problému"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-17",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-17",
+      "id": "komunalni-2022-567442-a-52",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-18",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-18",
+      "id": "komunalni-2022-567442-a-55",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-18",
       "comment": "Nemusí odpovídat platné legislativě "
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-19",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-19",
+      "id": "komunalni-2022-567442-a-58",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-20",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-20",
+      "id": "komunalni-2022-567442-a-61",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-21",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-21",
+      "id": "komunalni-2022-567442-a-64",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-21",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-22",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-22",
+      "id": "komunalni-2022-567442-a-67",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-22",
       "answer": "yes",
       "comment": "V případě dětí ze sociálně slabých rodin"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-23",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-23",
+      "id": "komunalni-2022-567442-a-70",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-24",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-24",
+      "id": "komunalni-2022-567442-a-73",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-25",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-25",
+      "id": "komunalni-2022-567442-a-76",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-26",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-26",
+      "id": "komunalni-2022-567442-a-79",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-26",
       "comment": "Podle druhu staveb"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-27",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-27",
+      "id": "komunalni-2022-567442-a-82",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-28",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-28",
+      "id": "komunalni-2022-567442-a-85",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-29",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-29",
+      "id": "komunalni-2022-567442-a-88",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-30",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-30",
+      "id": "komunalni-2022-567442-a-91",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-30",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-31",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-31",
+      "id": "komunalni-2022-567442-a-94",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-32",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-32"
+      "id": "komunalni-2022-567442-a-97",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-32"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-33",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-33",
+      "id": "komunalni-2022-567442-a-100",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-33",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-34",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-34",
+      "id": "komunalni-2022-567442-a-103",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-34",
       "answer": "no",
       "comment": "Snížené vstupné "
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-35",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-35"
+      "id": "komunalni-2022-567442-a-106",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-35"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-36",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-36",
+      "id": "komunalni-2022-567442-a-109",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-37",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-37",
+      "id": "komunalni-2022-567442-a-112",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-37",
       "answer": "yes",
       "comment": "Ne v památkových a lázeňských zónách "
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-38",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-38"
+      "id": "komunalni-2022-567442-a-115",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-38"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-39",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-39",
+      "id": "komunalni-2022-567442-a-118",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-40",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-40",
+      "id": "komunalni-2022-567442-a-121",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-41",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-41"
+      "id": "komunalni-2022-567442-a-124",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-41"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-42",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-42"
+      "id": "komunalni-2022-567442-a-127",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-42"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-43",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-43",
+      "id": "komunalni-2022-567442-a-130",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-44",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-44",
+      "id": "komunalni-2022-567442-a-133",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-45",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-45",
+      "id": "komunalni-2022-567442-a-136",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-45",
       "answer": "yes",
       "comment": "Ale smysluplné a podmíněně "
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-46",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-46",
+      "id": "komunalni-2022-567442-a-139",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-47",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-47",
+      "id": "komunalni-2022-567442-a-142",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-48",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-48",
+      "id": "komunalni-2022-567442-a-145",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-567442-answer-472474-49",
-      "candidate_id": "komunalni-2022-567442-candidate-472474",
-      "question_id": "komunalni-2022-567442-question-49",
+      "id": "komunalni-2022-567442-a-148",
+      "candidate_id": "komunalni-2022-567442-c-472474",
+      "question_id": "komunalni-2022-567442-q-49",
       "comment": "seznámit se lépe s konkrétní problematikou daného města"
     }
   ]

--- a/data/kalkulacka/komunalni-2022/569810.json
+++ b/data/kalkulacka/komunalni-2022/569810.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-569810",
   "name": "Hradec Králové",
-  "description": "Hradec Králové - DESCRIPTION",
+  "description": "Hradec Králové",
   "district_code": "569810",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-569810-question-1",
+      "id": "komunalni-2022-569810-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-2",
+      "id": "komunalni-2022-569810-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-3",
+      "id": "komunalni-2022-569810-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-4",
+      "id": "komunalni-2022-569810-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-5",
+      "id": "komunalni-2022-569810-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-6",
+      "id": "komunalni-2022-569810-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-7",
+      "id": "komunalni-2022-569810-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-8",
+      "id": "komunalni-2022-569810-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-9",
+      "id": "komunalni-2022-569810-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-10",
+      "id": "komunalni-2022-569810-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-11",
+      "id": "komunalni-2022-569810-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-12",
+      "id": "komunalni-2022-569810-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-13",
+      "id": "komunalni-2022-569810-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-14",
+      "id": "komunalni-2022-569810-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-15",
+      "id": "komunalni-2022-569810-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-16",
+      "id": "komunalni-2022-569810-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-17",
+      "id": "komunalni-2022-569810-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-18",
+      "id": "komunalni-2022-569810-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-19",
+      "id": "komunalni-2022-569810-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-20",
+      "id": "komunalni-2022-569810-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-21",
+      "id": "komunalni-2022-569810-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-22",
+      "id": "komunalni-2022-569810-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-23",
+      "id": "komunalni-2022-569810-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-24",
+      "id": "komunalni-2022-569810-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-25",
+      "id": "komunalni-2022-569810-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-26",
+      "id": "komunalni-2022-569810-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-27",
+      "id": "komunalni-2022-569810-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-28",
+      "id": "komunalni-2022-569810-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-29",
+      "id": "komunalni-2022-569810-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-30",
+      "id": "komunalni-2022-569810-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-31",
+      "id": "komunalni-2022-569810-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-32",
+      "id": "komunalni-2022-569810-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-33",
+      "id": "komunalni-2022-569810-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-34",
+      "id": "komunalni-2022-569810-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-35",
+      "id": "komunalni-2022-569810-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-36",
+      "id": "komunalni-2022-569810-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-37",
+      "id": "komunalni-2022-569810-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-38",
+      "id": "komunalni-2022-569810-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-39",
+      "id": "komunalni-2022-569810-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-40",
+      "id": "komunalni-2022-569810-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-41",
+      "id": "komunalni-2022-569810-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-42",
+      "id": "komunalni-2022-569810-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-43",
+      "id": "komunalni-2022-569810-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-44",
+      "id": "komunalni-2022-569810-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-45",
+      "id": "komunalni-2022-569810-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-46",
+      "id": "komunalni-2022-569810-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-47",
+      "id": "komunalni-2022-569810-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-48",
+      "id": "komunalni-2022-569810-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -395,7 +397,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-49",
+      "id": "komunalni-2022-569810-q-49",
       "name": "Majetková účast města v profi sportu",
       "title": "Město má mít majetkovou účast v profesionálních hokejových a fotbalových klubech.",
       "gist": "",
@@ -403,7 +405,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-50",
+      "id": "komunalni-2022-569810-q-50",
       "name": "Svinarský most",
       "title": "Město má uchránit torzo železného mostu plukovníka Šrámka.",
       "gist": "Zastupitelé se rozhodli pro záchranu zbytku mostu, podle kritiků Hradec potřebuje peníze na důležitější věci než záchranu fragmentu mostu. Částky na záchranu se pohybují v desítkách milionů. Podle zastánců most sice nebyl uznaný kulturní památkou, ale památka to díky technologii je a zasloužil by si, aby byl zachráněn.",
@@ -411,7 +413,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-51",
+      "id": "komunalni-2022-569810-q-51",
       "name": "Zápis do UNESCO",
       "title": "Má Hradec Králové usilovat o zápis na seznam UNESCO?",
       "gist": "Podle zastánců by mělo město usilovat o zápis staveb Josefa Gočára na Seznam světového dědictví UNESCO. ",
@@ -419,7 +421,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-52",
+      "id": "komunalni-2022-569810-q-52",
       "name": "Oprava Velkého náměstí",
       "title": "Podporuji opravu Vekého náměstí a snížení počtu parkovacích míst.",
       "gist": "Před deseti lety zablokovalo 24 ze 250 vlastníků nemovitostí opravu Velkého náměstí. Vadí jim hlavně, že by se změnšil počet parkovacíh míst. Vlastníci nemovitostí ani po deseti letech nesouhlasí se snížením počtu parkovacích míst. Řešením by mohly být úpravy ulic v okolí a vybudování bezbariérového přístupu na náměstí.",
@@ -427,7 +429,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-569810-question-53",
+      "id": "komunalni-2022-569810-q-53",
       "name": "Konec kamionů na Pouchově",
       "title": "Na ulici Pouchovské se mají omezit kamiony.",
       "gist": "Proti možnému omezení kamionů na Pouchově protestují ostatní městské části.",
@@ -437,16 +439,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-569810-candidate-760916",
+      "id": "komunalni-2022-569810-c-760916",
       "name": "HRADEC ROZUMEM",
       "type": "party",
       "description": "HRADEC ROZUMEM - DESCRIPTION",
+      "img_url": "svob-pro2022-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-569810-760916-party",
+          "id": "komunalni-2022-569810-c-760916-p",
           "name": "HRADEC ROZUMEM",
           "description": "HRADEC ROZUMEM - DESCRIPTION",
           "contacts": {
@@ -457,16 +460,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-569810-candidate-244511",
+      "id": "komunalni-2022-569810-c-244511",
       "name": "Česká strana sociálně demokratická s podporou nezávislých",
       "type": "party",
       "description": "Česká strana sociálně demokratická s podporou nezávislých - DESCRIPTION",
+      "img_url": "čssd-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-569810-244511-party",
+          "id": "komunalni-2022-569810-c-244511-p",
           "name": "Česká strana sociálně demokratická s podporou nezávislých",
           "description": "Česká strana sociálně demokratická s podporou nezávislých - DESCRIPTION",
           "contacts": {
@@ -477,16 +481,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-569810-candidate-515530",
+      "id": "komunalni-2022-569810-c-515530",
       "name": "ROMA LUMA",
       "type": "party",
       "description": "ROMA LUMA - DESCRIPTION",
+      "img_url": "luma",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-569810-515530-party",
+          "id": "komunalni-2022-569810-c-515530-p",
           "name": "ROMA LUMA",
           "description": "ROMA LUMA - DESCRIPTION",
           "contacts": {
@@ -497,16 +502,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-569810-candidate-748887",
+      "id": "komunalni-2022-569810-c-748887",
       "name": "HRADEČÁCI",
       "type": "party",
       "description": "HRADEČÁCI - DESCRIPTION",
+      "img_url": "hk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-569810-748887-party",
+          "id": "komunalni-2022-569810-c-748887-p",
           "name": "HRADEČÁCI",
           "description": "HRADEČÁCI - DESCRIPTION",
           "contacts": {
@@ -517,16 +523,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-569810-candidate-841188",
+      "id": "komunalni-2022-569810-c-841188",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-569810-841188-party",
+          "id": "komunalni-2022-569810-c-841188-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -537,16 +544,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-569810-candidate-813906",
+      "id": "komunalni-2022-569810-c-813906",
       "name": "Hradečtí kantoři a Nestraníci",
       "type": "party",
       "description": "Hradečtí kantoři a Nestraníci - DESCRIPTION",
+      "img_url": "nestraníci-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-569810-813906-party",
+          "id": "komunalni-2022-569810-c-813906-p",
           "name": "Hradečtí kantoři a Nestraníci",
           "description": "Hradečtí kantoři a Nestraníci - DESCRIPTION",
           "contacts": {
@@ -557,10 +565,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-569810-candidate-938535",
+      "id": "komunalni-2022-569810-c-938535",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
       "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "img_url": "stan",
       "contacts": {
         "web": [
           {
@@ -578,7 +587,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-569810-938535-party",
+          "id": "komunalni-2022-569810-c-938535-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
           "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
           "contacts": {
@@ -601,10 +610,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-569810-candidate-707699",
+      "id": "komunalni-2022-569810-c-707699",
       "name": "Hradecký demokratický klub a TOP 09 s podporou Hradeckých patriotů a LES",
       "type": "party",
       "description": "Hradecký demokratický klub a TOP 09 s podporou Hradeckých patriotů a LES - DESCRIPTION",
+      "img_url": "top-les-hp-hdk",
       "contacts": {
         "web": [
           {
@@ -621,7 +631,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-569810-707699-party",
+          "id": "komunalni-2022-569810-c-707699-p",
           "name": "Hradecký demokratický klub a TOP 09 s podporou Hradeckých patriotů a LES",
           "description": "Hradecký demokratický klub a TOP 09 s podporou Hradeckých patriotů a LES - DESCRIPTION",
           "contacts": {
@@ -643,10 +653,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-569810-candidate-956549",
+      "id": "komunalni-2022-569810-c-956549",
       "name": "Změna pro Hradec a Zelení",
       "type": "party",
       "description": "Změna pro Hradec a Zelení - DESCRIPTION",
+      "img_url": "zelení-nk",
       "contacts": {
         "web": [
           {
@@ -658,7 +669,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-569810-956549-party",
+          "id": "komunalni-2022-569810-c-956549-p",
           "name": "Změna pro Hradec a Zelení",
           "description": "Změna pro Hradec a Zelení - DESCRIPTION",
           "contacts": {
@@ -675,16 +686,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-569810-candidate-589869",
+      "id": "komunalni-2022-569810-c-589869",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-569810-589869-party",
+          "id": "komunalni-2022-569810-c-589869-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -695,16 +707,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-569810-candidate-601843",
+      "id": "komunalni-2022-569810-c-601843",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-569810-601843-party",
+          "id": "komunalni-2022-569810-c-601843-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -715,16 +728,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-569810-candidate-655604",
+      "id": "komunalni-2022-569810-c-655604",
       "name": "Občanská demokratická strana",
       "type": "party",
       "description": "Občanská demokratická strana - DESCRIPTION",
+      "img_url": "ods",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-569810-655604-party",
+          "id": "komunalni-2022-569810-c-655604-p",
           "name": "Občanská demokratická strana",
           "description": "Občanská demokratická strana - DESCRIPTION",
           "contacts": {
@@ -735,10 +749,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-569810-candidate-803953",
+      "id": "komunalni-2022-569810-c-803953",
       "name": "ROZVÍJÍME HRADEC - NOVÁ HRADECKÁ OBČANSKÁ KANDIDÁTKA",
       "type": "party",
       "description": "ROZVÍJÍME HRADEC - NOVÁ HRADECKÁ OBČANSKÁ KANDIDÁTKA - DESCRIPTION",
+      "img_url": "rh-nk",
       "contacts": {
         "web": [
           {
@@ -750,7 +765,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-569810-803953-party",
+          "id": "komunalni-2022-569810-c-803953-p",
           "name": "ROZVÍJÍME HRADEC - NOVÁ HRADECKÁ OBČANSKÁ KANDIDÁTKA",
           "description": "ROZVÍJÍME HRADEC - NOVÁ HRADECKÁ OBČANSKÁ KANDIDÁTKA - DESCRIPTION",
           "contacts": {
@@ -767,16 +782,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-569810-candidate-982677",
+      "id": "komunalni-2022-569810-c-982677",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-569810-982677-party",
+          "id": "komunalni-2022-569810-c-982677-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -787,17 +803,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-569810-candidate-278614",
+      "id": "komunalni-2022-569810-c-278614",
       "name": "Koalice pro Hradec",
       "type": "party",
       "description": "Koalice pro Hradec - DESCRIPTION",
+      "img_url": "kdu-čsl-nk",
       "contacts": {
         "web": [],
         "twitter": "https://twitter.com/koaliceHK"
       },
       "parties": [
         {
-          "id": "komunalni-2022-569810-278614-party",
+          "id": "komunalni-2022-569810-c-278614-p",
           "name": "Koalice pro Hradec",
           "description": "Koalice pro Hradec - DESCRIPTION",
           "contacts": {
@@ -811,1397 +828,1754 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-569810-answer-982677-1",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-1",
+      "id": "komunalni-2022-569810-a-4",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-1",
       "answer": "no",
       "comment": "Všem rovné šance."
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-2",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-2",
+      "id": "komunalni-2022-569810-a-7",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-3",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-3",
+      "id": "komunalni-2022-569810-a-10",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-3",
       "answer": "yes",
       "comment": "V případě nejvyšší nouze. V otázce není definováno na kolik °C "
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-4",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-4",
+      "id": "komunalni-2022-569810-a-13",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-5",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-5",
+      "id": "komunalni-2022-569810-a-16",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-6",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-6",
+      "id": "komunalni-2022-569810-a-19",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-6",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-7",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-7",
+      "id": "komunalni-2022-569810-a-22",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-8",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-8",
+      "id": "komunalni-2022-569810-a-25",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-9",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-9",
+      "id": "komunalni-2022-569810-a-28",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-10",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-10",
+      "id": "komunalni-2022-569810-a-31",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-10",
       "answer": "yes",
       "comment": "V Hradci Králové je to standard."
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-11",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-11",
+      "id": "komunalni-2022-569810-a-34",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-11",
       "answer": "yes",
       "comment": "V Hradci Králové se nezveřejňuje."
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-12",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-12",
+      "id": "komunalni-2022-569810-a-37",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-12",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-13",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-13",
+      "id": "komunalni-2022-569810-a-40",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-14",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-14",
+      "id": "komunalni-2022-569810-a-43",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-15",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-15",
+      "id": "komunalni-2022-569810-a-46",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-15",
       "answer": "yes",
       "comment": "Mezi 24 a 4 hodinou"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-16",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-16",
+      "id": "komunalni-2022-569810-a-49",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-16",
       "answer": "yes",
       "comment": "Na 18°C"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-17",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-17",
+      "id": "komunalni-2022-569810-a-52",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-18",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-18",
+      "id": "komunalni-2022-569810-a-55",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-19",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-19",
+      "id": "komunalni-2022-569810-a-58",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-20",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-20",
+      "id": "komunalni-2022-569810-a-61",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-21",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-21",
+      "id": "komunalni-2022-569810-a-64",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-21",
       "comment": "Podle aktuální situace na Vánoce."
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-22",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-22",
+      "id": "komunalni-2022-569810-a-67",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-23",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-23",
+      "id": "komunalni-2022-569810-a-70",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-24",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-24",
+      "id": "komunalni-2022-569810-a-73",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-25",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-25",
+      "id": "komunalni-2022-569810-a-76",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-26",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-26",
+      "id": "komunalni-2022-569810-a-79",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-27",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-27",
+      "id": "komunalni-2022-569810-a-82",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-27",
       "answer": "no",
       "comment": "Všechny typy dopravy by měly být vyvážené. Pěší a alternativní dopravu preferujeme, ale na úkor jiné skupiny obyvatel."
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-28",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-28",
+      "id": "komunalni-2022-569810-a-85",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-29",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-29",
+      "id": "komunalni-2022-569810-a-88",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-30",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-30"
+      "id": "komunalni-2022-569810-a-91",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-30"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-31",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-31",
+      "id": "komunalni-2022-569810-a-94",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-32",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-32",
+      "id": "komunalni-2022-569810-a-97",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-33",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-33",
+      "id": "komunalni-2022-569810-a-100",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-34",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-34",
+      "id": "komunalni-2022-569810-a-103",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-35",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-35",
+      "id": "komunalni-2022-569810-a-106",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-36",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-36",
+      "id": "komunalni-2022-569810-a-109",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-36",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-37",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-37",
+      "id": "komunalni-2022-569810-a-112",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-38",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-38",
+      "id": "komunalni-2022-569810-a-115",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-38",
       "comment": "Chybí legislativa."
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-39",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-39",
+      "id": "komunalni-2022-569810-a-118",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-39",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-40",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-40",
+      "id": "komunalni-2022-569810-a-121",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-41",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-41",
+      "id": "komunalni-2022-569810-a-124",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-42",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-42",
+      "id": "komunalni-2022-569810-a-127",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-43",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-43",
+      "id": "komunalni-2022-569810-a-130",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-44",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-44",
+      "id": "komunalni-2022-569810-a-133",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-45",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-45",
+      "id": "komunalni-2022-569810-a-136",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-46",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-46",
+      "id": "komunalni-2022-569810-a-139",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-47",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-47",
+      "id": "komunalni-2022-569810-a-142",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-48",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-48",
+      "id": "komunalni-2022-569810-a-145",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-49",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-49"
+      "id": "komunalni-2022-569810-a-148",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-49"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-50",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-50",
+      "id": "komunalni-2022-569810-a-151",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-50",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-51",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-51",
+      "id": "komunalni-2022-569810-a-154",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-51",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-52",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-52",
+      "id": "komunalni-2022-569810-a-157",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-52",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-53",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-53",
+      "id": "komunalni-2022-569810-a-160",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-53",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-982677-54",
-      "candidate_id": "komunalni-2022-569810-candidate-982677",
-      "question_id": "komunalni-2022-569810-question-54"
+      "id": "komunalni-2022-569810-a-163",
+      "candidate_id": "komunalni-2022-569810-c-982677",
+      "question_id": "komunalni-2022-569810-q-54"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-1",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-1"
+      "id": "komunalni-2022-569810-a-4",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-1"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-2",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-2",
+      "id": "komunalni-2022-569810-a-7",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-3",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-3",
+      "id": "komunalni-2022-569810-a-10",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-4",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-4",
+      "id": "komunalni-2022-569810-a-13",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-5",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-5",
+      "id": "komunalni-2022-569810-a-16",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-6",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-6",
+      "id": "komunalni-2022-569810-a-19",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-6",
       "comment": "Kamery ano, ale pouze pro eliminaci trestné činnosti či jako prevence."
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-7",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-7",
+      "id": "komunalni-2022-569810-a-22",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-7",
       "answer": "yes",
       "comment": "Jsme pro to, aby nebyly herny ve městě, nicméně nezakazovali bychom sportovní sázení."
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-8",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-8",
+      "id": "komunalni-2022-569810-a-25",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-9",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-9",
+      "id": "komunalni-2022-569810-a-28",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-10",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-10",
+      "id": "komunalni-2022-569810-a-31",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-11",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-11",
+      "id": "komunalni-2022-569810-a-34",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-12",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-12",
+      "id": "komunalni-2022-569810-a-37",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-13",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-13",
+      "id": "komunalni-2022-569810-a-40",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-14",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-14",
+      "id": "komunalni-2022-569810-a-43",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-15",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-15",
+      "id": "komunalni-2022-569810-a-46",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-15",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-16",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-16"
+      "id": "komunalni-2022-569810-a-49",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-16"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-17",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-17",
+      "id": "komunalni-2022-569810-a-52",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-18",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-18",
+      "id": "komunalni-2022-569810-a-55",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-19",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-19",
+      "id": "komunalni-2022-569810-a-58",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-20",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-20",
+      "id": "komunalni-2022-569810-a-61",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-21",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-21"
+      "id": "komunalni-2022-569810-a-64",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-21"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-22",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-22",
+      "id": "komunalni-2022-569810-a-67",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-22",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-23",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-23",
+      "id": "komunalni-2022-569810-a-70",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-23",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-24",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-24",
+      "id": "komunalni-2022-569810-a-73",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-25",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-25",
+      "id": "komunalni-2022-569810-a-76",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-26",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-26",
+      "id": "komunalni-2022-569810-a-79",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-27",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-27",
+      "id": "komunalni-2022-569810-a-82",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-28",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-28"
+      "id": "komunalni-2022-569810-a-85",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-28"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-29",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-29",
+      "id": "komunalni-2022-569810-a-88",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-30",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-30",
+      "id": "komunalni-2022-569810-a-91",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-31",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-31",
+      "id": "komunalni-2022-569810-a-94",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-32",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-32",
+      "id": "komunalni-2022-569810-a-97",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-33",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-33",
+      "id": "komunalni-2022-569810-a-100",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-34",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-34",
+      "id": "komunalni-2022-569810-a-103",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-35",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-35",
+      "id": "komunalni-2022-569810-a-106",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-36",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-36",
+      "id": "komunalni-2022-569810-a-109",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-37",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-37",
+      "id": "komunalni-2022-569810-a-112",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-38",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-38",
+      "id": "komunalni-2022-569810-a-115",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-39",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-39",
+      "id": "komunalni-2022-569810-a-118",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-40",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-40",
+      "id": "komunalni-2022-569810-a-121",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-41",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-41",
+      "id": "komunalni-2022-569810-a-124",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-42",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-42",
+      "id": "komunalni-2022-569810-a-127",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-43",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-43",
+      "id": "komunalni-2022-569810-a-130",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-44",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-44",
+      "id": "komunalni-2022-569810-a-133",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-44",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-45",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-45",
+      "id": "komunalni-2022-569810-a-136",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-46",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-46",
+      "id": "komunalni-2022-569810-a-139",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-47",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-47",
+      "id": "komunalni-2022-569810-a-142",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-48",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-48",
+      "id": "komunalni-2022-569810-a-145",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-49",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-49",
+      "id": "komunalni-2022-569810-a-148",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-50",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-50",
+      "id": "komunalni-2022-569810-a-151",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-50",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-51",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-51",
+      "id": "komunalni-2022-569810-a-154",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-51",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-52",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-52",
+      "id": "komunalni-2022-569810-a-157",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-52",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-53",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-53",
+      "id": "komunalni-2022-569810-a-160",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-53",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-707699-54",
-      "candidate_id": "komunalni-2022-569810-candidate-707699",
-      "question_id": "komunalni-2022-569810-question-54"
+      "id": "komunalni-2022-569810-a-163",
+      "candidate_id": "komunalni-2022-569810-c-707699",
+      "question_id": "komunalni-2022-569810-q-54"
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-1",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-1",
+      "id": "komunalni-2022-569810-a-4",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-1",
       "answer": "no",
       "comment": "Vytváření VIP čtvrtí vede k sociální segregaci a nárůstu sociálního pnutí ve společnosti. Městské části, kde se mohou potkávat lidé bohatí i ti chudší, lidé různých povolání a životních zkušeností přispívají k většímu porozumění ve společnosti."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-2",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-2",
+      "id": "komunalni-2022-569810-a-7",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-2",
       "answer": "yes",
       "comment": "Svoz odpadu je důležitou součástí městských služeb. Vzhledem k aktuální ekonomické situace není reálné svozové poplatky rušit, ale chceme je v následujícím volebním období udržet na stávající výši."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-3",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-3",
+      "id": "komunalni-2022-569810-a-10",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-3",
       "answer": "no",
       "comment": "Sociální demokracie bude aktivně bojovat proti snahám o omezení vytápění nejen v domovech pro seniory, ale v jakýchkoliv objektech poskytujících sociální a zdravotní služby. Podporujeme energetické úspory v provozu a investice do pořizování vybavení, které snižuje energetickou náročnost. Nikdy však nepodpoříme úspory na úkor komfortu a zdraví klientů sociálních a zdravotních služeb."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-4",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-4",
+      "id": "komunalni-2022-569810-a-13",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-4",
       "answer": "no",
       "comment": "Jsme obecně proti umělému omezování plynulosti dopravy, pokud k tomu není racionální důvod (např. blízkost zařízení s velkou koncentrací dětí, rizikové lokality z hlediska bezpečnosti silničního provozu, či obytné zóny atd.). Nad rámec těchto standardních případů nejsme pro omezování povolené rychlosti."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-5",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-5",
+      "id": "komunalni-2022-569810-a-16",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-6",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-6",
+      "id": "komunalni-2022-569810-a-19",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-6",
       "answer": "yes",
       "comment": "Podpoříme zvýšení počtu dohledových kamer v rizikových lokalitách, které identifikuje městská policie (lokality s vysokou kriminalitou, častým hlášením rušení veřejného pořádku atd.)."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-7",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-7",
+      "id": "komunalni-2022-569810-a-22",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-7",
       "answer": "no",
       "comment": "Podporujeme přísnou regulaci hazardu, nikoliv však jeho úplné vytlačení z města."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-8",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-8",
+      "id": "komunalni-2022-569810-a-25",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-8",
       "answer": "no",
       "comment": "ČSSD podporuje koncept bezplatné MHD, který úspěšně funguje v řadě měst západní Evropy a také již v několika městech v ČR. Tuto myšlenku jsme již měli v minulosti v našem programu. Jedná se však o určitý dlouhodobý cíl, který se odvíjí od rozpočtových možností města a dostatku řidičů a dalšího personálu nutného pro zvládání větší intenzity přepravy. V aktuální situaci tyto podmínky naplněny nejsou a pro následující 4 roky tak nepovažujeme tuto možnost za reálnou. Podpoříme však zpracování studie proveditelnosti takového záměru pro budoucí volební období. "
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-9",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-9",
+      "id": "komunalni-2022-569810-a-28",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-9",
       "answer": "yes",
       "comment": "Bezbariérový přístup k MHD je základním předpokladem fungující městské dopravy."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-10",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-10",
+      "id": "komunalni-2022-569810-a-31",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-10",
       "answer": "yes",
       "comment": "Jsme pro veřejné a jmenovité hlasování ve všech typech hlasování, kromě tajných personálních voleb, kde jmenovité hlasování vede ke kolektivnímu nátlaku na zastupitele, kteří se pak nemusí řídit svým svědomím (tajná personální volba je jedním z výdobytků demokratického zřízení po roce 1989). Ve všem ostatním má však veřejnost právo znát, jak který zastupitel hlasoval."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-11",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-11",
+      "id": "komunalni-2022-569810-a-34",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-11",
       "answer": "yes",
       "comment": "Jsme pro veřejné a jmenovité hlasování ve všech typech hlasování, kromě tajných personálních voleb."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-12",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-12",
+      "id": "komunalni-2022-569810-a-37",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-12",
       "answer": "yes",
       "comment": "Soukromé využívání zábavné pyrotechniky by mělo být kromě Silvestra zakázané. Město by však mělo mít možnost rozhodnout o profesionálním použití zábavné pyrotechniky při mimořádných akcích pořádaných městem samotným (např. při výročí významných událostí)."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-13",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-13",
+      "id": "komunalni-2022-569810-a-40",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-13",
       "comment": "Tato otázka má příliš mnoho variant a možností, než aby na ní bylo možné jednoznačně odpovědět. Obecně podporujeme maximální otevřenost veřejného prostoru, včetně veřejných budov, ovšem za jasných bezpečnostních podmínek. Je např. těžko představitelné, že by budova magistrátu města měla být přístupná mimo otevírací dobu. "
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-14",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-14",
+      "id": "komunalni-2022-569810-a-43",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-14",
       "answer": "yes",
       "comment": "Souhlasíme s omezením, či dokonce s ukončením nasvěcování kulturních památek. Toto je racionální příspěvkem ke snižování spotřeby energií v době jejich mimořádně vysockých cen."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-15",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-15",
+      "id": "komunalni-2022-569810-a-46",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-15",
       "answer": "yes",
       "comment": "Souhlasíme s omezením intenzity veřejného osvětlení kvůli nezbytným energetickým úsporám. Nebráníme se diskuzi o jeho vypnutí po omezenou dobu např. mezi jednou až pátou hodinou ráno. Úplné vypnutí však podpoříme jedině po vyhodnocení bezpečnostních rizik. "
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-16",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-16",
+      "id": "komunalni-2022-569810-a-49",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-16",
       "answer": "no",
       "comment": "Striktně nepodpoříme žádné opatření, které by vedlo ke snížení teploty pod úroveň hygienických požadavků na vnitřní prostředí staveb, ale nepodporujeme ani apriorní snižování teploty na nejnižší povolenou hranici. Zaměstnanci města nesmí mrznout a ohrožovat své zdraví. Nebráníme se vydání doporučení pro úspory při vytápění, případně návrhům řešení jdoucím od spodu, tedy od zaměstnanců samotných."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-17",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-17",
+      "id": "komunalni-2022-569810-a-52",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-17",
       "answer": "no",
       "comment": "Nesouhlasíme s apriorním odpouštěním dluhů mladistvých. Jsme však pro takovou úpravu, které povede k zastropování maximální výše dluhu, aby se ten např. o úroky nakumuloval do nesmyslných výšek a nestal se tak existenčním problémem pro danou osobu. "
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-18",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-18",
+      "id": "komunalni-2022-569810-a-55",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-18",
       "answer": "yes",
       "comment": "Ano, souhlasíme s vytvářením transparentních účtů pro možný dohled nad výdaji města."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-19",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-19",
+      "id": "komunalni-2022-569810-a-58",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-19",
       "answer": "yes",
       "comment": "Podpoříme zavedení prvků tzv. participativního rozpočtu, který umožnuje obyvatelům města přímo ovlivňovat, jakým směrem bude alespoň část městských peněz využita."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-20",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-20",
+      "id": "komunalni-2022-569810-a-61",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-20",
       "answer": "yes",
       "comment": "Jednou z hlavních priorit ČSSD je podpora dostupného obecního bydlení. Podpoříme výstavbu nových obecních bytů. Budeme iniciovat a prosazovat, aby se vytvořila pravidla, která by zavazovala developery ke spoluúčasti na rozvoji území, včetně předávání části nových bytů do městského bytového fondu. Podpoříme vyhledávání vhodných již existujících objektů a jejich odkup městem s cílem rozšíření bytového fondu města."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-21",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-21",
+      "id": "komunalni-2022-569810-a-64",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-21",
       "answer": "yes",
       "comment": "Souhlasíme s úsporami za energii při slavnostních osvětleních nejenom během Vánoc."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-22",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-22",
+      "id": "komunalni-2022-569810-a-67",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-22",
       "answer": "yes",
       "comment": "Souhlasíme s myšlenkou obědů ve školních jídelnách zdarma po vzoru Slovenska. Tato inciativa však musí být celostátní a být hrazena ze státního rozpočtu. ČSSD v minulosti z pozice MPSV takový návrh připravila, ale v poslanecké sněmovně nebyla tato myšlenka schválena."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-23",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-23",
+      "id": "komunalni-2022-569810-a-70",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-23",
       "answer": "yes",
       "comment": "Ano podpoříme hledání modelu, jak by město mohlo pomoci s tzv. carsharingem. "
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-24",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-24",
+      "id": "komunalni-2022-569810-a-73",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-24",
       "answer": "no",
       "comment": "Parkovací zóny mají svůj smysl vzhledem k zahlcenosti centra města. Vadí nám však to, že je parkovací systém vinnou pravicových ale i dalších lokálních stran zprivatizován. Naši zastupitelé by hledali všechny možné cesty k tomu navrátit parkovací systém do rukou města."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-25",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-25",
+      "id": "komunalni-2022-569810-a-76",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-25",
       "answer": "no",
       "comment": "ČSSD je principálně proti privatizaci bytového fondu města. Bez ohledu na okolnosti musí být bydlení rozpočtovou prioritou města, které musí do svých bytů investovat a za dostupné nájemné je nabízet lidem. Uděláme naopak vše pro to, aby se městský bytový fond rozšiřoval. "
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-26",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-26",
+      "id": "komunalni-2022-569810-a-79",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-26",
       "answer": "yes",
       "comment": "Budeme iniciovat a prosazovat, aby se vytvořila pravidla, která by zavazovala developery ke spoluúčasti na rozvoji území, aby se na něm spravedlivě podílel i soukromý sektor a náklady neneslo pouze město – například tím, že investor by byl povinen předat určitý počet bytů do městského bytového fondu."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-27",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-27",
+      "id": "komunalni-2022-569810-a-82",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-27",
       "answer": "no",
       "comment": "Ne. Pandemie, nedostatek řidičů v DPMHK a další faktory ukazují, že bez\nindividuální automobilové dopravy se město neobejde. Proto nepodporujeme\numělé omezování automobilistů, spíše chceme hledat cesty koexistence tak, aby\nautomobilová a jiná doprava mohly efektivně fungovat vedle sebe, nikoliv jedna proti\ndruhé."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-28",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-28",
+      "id": "komunalni-2022-569810-a-85",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-28",
       "answer": "yes",
       "comment": "Podporujeme myšlenku zdanění prázdných bytů. Jedná se o standardní mechanismus, který v západní Evropě pomáhá řešit bytovou krizi. Bydlení je veřejný statek, který má sloužit k uspokojení základních potřeb člověka a nesmí se stát nástrojem finanční spekulace. Bohužel ČR patří k zemím s jedním z nejvyšších podílů investičních bytů na celkovém bytovém fondu země. Pokud tuto věc nebudeme řešit, současná bytová krize se nezlepší."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-29",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-29",
+      "id": "komunalni-2022-569810-a-88",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-29",
       "answer": "yes",
       "comment": "Budeme iniciovat a prosazovat, aby se vytvořila pravidla, která by zavazovala developery ke spoluúčasti na rozvoji území, aby se na něm spravedlivě podílel i soukromý sektor a náklady neneslo pouze město"
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-30",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-30",
+      "id": "komunalni-2022-569810-a-91",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-30",
       "answer": "yes",
       "comment": "Elektomobilita je vzhledem k nastavení evropských a národních politik nezvratný trend a město na to musí reagovat."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-31",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-31",
+      "id": "komunalni-2022-569810-a-94",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-31",
       "answer": "yes",
       "comment": "ČSSD je největším politickým podporovatelem družstevního bydlení. V minulém období poslanecké sněmovny představila vlastní návrh podpory družstevního bydlení. Naši zastupitelé by hledali všechny možné cesty na jeho rozvoj. Podporujeme také spolkovou a výstavbu a další alternativní formy řešení bytové situace."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-32",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-32",
+      "id": "komunalni-2022-569810-a-97",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-32",
       "answer": "no",
       "comment": "Vzhledem k aktuální finanční situaci nepodporujeme jízdné zdarma a to ani u specifických skupin. Chceme však zastropovat ceny za MHD na úrovni k 31.12.2021. Nepodpoříme žádné zvyšování cen jízdného. Nezbytné navyšování výdajů za činnost dopravního podniku bude město financovat z vlastního rozpočtu. Chceme však podpořit zpracování studie proveditelnosti na koncept MHD zdarma jako možné cesty pro HK do budoucnosti."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-33",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-33",
+      "id": "komunalni-2022-569810-a-100",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-33",
       "answer": "yes",
       "comment": "Město by mělo podporovat nástroje energetické soběstačnosti či snižování závislosti na externích zdrojích u svých bytových i veřejných budov."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-34",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-34",
+      "id": "komunalni-2022-569810-a-103",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-34",
       "comment": "V úplné obecnosti na tuto otázku nelze odpovědět. Principiálně podporujeme bezplatný přístup pro mládež na sportoviště. U kulturních organizací bychom zachovali současné nastavení. Konkrétní rozhodnutí bychom však chtěli opřít o finanční analýzu toho, do jaké míry by odpouštění vstupného mohlo ohrozit finanční stabilitu, té které organizace."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-35",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-35",
+      "id": "komunalni-2022-569810-a-106",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-35",
       "answer": "yes",
       "comment": "Podporujeme volnou dostupnost menstruačních pomůcek ve školských zařízeních, protože především mladé dívky s mají s tímto problémy. Ve veřejných budovách bychom takovou věc podpořili, ale formou zpoplatněné služby v ceně minimálně pokrývající nutné náklady (např. automat na toaletách s takovými pomůckami za poplatek)."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-36",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-36",
+      "id": "komunalni-2022-569810-a-109",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-36",
       "answer": "no",
       "comment": "Taková věc dle našeho názoru nemá být vynucována zákonem."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-37",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-37",
+      "id": "komunalni-2022-569810-a-112",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-37",
       "answer": "yes",
       "comment": "Podpoříme racionální (návratné) investice do fotovoltaiky na veřejných budovách, pokud se nejedná o kulturní památky."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-38",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-38",
+      "id": "komunalni-2022-569810-a-115",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-38",
       "answer": "no",
       "comment": "Město má formou vyhlášky upravit fungování sdílených koloběžek či jiných dopravních prostředků, tak aby jejich používání bylo bezpečné. Přímou finanční podporu těmto formám dopravy by však dávat nemělo. "
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-39",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-39",
+      "id": "komunalni-2022-569810-a-118",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-39",
       "answer": "no",
       "comment": "Město by nemělo suplovat roli státu v obecné otázce integrace cizinců. Město může aktivně podpořit integraci těch cizinců, kteří např. díky své kvalifikaci mají význam pro rozvoj města (lékaři, učitelé ale např. i řidiči MHD atd...). "
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-40",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-40",
+      "id": "komunalni-2022-569810-a-121",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-40",
       "answer": "yes",
       "comment": "Podporujeme navýšení počtu městských strážníků, především těch, kteří budou sloužit v přímém výkonu v ulicích města."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-41",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-41",
+      "id": "komunalni-2022-569810-a-124",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-41",
       "answer": "yes",
       "comment": "Podporujeme princi tzv. zelených střech a jejich instalace na veřejné budovy, pokud se nejedná o památkově chráněné budovy."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-42",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-42",
+      "id": "komunalni-2022-569810-a-127",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-42",
       "answer": "yes",
       "comment": "Město by mělo podporovat oddělenou cyklodopravu po městě (dobudováním sítě cyklostezek na základě generelů cyklodopravy prodiskutovaných s komisemi místních samospráv a občanskými inciativami). Podporujeme také investice do doprovodné infrastruktury jako jsou úschovná místa pro kola a jejich příslušenství apod.."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-43",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-43",
+      "id": "komunalni-2022-569810-a-130",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-43",
       "answer": "yes",
       "comment": "Město by mělo finančně podporovat profesionální sportovní kluby a organizace v Hradci Králové. Současně by však mělo hledat i soukromé sponzory."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-44",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-44",
+      "id": "komunalni-2022-569810-a-133",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-44",
       "answer": "no",
       "comment": "Jsme pro zachování daně z nemovitosti na stávající úrovni. "
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-45",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-45",
+      "id": "komunalni-2022-569810-a-136",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-45",
       "answer": "yes",
       "comment": "Ano město by mělo hledat nástroje, které má k dispozici, a které mohou pomoci lidem v nouzi. Město nemůže v obecné rovině suplovat roli státu a jeho sociální politiky ale může využívat některé nástroje, které mohou pomoci konkrétním lidem (např. dočasné odpouštění poplatků, snížení nájemného v obecním bytě apod.)."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-46",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-46",
+      "id": "komunalni-2022-569810-a-139",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-46",
       "answer": "yes",
       "comment": "Při výstavbě bytů by mělo být aktivní samo město, nemělo by nadále být pouze „rukojmím“ developerů. Naším cílem je nastartování vlastní městské výstavby dostupných a startovacích bytů a podpora družstevní výstavby. Budeme iniciovat a prosazovat, aby se vytvořila pravidla, která by zavazovala developery ke spoluúčasti na rozvoji území – například tím, že investor by byl povinen předat určitý počet bytů do městského bytového fondu. Podpoříme vyhledávání vhodných již existujících objektů a jejich odkup městem s cílem rozšíření bytového fondu města."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-47",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-47",
+      "id": "komunalni-2022-569810-a-142",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-47",
       "answer": "no",
       "comment": "Město by nemělo administrativně \"rozdělovat\" děti podle jejich sociálního zázemí. Samozřejmě vnímáme, že některé školy jsou lokalizovány v místech s větší koncentrací sociálně znevýhodněných skupin. Není však řešení jejich \"řízené rozptylování\" po městě, které by bylo navíc často činěno proti vůli dětí samotných. Podporujeme spíše přímou pomoc takovým školám a to jak finanční, tak personální."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-48",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-48",
+      "id": "komunalni-2022-569810-a-145",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-48",
       "answer": "yes",
       "comment": "Dle všech studií se ukazuje, že dostupná předškolní výchova má pozitivní vliv na životní šance daných osob v jejich následném životě. Je to navíc šance pro mnoho rodin sladit svoji pracovní kariéru s rodinným životem. "
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-49",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-49",
+      "id": "komunalni-2022-569810-a-148",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-49",
       "answer": "yes",
       "comment": "Za současných podmínek podporujeme majetkové zapojení města v hradeckém fotbalu a hokeji. Současně však podporujeme hledání strategického investora, který by měl parametry rozvíjet dané kluby lépe než město. "
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-50",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-50",
+      "id": "komunalni-2022-569810-a-151",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-50",
       "answer": "yes",
       "comment": "Souhlasili jsme s uchováním a konzervováním konstrukce mostu a jeho uložení na hradeckém letišti. Budoucí plánované využití na přemostění Piletického potoka však vnímáme jako problematické, protože plánovaný návazný developerský projekt tzv. Severní zóny nepodporujeme. Pro most bychom tak hledali pravděpodobně jiné využití."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-51",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-51",
+      "id": "komunalni-2022-569810-a-154",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-51",
       "answer": "no",
       "comment": "V tuto chvíli zápis do UNESCO nepodporujeme. Ačkoliv Hradce Králové má parametry na zapsání do UNESCO, musíme realisticky hodnotit i možná rizika takového situace. Zapsání do UNESCO sebou přináší řadu omezení pokud jde území rozvoj v daném území. Benefit v podobě větších zisků z cestovního ruchu může být vykoupen příliš velkým dopravním zatížením, které HK v tuto chvíli nemůže unést, nehledě na zhoršení podmínek k životu místních rezidentů. Bez dořešení dopravní situace města, dostavby parkovacích kapacit a dobudování doprovodné turistické infrastruktury by taková situace přinesla pro HK spíše více negativ než pozitiv. Do budoucna se však diskuzi na toto téma nebráníme."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-52",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-52",
+      "id": "komunalni-2022-569810-a-157",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-52",
       "answer": "yes",
       "comment": "Podporujeme projekt rekonstrukce Velkého náměstí, ale bez podzemního parkoviště."
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-53",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-53",
+      "id": "komunalni-2022-569810-a-160",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-53",
       "answer": "yes",
       "comment": "Principiálně jsme ochotni podpořit omezení kamionové dopravy v Pouchovské ulici. Celkovou špatnou dopravní situaci v této lokalitě je však možné koncepčně vyřešit jedině vybudováním tzv. severní tangenty (tyrkysová varianta). Je nutné vyvinout politický tlak na orgány státu s cílem vybudování klíčových infrastrukturních staveb za účelem odvedení tranzitní dopravy z města"
     },
     {
-      "id": "komunalni-2022-569810-answer-244511-54",
-      "candidate_id": "komunalni-2022-569810-candidate-244511",
-      "question_id": "komunalni-2022-569810-question-54",
+      "id": "komunalni-2022-569810-a-163",
+      "candidate_id": "komunalni-2022-569810-c-244511",
+      "question_id": "komunalni-2022-569810-q-54",
       "comment": "V anketě nám chybělo téma rozvoje sociálních služeb."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-1",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-1",
+      "id": "komunalni-2022-569810-a-4",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-1",
       "answer": "no",
       "comment": "Jsme proti jakýmkoliv formám segregace obyvatel."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-2",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-2",
+      "id": "komunalni-2022-569810-a-7",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-2",
       "answer": "yes",
       "comment": "Poplatek je nezbytný pro pokrytí alespoň části nákladů na likvidaci odpadů. Jeho výši však chceme zachovat na současné úrovni, a to za předpokladu, že se bude zlepšovat úroveň třídění odpadů obyvateli."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-3",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-3",
+      "id": "komunalni-2022-569810-a-10",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-3",
       "answer": "no",
       "comment": "Souhlasíme, že senioři jsou ohroženou skupinou a mají specifické potřeby, které je třeba respektovat. Nicméně město neprovozuje žádný domov pro seniory."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-4",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-4",
+      "id": "komunalni-2022-569810-a-13",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-4",
       "answer": "yes",
       "comment": "Jsme pro vytváření zklidněných zón zejména v centru města a v rezidenčních oblastech."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-5",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-5",
+      "id": "komunalni-2022-569810-a-16",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-5",
       "answer": "yes",
       "comment": "Informování dlužníků by určitě bylo přínosem. Jinak podpořili jsme v zastupitelstvu i dluhovou amnestii, která rozšiřuje možnost zbavit se dluhů pro řadu dalších občanů."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-6",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-6",
+      "id": "komunalni-2022-569810-a-19",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-6",
       "answer": "no",
       "comment": "Další rozšiřování kamerového systému by mělo být už jen ve zcela výjimečných případech - v místech, kde se objeví problémy, které není možné řešit jiným způsobem."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-7",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-7",
+      "id": "komunalni-2022-569810-a-22",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-7",
       "answer": "yes",
       "comment": "Škodlivé vlivy hazardu jsou prokázány naprosto jasně a získané finance (které můžeme označit i jako špinavé peníze) nemohou vynahradit celospolečenské problémy a ztráty, které hazard působí."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-8",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-8",
+      "id": "komunalni-2022-569810-a-25",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-8",
       "answer": "no",
       "comment": "Doprava úplně zdarma je v současné době mimo finanční možnosti města. K cenové politice je však třeba přistupovat velmi obezřetně a vyhnout se takovému zdražování, které by způsobilo odliv cestujících z MHD. V uplynulém období jsme prosadili symbolické jízdné pro lidi s invaliditou III. stupně. Stejně tak jsme pro zcela symbolické jízdné pro osoby nad 65 let (na úrovni 100 Kč za rok). "
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-9",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-9",
+      "id": "komunalni-2022-569810-a-28",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-10",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-10",
+      "id": "komunalni-2022-569810-a-31",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-10",
       "answer": "yes",
       "comment": "Hlasování členů zastupitelstva se již zveřejňuje."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-11",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-11",
+      "id": "komunalni-2022-569810-a-34",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-11",
       "answer": "yes",
       "comment": "Jsme pro větší otevřenost i v jednání rady města, včetně zveřejňování zápisů a podkladů z jednání rady. Jsou však právní výklady (kterými argumentuje např. právní oddělení magistrátu), že tyto informace zveřejňovat nelze. Chceme proto, aby tato možnost byla nezávisle prověřena."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-12",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-12",
+      "id": "komunalni-2022-569810-a-37",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-12",
       "answer": "yes",
       "comment": "Zábavní pyrotechnika obtěžuje lidi, stresuje domácí i volně žijící zvířata a působí nepořádek a zbytečné znečištění ovzduší."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-13",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-13",
+      "id": "komunalni-2022-569810-a-40",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-13",
       "answer": "yes",
       "comment": "Nevidíme v tom problém. Nejsme si ale jisti, zda bude takové opatření v HK potřeba."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-14",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-14",
+      "id": "komunalni-2022-569810-a-43",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-14",
       "answer": "yes",
       "comment": "Osvětlení památek je někdy přehnané a když na to přijde, tak je to zbytná záležitost, na které je možné šetřit (není nutné památky osvětlovat celou noc a každý jejich detail, bude také potřeba hledat úspornější svítidla pro tyto účely). Nevhodné osvětlení navíc působí jako past na ohrožený a ubývající hmyz."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-15",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-15",
+      "id": "komunalni-2022-569810-a-46",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-15",
       "answer": "yes",
       "comment": "Na prvním místě musí být postupná náhrada současných světelných zdrojů za ty úsporné a regulovatelné, aby mohla být např. v nočních hodinách snižována intenzita osvětlení. Dále je třeba posoudit, zda skutečně všechna místa je nutné osvětlovat v takové míře jako nyní. Úplné vypínání veřejného osvětlení však nepředpokládáme."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-16",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-16",
+      "id": "komunalni-2022-569810-a-49",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-16",
       "answer": "yes",
       "comment": "Pokud to bude nutné, pak je to možné řešení jak snížit náklady za vytápění."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-17",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-17",
+      "id": "komunalni-2022-569810-a-52",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-17",
       "answer": "yes",
       "comment": "Obecně souhlasíme. Město HK však, dle našich informací, dětské exekuce neprovozuje."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-18",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-18",
+      "id": "komunalni-2022-569810-a-55",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-18",
       "answer": "yes",
       "comment": "Bude-li to právně možné, nevidíme důvod, proč by město nemohlo mít své účty transparentní."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-19",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-19",
+      "id": "komunalni-2022-569810-a-58",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-19",
       "answer": "yes",
       "comment": "Stejně tak chceme část rozpočtu, o které budou rozhodovat komise místních samospráv."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-20",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-20",
+      "id": "komunalni-2022-569810-a-61",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-20",
       "answer": "yes",
       "comment": "Chceme prosazovat výstavbu městských bytů. Je to jeden z hlavních bodů našeho programu. Přišli jsme s projektem výstavby 1200 městských dostupných bytů v lokalitě Severní zóna. Podpoříme vznik městského developera i podporu družstevního bydlení."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-21",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-21",
+      "id": "komunalni-2022-569810-a-64",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-21",
       "comment": "Nejsme si jisti, zda zrovna tato věc bude mít tak zásadní význam vzhledem ke krátkodobosti vánočního osvětlení. V případě skutečné krize je však možné přistoupit i k tomuto kroku."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-22",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-22",
+      "id": "komunalni-2022-569810-a-67",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-22",
       "comment": "Ano i ne: Ano - potřebným skupinám. Již nyní existuje systém anonymní podpory sociálně potřebných dětí, kdy jim jsou obědy hrazeny. Ne - celoplošné obědy zdarma."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-23",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-23",
+      "id": "komunalni-2022-569810-a-70",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-23",
       "answer": "yes",
       "comment": "Formou parkování zdarma ve středu města."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-24",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-24",
+      "id": "komunalni-2022-569810-a-73",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-24",
       "answer": "no",
       "comment": "Bez placených parkovacích zón se neobejdeme. Rozhodně však odmítáme rozšiřování parkovacích zón provozovaných firmou ISP. Nové placené parkování podpoříme jen pokud bude v režii města/městské organizace."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-25",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-25",
+      "id": "komunalni-2022-569810-a-76",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-25",
       "answer": "no",
       "comment": "Privatizaci městských bytů považujeme za už jednou pro vždy uzavřenou kapitolu, která patří do historie devadesátých a nultých let. Rozhodně nechceme, aby se město zbavovalo jakýchkoliv dalších bytů."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-26",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-26",
+      "id": "komunalni-2022-569810-a-79",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-26",
       "answer": "yes",
       "comment": "Zatím to tady fungovalo spíše opačně, že město dělalo servis developerům. Je načase podmínky narovnat."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-27",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-27",
+      "id": "komunalni-2022-569810-a-82",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-27",
       "answer": "yes",
       "comment": "Je to jeden z klíčových bodů našeho programu."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-28",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-28",
+      "id": "komunalni-2022-569810-a-85",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-28",
       "comment": "Bylo by to asi spravedlivé, ale je otázka, zda to je v současné době právně a technicky realizovatelné. Není to téma pro komunální úroveň politiky."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-29",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-29",
+      "id": "komunalni-2022-569810-a-88",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-29",
       "answer": "yes",
       "comment": "Zejm. příspěvky na občanskou vybavenost typu mateřských škol a také technickou a dopravní infrastrukturu."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-30",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-30",
+      "id": "komunalni-2022-569810-a-91",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-30",
       "answer": "yes",
       "comment": "Podporovali jsme již v současném volebním období."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-31",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-31",
+      "id": "komunalni-2022-569810-a-94",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-31",
       "answer": "yes",
       "comment": "Určitě to je jedna z cest jak nastartovat dostupnou bytovou výstavbu a jsme pro její podporu."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-32",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-32",
+      "id": "komunalni-2022-569810-a-97",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-32",
       "answer": "no",
       "comment": "Úplně zdarma ne, ale chceme dostupnou MHD s výraznou slevou pro děti do 18 let."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-33",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-33",
+      "id": "komunalni-2022-569810-a-100",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-33",
       "answer": "yes",
       "comment": "V první řadě je třeba, aby město instalovalo fotovoltaické panely na střechy vlastních budov. Město by ale mělo pomáhat i soukromníkům s instalací FVE na střechy například panelových domů. (Např. Tepelné hospodářství jako městská společnost by mělo připravovat FVE nejen na městských budovách, ale i pomáhat společenství vlastníků). "
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-34",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-34",
+      "id": "komunalni-2022-569810-a-103",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-34",
       "answer": "yes",
       "comment": "Jsme pro symbolické vstupné (úplně zadarmo ne)."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-35",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-35",
+      "id": "komunalni-2022-569810-a-106",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-35",
       "answer": "yes",
       "comment": "Mělo by to být jako s toaletním papírem a mýdlem, které jsou také na toaletách k dispozici."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-36",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-36",
+      "id": "komunalni-2022-569810-a-109",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-36",
       "answer": "no",
       "comment": "Jiné hygienické potřeby (např. toaletní papír a mýdlo) se také bezplatně neposkytují (s výjimkou právě veřejně přístupných toalet - viz otázka č. 35). Zákonnou povinnost navíc na komunální úrovni asi nevyřešíme."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-37",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-37",
+      "id": "komunalni-2022-569810-a-112",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-37",
       "answer": "yes",
       "comment": "Je to jeden z hlavních bodů našeho programu. Přinese to alespoň částečnou soběstačnost města v oblasti energetiky."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-38",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-38",
+      "id": "komunalni-2022-569810-a-115",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-38",
       "comment": "Město by mělo obecně vytvářet podmínky pro šetrné formy dopravy. Je třeba, aby byla dodržována pravidla při parkování koloběžek a nestávaly se tyto nebezpečnou překážkou pro chodce, cyklisty i další účastníky dopravního provozu."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-39",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-39",
+      "id": "komunalni-2022-569810-a-118",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-39",
       "answer": "yes",
       "comment": "Mj. i podporou různých neziskových organizací a projektů zaměřených na pomoc a integraci cizinců."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-40",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-40",
+      "id": "komunalni-2022-569810-a-121",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-40",
       "answer": "no",
       "comment": "Jsme pro zachování stávajícího počtu."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-41",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-41",
+      "id": "komunalni-2022-569810-a-124",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-41",
       "answer": "yes",
       "comment": "Zelené střechy jsme prosazovali velmi intenzívně už v současném volebním období (budova odlehčovací služby, rekonstrukce MŠ Kamarád, nová MŠ Podzímčí II). "
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-42",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-42",
+      "id": "komunalni-2022-569810-a-127",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-42",
       "answer": "yes",
       "comment": "Podpora cyklodopravy je jedním z hlavních bodů našeho programu."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-43",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-43",
+      "id": "komunalni-2022-569810-a-130",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-43",
       "answer": "yes",
       "comment": "Určitě podpora mládeže a údržby a provozu sportovišť. Podpora profesionálních klubů pouze do výše možné veřejné podpory dle pravidel EU."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-44",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-44",
+      "id": "komunalni-2022-569810-a-133",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-44",
       "answer": "no",
       "comment": "Chceme zachovat současnou úroveň daně z nemovitosti."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-45",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-45",
+      "id": "komunalni-2022-569810-a-136",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-45",
       "answer": "yes",
       "comment": "Podporujeme již v současné době formou příspěvků pro studenty v tíživé sociální situaci z městského nadačního fondu. "
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-46",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-46",
+      "id": "komunalni-2022-569810-a-139",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-46",
       "answer": "yes",
       "comment": "Rozhodně chceme, aby město systematicky budovalo a řádně udržovalo svůj bytový fond."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-47",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-47",
+      "id": "komunalni-2022-569810-a-142",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-47",
       "answer": "yes",
       "comment": "Odmítáme jakékoliv formy segregace obyvatel a u dětí to platí dvojnásob."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-48",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-48",
+      "id": "komunalni-2022-569810-a-145",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-49",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-49",
+      "id": "komunalni-2022-569810-a-148",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-49",
       "answer": "no",
       "comment": "Město by se mělo snažit majetkových podílů zbavit (resp. ponechat si jen kontrolní podíl), ovšem za podmínky, že tím výrazně sníží své výdaje na provoz těchto klubů."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-50",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-50",
+      "id": "komunalni-2022-569810-a-151",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-50",
       "answer": "yes",
       "comment": "Jsme iniciátory a hlavními zastánci záchrany historického svinarského mostu. Most, který je památkově velmi cenný, je aktuálně bezpečně uložen a  zakonzervován a jeho budoucí umístění je známé. Jeho využití a rekonstrukce bude finančně srovnatelná se stavbou nové lávky pro cyklisty a pěší, která by se na daném místě musela postavit tak jako tak (odhad je cca kolem 20 milionů)."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-51",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-51",
+      "id": "komunalni-2022-569810-a-154",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-51",
       "answer": "no",
       "comment": "Myslíme, že Hradec Králové nemá šanci a je zbytečné utrácet peníze za další přípravné studie a dokumenty. Berme naše město takové, jaké je a pečujme o jeho kulturní a přírodní dědictví ve vší jeho rozmanitosti. "
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-52",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-52",
+      "id": "komunalni-2022-569810-a-157",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-52",
       "answer": "yes",
       "comment": "Odmítáme stavbu podzemního parkoviště na Velkém náměstí. Ohledně počtu parkovacích míst na VN je třeba najít rozumný kompromis. Současný stav je neudržitelný."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-53",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-53",
+      "id": "komunalni-2022-569810-a-160",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-53",
       "answer": "yes",
       "comment": "Podporujeme odklon kamionové dopravy z Pouchovské ulice. V zastupitelstvu jsme podpořili první krok k možnému řešení. Důležitá je přeložka Kladské ulice a rekonstrukce Vážní ulice, kam by byly kamiony odkloněny."
     },
     {
-      "id": "komunalni-2022-569810-answer-956549-54",
-      "candidate_id": "komunalni-2022-569810-candidate-956549",
-      "question_id": "komunalni-2022-569810-question-54",
+      "id": "komunalni-2022-569810-a-163",
+      "candidate_id": "komunalni-2022-569810-c-956549",
+      "question_id": "komunalni-2022-569810-q-54",
       "comment": "Některé otázky se možná zbytečně dublují nebo jsou podobné a jen významově trochu posunuté. Mohlo by být více otázek ke konkrétním kauzám nebo záměrům ve městě."
+    },
+    {
+      "id": "komunalni-2022-569810-a-4",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-1",
+      "answer": "no",
+      "comment": "Samospráva nemá přímou možnost ovlivnit vlastnickou strukturu obyvatel v jednotlivých lokalitách. K pestřejšímu a komplexnějšímu složení může přispět nepřímo pomocí územního plánu, vybavenosti, dopravní obslužností, zajištěním služeb, údržbou,..."
+    },
+    {
+      "id": "komunalni-2022-569810-a-7",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-10",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-3",
+      "answer": "no",
+      "comment": "V obytných prostorách by měl být zajištěn odpovídající standard. Lze omezit plýtvání, přetápění, zavést efektivnější systém větrání, omezit vytápění technického zázemí,..."
+    },
+    {
+      "id": "komunalni-2022-569810-a-13",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-4",
+      "answer": "yes",
+      "comment": "V obytných zónách přispěje ke zklidnění dopravy a zvýšení bezpečnosti za předpokladu ohleduplnosti řidičů."
+    },
+    {
+      "id": "komunalni-2022-569810-a-16",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-5",
+      "answer": "yes",
+      "comment": "Snížení počtu obyvatel v exekuci přispěje ke snížení množství problémů v dalším období."
+    },
+    {
+      "id": "komunalni-2022-569810-a-19",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-6",
+      "answer": "yes",
+      "comment": "Použití kamer ve veřejném prostoru přispěje jako preventivní opatření ke zvýšení bezpečnosti."
+    },
+    {
+      "id": "komunalni-2022-569810-a-22",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-7",
+      "answer": "yes",
+      "comment": "Finance nemohou kompenzovat negativní dopady závislosti na hazardu."
+    },
+    {
+      "id": "komunalni-2022-569810-a-25",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-8",
+      "answer": "yes",
+      "comment": "Toho, co je zadarmo si málokdo dostatečně váží."
+    },
+    {
+      "id": "komunalni-2022-569810-a-28",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-9",
+      "answer": "yes",
+      "comment": "Eliminace bariér neslouží jen pro zvýšení soběstačnosti hendikepovaných, ale i maminkám s kočárky."
+    },
+    {
+      "id": "komunalni-2022-569810-a-31",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-34",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-37",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-12",
+      "answer": "yes",
+      "comment": "Regulace je nezbytná."
+    },
+    {
+      "id": "komunalni-2022-569810-a-40",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-13",
+      "answer": "yes",
+      "comment": "Již nyní jsou bezplatně přístupné veřejné knihovny."
+    },
+    {
+      "id": "komunalni-2022-569810-a-43",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-14",
+      "answer": "no",
+      "comment": "Jde o zbytné náklady, u nichž by mělo být přistoupeno k úsporám nejdříve."
+    },
+    {
+      "id": "komunalni-2022-569810-a-46",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-15",
+      "answer": "yes",
+      "comment": "Rezervy zde město má poměrně značné, protože v řadě míst se v současné době vyskytuje opačný problém, jímž je světelné znečištění. Výhledově by mohlo být přistoupeno i k investici do inteligentního osvětlení (svícení pouze v době přítomnosti osob ve veřejném prostoru)."
+    },
+    {
+      "id": "komunalni-2022-569810-a-49",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-16",
+      "answer": "yes",
+      "comment": "Rezervy a možnosti úspor v tomto ohledu na řadě míst má nejen město."
+    },
+    {
+      "id": "komunalni-2022-569810-a-52",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-17",
+      "answer": "no",
+      "comment": "Jde o odpovědnost rodičů / zákonných zástupců."
+    },
+    {
+      "id": "komunalni-2022-569810-a-55",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-18",
+      "comment": "Nejednoznačné zadání, samotný transparentní účet, tj. zveřejnění jednotlivých plateb, ale bez vazby na účetnictví (smlouvy, účel platby) nedává smysl. Smysl dává zveřejnění údajů o hospodaření v rámci agregovaných položek."
+    },
+    {
+      "id": "komunalni-2022-569810-a-58",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-19",
+      "comment": "Správně nastavená pravidla přispějí ke zlepšení sounáležitosti, povědomí o správě města i zvýšení podílu obyvatel na chodu města."
+    },
+    {
+      "id": "komunalni-2022-569810-a-61",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-20",
+      "answer": "yes",
+      "comment": "startovací byty, sociální bydlení, ...."
+    },
+    {
+      "id": "komunalni-2022-569810-a-64",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-21",
+      "answer": "yes",
+      "comment": "jde o zbytný náklad"
+    },
+    {
+      "id": "komunalni-2022-569810-a-67",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-22",
+      "comment": "Toho, co je zdarma, si málokdo váží. Ale příspěvky pro potřebné by měly být samozřejmostí."
+    },
+    {
+      "id": "komunalni-2022-569810-a-70",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-23",
+      "answer": "yes",
+      "comment": "Stejně jako sdílená kola, tento nástroj by měl přispět i ke snížení nedostatku parkovacích míst."
+    },
+    {
+      "id": "komunalni-2022-569810-a-73",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-24",
+      "answer": "yes",
+      "comment": "Jde o nástroj přispívající ke snížení dopravní zátěže v centru města."
+    },
+    {
+      "id": "komunalni-2022-569810-a-76",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-569810-a-79",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-26",
+      "answer": "yes",
+      "comment": "Jde-li o související investici, jež je předpokladem pro funkčnost navazujícího veřejného prostoru, pak nelze tuto zátěž přenášet na stranu veřejného rozpočtu."
+    },
+    {
+      "id": "komunalni-2022-569810-a-82",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-27",
+      "comment": "Rozhodně, jde nejen o ekologii, ale o snížení dopravní zátěže."
+    },
+    {
+      "id": "komunalni-2022-569810-a-85",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-28",
+      "answer": "yes",
+      "comment": "Otázkou je nastavení pravidel a jejich kontrolu."
+    },
+    {
+      "id": "komunalni-2022-569810-a-88",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-29",
+      "comment": "Nejednoznačná a zavádějící otázka."
+    },
+    {
+      "id": "komunalni-2022-569810-a-91",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-94",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-97",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-32",
+      "answer": "no",
+      "comment": "Viz výše - toho, co je zadarmo, si málokdo váží."
+    },
+    {
+      "id": "komunalni-2022-569810-a-100",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-33",
+      "answer": "yes",
+      "comment": "Komunitní energetika je efektivním nástrojem na řešení současné energetické krize."
+    },
+    {
+      "id": "komunalni-2022-569810-a-103",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-34",
+      "comment": "Nejednoznačná a zavádějící otázka, zvýhodněné vstupné je obvyklé již nyní."
+    },
+    {
+      "id": "komunalni-2022-569810-a-106",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-35",
+      "comment": "Řešení sociálních otázek prostřednictvím provozu veřejných institucí?"
+    },
+    {
+      "id": "komunalni-2022-569810-a-109",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-36",
+      "answer": "no",
+      "comment": "viz výše - sociální otázky  mají být řešeny jiným způsobem \nNavíc to, co je zadarmo, tím se plýtvá."
+    },
+    {
+      "id": "komunalni-2022-569810-a-112",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-37",
+      "answer": "yes",
+      "comment": "Zajištění energetické soběstačnosti v kombinaci s úsporami (snížením energetické náročnosti) jsou nástroje k efektivní správě majetku města."
+    },
+    {
+      "id": "komunalni-2022-569810-a-115",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-38",
+      "answer": "no",
+      "comment": "nejednoznačná a zavádějící otázka"
+    },
+    {
+      "id": "komunalni-2022-569810-a-118",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-39",
+      "answer": "yes",
+      "comment": "Integrace je důležitá pro eliminaci výrazných kulturních odlišností, které by mohly vést k rozdělení společnosti."
+    },
+    {
+      "id": "komunalni-2022-569810-a-121",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-40",
+      "answer": "no",
+      "comment": "Proč?"
+    },
+    {
+      "id": "komunalni-2022-569810-a-124",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-41",
+      "answer": "yes",
+      "comment": "Jde o efektivní způsob omezení negativního vlivu urbanizace - eliminace tzv. tepelného ostrova."
+    },
+    {
+      "id": "komunalni-2022-569810-a-127",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-42",
+      "answer": "yes",
+      "comment": "Rozhodně."
+    },
+    {
+      "id": "komunalni-2022-569810-a-130",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-43",
+      "answer": "no",
+      "comment": "Město by mělo podporovat především amatérský sport."
+    },
+    {
+      "id": "komunalni-2022-569810-a-133",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-569810-a-136",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-139",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-46",
+      "answer": "yes",
+      "comment": "viz výše - startovací byty, sociální bydlení"
+    },
+    {
+      "id": "komunalni-2022-569810-a-142",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-47",
+      "answer": "yes",
+      "comment": "Segregace má negativní dopady na fungování celé společnosti."
+    },
+    {
+      "id": "komunalni-2022-569810-a-145",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-148",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-569810-a-151",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-50",
+      "answer": "yes",
+      "comment": "Jde o unikátní doklad zajímavého technického řešení, ale je potřeba zajistit jeho vhodné začlenění do městského prostoru."
+    },
+    {
+      "id": "komunalni-2022-569810-a-154",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-157",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-160",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-53",
+      "comment": "Nejednoznačná a zavádějící otázka. K eliminaci dopravy by mělo dojít po dokončení severní tangenty."
+    },
+    {
+      "id": "komunalni-2022-569810-a-163",
+      "candidate_id": "komunalni-2022-569810-c-278614",
+      "question_id": "komunalni-2022-569810-q-54",
+      "comment": "Dotazník je zaměřen především na řešení investic, dopravní problematiky, sociální oblasti a bydlení. Zcela chybí otázky z oblasti kultury a řešení územního plánu. Řada otázek je položena nejednoznačně či jsou dokonce zavádějící."
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/582786.json
+++ b/data/kalkulacka/komunalni-2022/582786.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-582786",
   "name": "Brno",
-  "description": "Brno - DESCRIPTION",
+  "description": "Brno",
   "district_code": "582786",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-582786-question-1",
+      "id": "komunalni-2022-582786-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-2",
+      "id": "komunalni-2022-582786-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-3",
+      "id": "komunalni-2022-582786-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-4",
+      "id": "komunalni-2022-582786-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-5",
+      "id": "komunalni-2022-582786-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-6",
+      "id": "komunalni-2022-582786-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-7",
+      "id": "komunalni-2022-582786-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-8",
+      "id": "komunalni-2022-582786-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-9",
+      "id": "komunalni-2022-582786-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-10",
+      "id": "komunalni-2022-582786-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-11",
+      "id": "komunalni-2022-582786-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-12",
+      "id": "komunalni-2022-582786-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-13",
+      "id": "komunalni-2022-582786-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-14",
+      "id": "komunalni-2022-582786-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-15",
+      "id": "komunalni-2022-582786-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-16",
+      "id": "komunalni-2022-582786-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-17",
+      "id": "komunalni-2022-582786-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-18",
+      "id": "komunalni-2022-582786-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-19",
+      "id": "komunalni-2022-582786-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-20",
+      "id": "komunalni-2022-582786-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-21",
+      "id": "komunalni-2022-582786-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-22",
+      "id": "komunalni-2022-582786-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-23",
+      "id": "komunalni-2022-582786-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-24",
+      "id": "komunalni-2022-582786-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-25",
+      "id": "komunalni-2022-582786-q-25",
       "name": "Jedna parkovací zóna pro celé město",
       "title": "Město má umožňovat rezidentům za jeden roční paušální poplatek parkovat kdekoli na svém území.",
       "gist": "Ve městě by existovala jen jedna rezidenční parkovací zóna, nedělená podle oblastí či městských částí. Kritikům více zón vadí, že předplatné rezidentům parkovací místo automaticky nezaručí. Podle nich by jedna zóna pomohla parkovat i v jiném bloku nebo ulici, jež například spadají do vedlejší městské části.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-26",
+      "id": "komunalni-2022-582786-q-26",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-27",
+      "id": "komunalni-2022-582786-q-27",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-28",
+      "id": "komunalni-2022-582786-q-28",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-29",
+      "id": "komunalni-2022-582786-q-29",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-30",
+      "id": "komunalni-2022-582786-q-30",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-31",
+      "id": "komunalni-2022-582786-q-31",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-32",
+      "id": "komunalni-2022-582786-q-32",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-33",
+      "id": "komunalni-2022-582786-q-33",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-34",
+      "id": "komunalni-2022-582786-q-34",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-35",
+      "id": "komunalni-2022-582786-q-35",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-36",
+      "id": "komunalni-2022-582786-q-36",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-37",
+      "id": "komunalni-2022-582786-q-37",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-38",
+      "id": "komunalni-2022-582786-q-38",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-39",
+      "id": "komunalni-2022-582786-q-39",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-40",
+      "id": "komunalni-2022-582786-q-40",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-41",
+      "id": "komunalni-2022-582786-q-41",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-42",
+      "id": "komunalni-2022-582786-q-42",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-43",
+      "id": "komunalni-2022-582786-q-43",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-44",
+      "id": "komunalni-2022-582786-q-44",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-45",
+      "id": "komunalni-2022-582786-q-45",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-46",
+      "id": "komunalni-2022-582786-q-46",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-47",
+      "id": "komunalni-2022-582786-q-47",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-48",
+      "id": "komunalni-2022-582786-q-48",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -395,7 +397,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-49",
+      "id": "komunalni-2022-582786-q-49",
       "name": "Bydlení především",
       "title": "Podporuji, aby Brno opět zavedlo projekt Housing First.",
       "gist": "Do projektu se zapojují i další česká i světová města, např. ve Vídni si bydlení udrželo 98 % domácností. Brno i přes úspěch i ocenění od projektu postupně ustoupilo. Vedení města argumentovalo vysokými náklady, zastánci projektu ale poukazovali, že jsou výdaje hrazené většinou z fondů EU.",
@@ -403,7 +405,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-50",
+      "id": "komunalni-2022-582786-q-50",
       "name": "Krátkodobé pronájmy",
       "title": "Podporuji, aby se v Brně výrazně reguloval trh s krátkodobým bydlením.",
       "gist": "Zastánci regulace argumentují, že krátkodobě pronajímané nemovitosti křiví trh a vedou ke zvýšení cen. Vadí také nulové sousedské vazby a malá ohleduplnost hostů k dlouhodobým obyvatelům. Kritici poukazují, že se soukromým majetkem si vlastníci mohou nakládat jak chtějí.",
@@ -411,7 +413,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-51",
+      "id": "komunalni-2022-582786-q-51",
       "name": "Zákaz alkoholu na veřejnosti",
       "title": "Podporuji zákaz pití alkoholu na veřejných místech u škol a stanic MHD.",
       "gist": "",
@@ -419,7 +421,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-52",
+      "id": "komunalni-2022-582786-q-52",
       "name": "Nová multifunkční hala",
       "title": "Město má postavit multifunkční halu na výstavišti.",
       "gist": "Město halu plánuje jako nové zázemí pro hokejovou Kometu a jednorázové sportovní a kulturní akce. Odhad ceny je 6,8 miliardy korun. Kritici považují stavbu za zbytečnou, pochybuje se i o schopnosti provozovatele vydělávat, aby platil miliony korun do rozpočtu Brna.",
@@ -427,7 +429,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-53",
+      "id": "komunalni-2022-582786-q-53",
       "name": "Přechod na Údolní",
       "title": "Má být obnoven přechod na Údolní?",
       "gist": "",
@@ -435,7 +437,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-54",
+      "id": "komunalni-2022-582786-q-54",
       "name": "Územní plán",
       "title": "Má mít podle vás Brno aktuální územní plán?",
       "gist": "V Brně platí téměř 30 let starý územní plán s řadou pozdějších aktualizací. V roce 2014 byla schválena jeho velká aktualizace, kterou však o rok později zrušil soud pro nepřezkoumatelnost některých rozhodnutí. Ani letos ke schválení nedošlo, důvodem jsou problémy, které město řeší se Státním pozemkovým úřadem. ",
@@ -443,7 +445,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-55",
+      "id": "komunalni-2022-582786-q-55",
       "name": "Výstavba bytů",
       "title": "Souhlasíte, že Brno musí rozšířit bytovou výstavbu za současné hranice města?",
       "gist": "V Brně za poslední dekádu poklesla výstavba nových bytů o 12 %. Pro vyrovnání současného deficitu by město mělo v následujícím desetiletí budovat 3 tisíce bytů ročně. Průměrná výstavba přitom v posledních 20 letech nedosáhla ani na 1,5 tisíce bytů za rok a experti upozorňují na omezené možnosti vnitřních rozvojových ploch.",
@@ -451,7 +453,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-56",
+      "id": "komunalni-2022-582786-q-56",
       "name": "Horkovod Dukovany",
       "title": "Má se začít stavět horkovod z jaderné elektrárny Dukovany do Brna?",
       "gist": "Přes 40 kilometrů dlouhý horkovod by stál odhadem miliardy korun. Brno je nyní závislé na ruském plynu. Před 10 lety byla tato akce pozastavena, protože tehdy nemohlo město podle primátorky garantovat dostatečnou spotřebu.",
@@ -459,7 +461,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-57",
+      "id": "komunalni-2022-582786-q-57",
       "name": "Zákaz aut na náměstí Svobody",
       "title": "Souhlasím s tím, aby na náměstí Svobody nesměla osobní auta.",
       "gist": "Abonenti, rezidenti, zásobování a poskytovatelé služeb se na náměstí dostanou od šesti hodin do půl jedenácté dopoledne. Pro taxi a carsharingové vozy je oblast uzavřená. Zastánci si od toho slibují méně aut a více bezpečnosti pro pěší i cyklisty. Odpůrci namítají, že je systém vjezdu do centra složitý kvůli sedmi různým oblastem a nesystémový.",
@@ -467,7 +469,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-58",
+      "id": "komunalni-2022-582786-q-58",
       "name": "Grand Prix Brno",
       "title": "Grand Prix Brno už by se neměla obnovovat.",
       "gist": "Velká cena silničních motocyklů měla potíže už roky. Zastupitelstvo loni odhlasovalo, že pořádající spolek města a kraje má jít do insolvence. Závod s letitou tradicí se tak přestal jezdit. Spolek dluží promotérské společnosti Dorna, vlastníkovi Masarykova okruhu Automotodromu a musí vracet lidem peníze za nevyužité lístky v roce 2020, kdy se závod kvůli pandemii konal bez diváků.",
@@ -475,7 +477,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-59",
+      "id": "komunalni-2022-582786-q-59",
       "name": "Startovací byty",
       "title": "Z nabídek městských startovacích bytů se musí vyloučit všichni zaměstnanci města.",
       "gist": "Brno nabízí mladým rodinám (sezdaným, nesezdaným či registrovaným párům) startovací bydlení. Žadatelé musí splňovat věková a příjmová kritéria. Kritikům vadí, že na tyto byty dosáhli lidé zaměstnaní na městském úřadu.",
@@ -483,7 +485,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-582786-question-60",
+      "id": "komunalni-2022-582786-q-60",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -493,10 +495,11 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-582786-candidate-895801",
+      "id": "komunalni-2022-582786-c-895801",
       "name": "ČSSD VAŠI STAROSTOVÉ",
       "type": "party",
       "description": "ČSSD VAŠI STAROSTOVÉ - DESCRIPTION",
+      "img_url": "čssd-nk",
       "contacts": {
         "web": [
           {
@@ -512,7 +515,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-582786-895801-party",
+          "id": "komunalni-2022-582786-c-895801-p",
           "name": "ČSSD VAŠI STAROSTOVÉ",
           "description": "ČSSD VAŠI STAROSTOVÉ - DESCRIPTION",
           "contacts": {
@@ -533,10 +536,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-582786-candidate-380850",
+      "id": "komunalni-2022-582786-c-380850",
       "name": "Brno Brňankám a Brňanům! (B3!)",
       "type": "party",
       "description": "Brno Brňankám a Brňanům! (B3!) - DESCRIPTION",
+      "img_url": "levice-nk",
       "contacts": {
         "web": [
           {
@@ -553,7 +557,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-582786-380850-party",
+          "id": "komunalni-2022-582786-c-380850-p",
           "name": "Brno Brňankám a Brňanům! (B3!)",
           "description": "Brno Brňankám a Brňanům! (B3!) - DESCRIPTION",
           "contacts": {
@@ -575,17 +579,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-582786-candidate-395398",
+      "id": "komunalni-2022-582786-c-395398",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": [],
         "twitter": "https://twitter.com/MarekLahoda"
       },
       "parties": [
         {
-          "id": "komunalni-2022-582786-395398-party",
+          "id": "komunalni-2022-582786-c-395398-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -597,10 +602,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-582786-candidate-658413",
+      "id": "komunalni-2022-582786-c-658413",
       "name": "Zelení a Žít Brno s podporou Idealistů",
       "type": "party",
       "description": "Zelení a Žít Brno s podporou Idealistů - DESCRIPTION",
+      "img_url": "zelen-žtb-ideal",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/idealistehnuti",
@@ -608,7 +614,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-582786-658413-party",
+          "id": "komunalni-2022-582786-c-658413-p",
           "name": "Zelení a Žít Brno s podporou Idealistů",
           "description": "Zelení a Žít Brno s podporou Idealistů - DESCRIPTION",
           "contacts": {
@@ -621,10 +627,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-582786-candidate-968366",
+      "id": "komunalni-2022-582786-c-968366",
       "name": "Lidovci a Starostové (KDU-ČSL + Starostové a nezávislí)",
       "type": "party",
       "description": "Lidovci a Starostové (KDU-ČSL + Starostové a nezávislí) - DESCRIPTION",
+      "img_url": "kdu-čsl-stan",
       "contacts": {
         "web": [
           {
@@ -635,7 +642,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-582786-968366-party",
+          "id": "komunalni-2022-582786-c-968366-p",
           "name": "Lidovci a Starostové (KDU-ČSL + Starostové a nezávislí)",
           "description": "Lidovci a Starostové (KDU-ČSL + Starostové a nezávislí) - DESCRIPTION",
           "contacts": {
@@ -651,10 +658,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-582786-candidate-778616",
+      "id": "komunalni-2022-582786-c-778616",
       "name": "Brno Plus a Svobodní",
       "type": "party",
       "description": "Brno Plus a Svobodní - DESCRIPTION",
+      "img_url": "svobodní-brno-",
       "contacts": {
         "web": [
           {
@@ -672,7 +680,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-582786-778616-party",
+          "id": "komunalni-2022-582786-c-778616-p",
           "name": "Brno Plus a Svobodní",
           "description": "Brno Plus a Svobodní - DESCRIPTION",
           "contacts": {
@@ -695,16 +703,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-582786-candidate-197622",
+      "id": "komunalni-2022-582786-c-197622",
       "name": "SPD, TRIKOLORA, MORAVANÉ a nezávislí",
       "type": "party",
       "description": "SPD, TRIKOLORA, MORAVANÉ a nezávislí - DESCRIPTION",
+      "img_url": "mor-spd-trik-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-582786-197622-party",
+          "id": "komunalni-2022-582786-c-197622-p",
           "name": "SPD, TRIKOLORA, MORAVANÉ a nezávislí",
           "description": "SPD, TRIKOLORA, MORAVANÉ a nezávislí - DESCRIPTION",
           "contacts": {
@@ -715,10 +724,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-582786-candidate-475575",
+      "id": "komunalni-2022-582786-c-475575",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": [
           {
@@ -733,7 +743,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-582786-475575-party",
+          "id": "komunalni-2022-582786-c-475575-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -753,10 +763,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-582786-candidate-119941",
+      "id": "komunalni-2022-582786-c-119941",
       "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
       "type": "party",
       "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
+      "img_url": "přísaha",
       "contacts": {
         "web": [
           {
@@ -771,7 +782,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-582786-119941-party",
+          "id": "komunalni-2022-582786-c-119941-p",
           "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
           "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
           "contacts": {
@@ -791,16 +802,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-582786-candidate-467949",
+      "id": "komunalni-2022-582786-c-467949",
       "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT – sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
       "type": "party",
       "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT – sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+      "img_url": "dsz-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-582786-467949-party",
+          "id": "komunalni-2022-582786-c-467949-p",
           "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT – sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
           "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT – sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
           "contacts": {
@@ -811,10 +823,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-582786-candidate-524545",
+      "id": "komunalni-2022-582786-c-524545",
       "name": "SPOLEČNĚ - ODS a TOP 09",
       "type": "party",
       "description": "SPOLEČNĚ - ODS a TOP 09 - DESCRIPTION",
+      "img_url": "ods-top 09",
       "contacts": {
         "web": [
           {
@@ -829,7 +842,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-582786-524545-party",
+          "id": "komunalni-2022-582786-c-524545-p",
           "name": "SPOLEČNĚ - ODS a TOP 09",
           "description": "SPOLEČNĚ - ODS a TOP 09 - DESCRIPTION",
           "contacts": {
@@ -849,17 +862,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-582786-candidate-726436",
+      "id": "komunalni-2022-582786-c-726436",
       "name": "RESTART PRO BRNO",
       "type": "party",
       "description": "RESTART PRO BRNO - DESCRIPTION",
+      "img_url": "ksčmspozsuvdom",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/Restart-pro-Brno-103632592357718/"
       },
       "parties": [
         {
-          "id": "komunalni-2022-582786-726436-party",
+          "id": "komunalni-2022-582786-c-726436-p",
           "name": "RESTART PRO BRNO",
           "description": "RESTART PRO BRNO - DESCRIPTION",
           "contacts": {
@@ -871,16 +885,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-582786-candidate-625869",
+      "id": "komunalni-2022-582786-c-625869",
       "name": "JSI PRO? Jistota Solidarita Investice pro budoucnost",
       "type": "party",
       "description": "JSI PRO? Jistota Solidarita Investice pro budoucnost - DESCRIPTION",
+      "img_url": "jsi pro?",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-582786-625869-party",
+          "id": "komunalni-2022-582786-c-625869-p",
           "name": "JSI PRO? Jistota Solidarita Investice pro budoucnost",
           "description": "JSI PRO? Jistota Solidarita Investice pro budoucnost - DESCRIPTION",
           "contacts": {
@@ -891,10 +906,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-582786-candidate-919557",
+      "id": "komunalni-2022-582786-c-919557",
       "name": "Fakt Brno",
       "type": "party",
       "description": "Fakt Brno - DESCRIPTION",
+      "img_url": "fakt brno",
       "contacts": {
         "web": [
           {
@@ -912,7 +928,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-582786-919557-party",
+          "id": "komunalni-2022-582786-c-919557-p",
           "name": "Fakt Brno",
           "description": "Fakt Brno - DESCRIPTION",
           "contacts": {
@@ -937,790 +953,1544 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-582786-answer-895801-1",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-1",
+      "id": "komunalni-2022-582786-a-4",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-1",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-2",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-2",
+      "id": "komunalni-2022-582786-a-7",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-2",
       "answer": "yes",
       "comment": "Vyjma seniorů a dětí. ČSSD v Brně prosadila zrušení poplatku pro seniory od 70 let a děti do 3 let věku. "
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-3",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-3",
+      "id": "komunalni-2022-582786-a-10",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-4",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-4",
+      "id": "komunalni-2022-582786-a-13",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-5",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-5",
+      "id": "komunalni-2022-582786-a-16",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-6",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-6",
+      "id": "komunalni-2022-582786-a-19",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-6",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-7",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-7",
+      "id": "komunalni-2022-582786-a-22",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-8",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-8",
+      "id": "komunalni-2022-582786-a-25",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-9",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-9",
+      "id": "komunalni-2022-582786-a-28",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-10",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-10",
+      "id": "komunalni-2022-582786-a-31",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-10",
       "answer": "yes",
       "comment": "v Brně tomu tak je"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-11",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-11",
+      "id": "komunalni-2022-582786-a-34",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-11",
       "answer": "yes",
       "comment": "v Brně tomu tak je "
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-12",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-12",
+      "id": "komunalni-2022-582786-a-37",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-13",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-13",
+      "id": "komunalni-2022-582786-a-40",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-14",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-14",
+      "id": "komunalni-2022-582786-a-43",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-15",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-15",
+      "id": "komunalni-2022-582786-a-46",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-15",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-16",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-16",
+      "id": "komunalni-2022-582786-a-49",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-16",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-17",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-17",
+      "id": "komunalni-2022-582786-a-52",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-18",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-18",
+      "id": "komunalni-2022-582786-a-55",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-19",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-19",
+      "id": "komunalni-2022-582786-a-58",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-19",
       "answer": "yes",
       "comment": "v Brně tomu tak je "
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-20",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-20",
+      "id": "komunalni-2022-582786-a-61",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-21",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-21",
+      "id": "komunalni-2022-582786-a-64",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-21",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-22",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-22",
+      "id": "komunalni-2022-582786-a-67",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-23",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-23",
+      "id": "komunalni-2022-582786-a-70",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-23",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-24",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-24",
+      "id": "komunalni-2022-582786-a-73",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-25",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-25",
+      "id": "komunalni-2022-582786-a-76",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-26",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-26",
+      "id": "komunalni-2022-582786-a-79",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-26",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-27",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-27",
+      "id": "komunalni-2022-582786-a-82",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-27",
       "answer": "yes",
       "comment": "v Brně se tak děje "
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-28",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-28",
+      "id": "komunalni-2022-582786-a-85",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-28",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-29",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-29",
+      "id": "komunalni-2022-582786-a-88",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-30",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-30",
+      "id": "komunalni-2022-582786-a-91",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-30",
       "answer": "no",
       "comment": "v Brně jsou příspěvky developerů nastaveny akorát "
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-31",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-31",
+      "id": "komunalni-2022-582786-a-94",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-32",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-32",
+      "id": "komunalni-2022-582786-a-97",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-32",
       "answer": "yes",
       "comment": "v Brně se to děje "
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-33",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-33",
+      "id": "komunalni-2022-582786-a-100",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-34",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-34",
+      "id": "komunalni-2022-582786-a-103",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-35",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-35",
+      "id": "komunalni-2022-582786-a-106",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-36",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-36",
+      "id": "komunalni-2022-582786-a-109",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-36",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-37",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-37"
+      "id": "komunalni-2022-582786-a-112",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-37"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-38",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-38",
+      "id": "komunalni-2022-582786-a-115",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-38",
       "answer": "yes",
       "comment": "v Brně se tak děje "
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-39",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-39",
+      "id": "komunalni-2022-582786-a-118",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-40",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-40",
+      "id": "komunalni-2022-582786-a-121",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-41",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-41",
+      "id": "komunalni-2022-582786-a-124",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-42",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-42",
+      "id": "komunalni-2022-582786-a-127",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-43",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-43",
+      "id": "komunalni-2022-582786-a-130",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-44",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-44",
+      "id": "komunalni-2022-582786-a-133",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-44",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-45",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-45",
+      "id": "komunalni-2022-582786-a-136",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-45",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-46",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-46",
+      "id": "komunalni-2022-582786-a-139",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-47",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-47",
+      "id": "komunalni-2022-582786-a-142",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-47",
       "answer": "yes",
       "comment": "v Brně se tak děje "
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-48",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-48",
+      "id": "komunalni-2022-582786-a-145",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-48",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-49",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-49",
+      "id": "komunalni-2022-582786-a-148",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-50",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-50",
+      "id": "komunalni-2022-582786-a-151",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-50",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-51",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-51",
+      "id": "komunalni-2022-582786-a-154",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-51",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-52",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-52",
+      "id": "komunalni-2022-582786-a-157",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-52",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-53",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-53"
+      "id": "komunalni-2022-582786-a-160",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-53"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-54",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-54",
+      "id": "komunalni-2022-582786-a-163",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-54",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-55",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-55",
+      "id": "komunalni-2022-582786-a-166",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-55",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-56",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-56",
+      "id": "komunalni-2022-582786-a-169",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-56",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-57",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-57",
+      "id": "komunalni-2022-582786-a-172",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-57",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-58",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-58",
+      "id": "komunalni-2022-582786-a-175",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-58",
       "comment": "To záleží na podmínkách, za ty peníze co požadovala DORNA je to nepřijatelné. "
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-59",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-59",
+      "id": "komunalni-2022-582786-a-178",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-59",
       "answer": "no",
       "comment": "to by bylo diskriminační, nicméně nevím o žádných zaměstnancích MMB, kteří by se přihlásili do startovacích bytů "
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-60",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-60",
+      "id": "komunalni-2022-582786-a-181",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-60",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-895801-61",
-      "candidate_id": "komunalni-2022-582786-candidate-895801",
-      "question_id": "komunalni-2022-582786-question-61"
+      "id": "komunalni-2022-582786-a-184",
+      "candidate_id": "komunalni-2022-582786-c-895801",
+      "question_id": "komunalni-2022-582786-q-61"
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-1",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-1",
+      "id": "komunalni-2022-582786-a-4",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-2",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-2",
+      "id": "komunalni-2022-582786-a-7",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-3",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-3",
+      "id": "komunalni-2022-582786-a-10",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-3",
       "answer": "no",
       "comment": "V žádném případě. Jde o nejohroženější skupinu občanů."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-4",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-4",
+      "id": "komunalni-2022-582786-a-13",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-4",
       "answer": "yes",
       "comment": "Tam, kde to dává smysl (např. školy, školky, okolí hřišť, místa s velkým počtem dopravních nehod)."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-5",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-5",
+      "id": "komunalni-2022-582786-a-16",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-5",
       "answer": "yes",
       "comment": "Město Brno obeslalo všechny dlužníky informačním dopisem."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-6",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-6",
+      "id": "komunalni-2022-582786-a-19",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-6",
       "answer": "yes",
       "comment": "Po konzultaci s městskými částmi."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-7",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-7",
+      "id": "komunalni-2022-582786-a-22",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-7",
       "answer": "no",
       "comment": "Tzv. živá hra (casina, ruleta, poker) by mohla být zachována, ale hrací automaty vnímáme jako hrozbu."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-8",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-8",
+      "id": "komunalni-2022-582786-a-25",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-9",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-9",
+      "id": "komunalni-2022-582786-a-28",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-9",
       "answer": "yes",
       "comment": "Důležité pro všechny handikepované."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-10",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-10",
+      "id": "komunalni-2022-582786-a-31",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-11",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-11",
+      "id": "komunalni-2022-582786-a-34",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-11",
       "answer": "yes",
       "comment": "Hlasování je již jmenovitě zveřejňováno."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-12",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-12",
+      "id": "komunalni-2022-582786-a-37",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-12",
       "comment": "Např. IGNIS BRUNENSIS bychom rádi zachovali."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-13",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-13",
+      "id": "komunalni-2022-582786-a-40",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-13",
       "answer": "yes",
       "comment": "Bude-li situace natolik závažná."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-14",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-14",
+      "id": "komunalni-2022-582786-a-43",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-14",
       "answer": "yes",
       "comment": "Bude záležet na konkrétních podmínkách, dostatku a ceně elektrické energie."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-15",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-15",
+      "id": "komunalni-2022-582786-a-46",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-15",
       "answer": "no",
       "comment": "Omezení pouze za předpokladu neúnosné situace."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-16",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-16",
+      "id": "komunalni-2022-582786-a-49",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-16",
       "answer": "yes",
       "comment": "Bude nezbytné šetřit energiemi."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-17",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-17",
+      "id": "komunalni-2022-582786-a-52",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-17",
       "answer": "yes",
       "comment": "Děti nemohou trpět za svoje rodiče."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-18",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-18",
+      "id": "komunalni-2022-582786-a-55",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-19",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-19",
+      "id": "komunalni-2022-582786-a-58",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-19",
       "answer": "yes",
       "comment": "Už se tak děje prostřednictvím participativního rozpočtu."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-20",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-20",
+      "id": "komunalni-2022-582786-a-61",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-20",
       "answer": "yes",
       "comment": "Obecních bytů je nedostatek. Primárně by měly být dostupné pro mladé rodiny, samoživitele, seniory a sociálně slabé občany."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-21",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-21",
+      "id": "komunalni-2022-582786-a-64",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-21",
       "answer": "yes",
       "comment": "Pokud to bude nezbytné."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-22",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-22",
+      "id": "komunalni-2022-582786-a-67",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-22",
       "answer": "no",
       "comment": "Je ale třeba pomáhat sociálně slabým rodinám."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-23",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-23",
+      "id": "komunalni-2022-582786-a-70",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-23",
       "answer": "yes",
       "comment": "Záleží na formě podpory. Je to jistě jedna z možných cest jak snížit počet aut ve městě Brně."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-24",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-24",
+      "id": "komunalni-2022-582786-a-73",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-24",
       "answer": "no",
       "comment": "Modré zóny se ukázaly jako dobrý koncept, se kterým jsme přišli už před osmi lety. Vždy je nutná koordinace s městskými částmi."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-25",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-25",
+      "id": "komunalni-2022-582786-a-76",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-25",
       "answer": "no",
       "comment": "Koncept modrých zón by tím ztratil smysl. Primárně by měl mít rezident možnost zaparkovat co nejblíž bydlišti. "
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-26",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-26",
+      "id": "komunalni-2022-582786-a-79",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-26",
       "answer": "yes",
       "comment": "Především tam, kde už jsou v domě některé byty prodané (tzn. doprodat)."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-27",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-27",
+      "id": "komunalni-2022-582786-a-82",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-27",
       "answer": "yes",
       "comment": "Zavedli jsme příspěvek pro developery sloužící na pokrytí části nákladů při výstavbě školek a infrastruktury."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-28",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-28",
+      "id": "komunalni-2022-582786-a-85",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-28",
       "comment": "Preferujeme městskou hromadnou dopravu, ale všechny druhy dopravy jsou důležité."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-29",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-29",
+      "id": "komunalni-2022-582786-a-88",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-29",
       "answer": "no",
       "comment": "Není jednoduché zjistit důvod neobsazenosti bytu a definovat dlouhodobě."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-30",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-30",
+      "id": "komunalni-2022-582786-a-91",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-30",
       "answer": "no",
       "comment": "Vždy jde o dohodu s developery a přílišné zvýšení se odrazí v ceně bytů."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-31",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-31",
+      "id": "komunalni-2022-582786-a-94",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-31",
       "answer": "yes",
       "comment": "Ve spolupráci s Teplárnami Brno a.s. jsme ve městě Brně již vybudovali 35 dobíjecích stanic, do konce roku jich bude vybudováno 50."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-32",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-32",
+      "id": "komunalni-2022-582786-a-97",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-32",
       "answer": "yes",
       "comment": "Družstevní bydlení je forma bydlení, kterou podporujeme a která se zavádí."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-33",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-33",
+      "id": "komunalni-2022-582786-a-100",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-33",
       "answer": "no",
       "comment": "Je ale třeba pomáhat sociálně slabým rodinám."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-34",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-34",
+      "id": "komunalni-2022-582786-a-103",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-34",
       "answer": "yes",
       "comment": "Určitě minimálně v rámci poradenství. Teplárny Brno a.s. plánují rozšířit poradenskou činnost i na tento segment, kdy již nyní funguje poradenská činnost v rámci energií."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-35",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-35",
+      "id": "komunalni-2022-582786-a-106",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-35",
       "answer": "no",
       "comment": "Opět sociální aspekt. Rádi bychom ovšem otevřeli hřiště u základních škol bezplatně i mimo vyučovací dobu. "
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-36",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-36",
+      "id": "komunalni-2022-582786-a-109",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-37",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-37",
+      "id": "komunalni-2022-582786-a-112",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-37",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-38",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-38",
+      "id": "komunalni-2022-582786-a-115",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-38",
       "answer": "yes",
       "comment": "Ano a už se tak děje."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-39",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-39",
+      "id": "komunalni-2022-582786-a-118",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-39",
       "answer": "yes",
       "comment": "Ano, ale za jasně nastavených podmínek (důraz na bezpečnost a vyznačení míst)."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-40",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-40",
+      "id": "komunalni-2022-582786-a-121",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-40",
       "answer": "yes",
       "comment": "Těch, kteří se mají zájem začlenit a dodržují pravidla a zákony ČR."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-41",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-41",
+      "id": "komunalni-2022-582786-a-124",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-41",
       "answer": "yes",
       "comment": "Intenzivně dlouhodobě podporujeme nábor strážníků Městské policie Brno."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-42",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-42",
+      "id": "komunalni-2022-582786-a-127",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-42",
       "answer": "yes",
       "comment": "Děláme a podporujeme."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-43",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-43",
+      "id": "komunalni-2022-582786-a-130",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-43",
       "answer": "yes",
       "comment": "Zapojujeme se do akcí typu \"Do práce na kole\"."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-44",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-44",
+      "id": "komunalni-2022-582786-a-133",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-44",
       "answer": "yes",
       "comment": "Postupně navyšujeme dotace do vrcholového i mládežnického sportu. "
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-45",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-45",
+      "id": "komunalni-2022-582786-a-136",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-45",
       "answer": "no",
       "comment": "Neměla by se navyšovat."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-46",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-46",
+      "id": "komunalni-2022-582786-a-139",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-46",
       "answer": "yes",
       "comment": "Děláme a podporujeme."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-47",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-47",
+      "id": "komunalni-2022-582786-a-142",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-48",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-48",
+      "id": "komunalni-2022-582786-a-145",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-48",
       "answer": "yes",
       "comment": "Segregace dětí je špatně."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-49",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-49",
+      "id": "komunalni-2022-582786-a-148",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-49",
       "answer": "yes",
       "comment": "Projekt Housing First nebyl ukončen, jen byla upraveny kritéria pro výběr nájemníků."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-50",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-50",
+      "id": "komunalni-2022-582786-a-151",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-50",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-51",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-51",
+      "id": "komunalni-2022-582786-a-154",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-51",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-52",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-52",
+      "id": "komunalni-2022-582786-a-157",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-52",
       "answer": "yes",
       "comment": "Brno si multifukční halu zaslouží."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-53",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-53",
+      "id": "komunalni-2022-582786-a-160",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-53",
       "answer": "no",
       "comment": "Není to technicky možné. Obnovení přechodu bylo mnohokrát prověřováno - nesouhlas Policie České republiky."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-54",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-54",
+      "id": "komunalni-2022-582786-a-163",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-54",
       "answer": "yes",
       "comment": "Po zapracování připomínek. Územní plán musí být bez chyb."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-55",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-55",
+      "id": "komunalni-2022-582786-a-166",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-55",
       "answer": "no",
       "comment": "Je potřeba město krátkodobých vzdáleností."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-56",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-56",
+      "id": "komunalni-2022-582786-a-169",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-56",
       "answer": "yes",
       "comment": "Jednání již probíhají. Je nutné snížit závislost na ruském plynu."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-57",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-57",
+      "id": "komunalni-2022-582786-a-172",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-57",
       "answer": "yes",
       "comment": "Pilotní zavedení se jeví jako dobrý krok. Je ovšem nezbytné zachovat komfort občanů žijících na náměstí Svobody."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-58",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-58",
+      "id": "komunalni-2022-582786-a-175",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-58",
       "comment": "Bez spoluúčasti státu to není v možnostech rozpočtu města Brna. "
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-59",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-59",
+      "id": "komunalni-2022-582786-a-178",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-59",
       "answer": "no",
       "comment": "Není možná diskriminace. Výběr probíhá transparentním veřejným losováním."
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-60",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-60",
+      "id": "komunalni-2022-582786-a-181",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-60",
       "answer": "yes",
       "comment": "Rozšíří se možnosti pro pracující rodiče. "
     },
     {
-      "id": "komunalni-2022-582786-answer-524545-61",
-      "candidate_id": "komunalni-2022-582786-candidate-524545",
-      "question_id": "komunalni-2022-582786-question-61",
+      "id": "komunalni-2022-582786-a-184",
+      "candidate_id": "komunalni-2022-582786-c-524545",
+      "question_id": "komunalni-2022-582786-q-61",
       "comment": "Děkujeme za zaslání dotazníku."
+    },
+    {
+      "id": "komunalni-2022-582786-a-4",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-7",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-10",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-13",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-16",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-19",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-22",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-25",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-28",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-31",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-34",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-37",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-40",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-43",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-46",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-49",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-52",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-55",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-58",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-61",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-64",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-67",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-70",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-73",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-76",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-25",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-79",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-82",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-85",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-88",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-91",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-94",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-97",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-100",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-103",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-34"
+    },
+    {
+      "id": "komunalni-2022-582786-a-106",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-109",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-112",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-115",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-118",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-39",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-121",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-124",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-127",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-130",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-133",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-136",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-139",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-46",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-142",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-145",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-148",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-151",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-154",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-157",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-52",
+      "answer": "yes",
+      "comment": "Bez předem domluveného provozovatele tento strategický projekt města Brna nemůže být realizován!"
+    },
+    {
+      "id": "komunalni-2022-582786-a-160",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-163",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-166",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-169",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-172",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-57",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-175",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-178",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-59",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-181",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-60",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-184",
+      "candidate_id": "komunalni-2022-582786-c-197622",
+      "question_id": "komunalni-2022-582786-q-61"
+    },
+    {
+      "id": "komunalni-2022-582786-a-4",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-1",
+      "answer": "no",
+      "comment": "Gentrifikace je pohroma pro město, vylidňuje ho a vytváří rozsáhlé sociální problémy. Město patří všem!"
+    },
+    {
+      "id": "komunalni-2022-582786-a-7",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-10",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-3",
+      "answer": "no",
+      "comment": "Město by mělo v případě omezit vytápění bank, korporací a supermarketů."
+    },
+    {
+      "id": "komunalni-2022-582786-a-13",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-4",
+      "answer": "yes",
+      "comment": "V Brně se stejně rychleji než 20 km/h v centru jet nedá. Ale potřebujeme chránit chodce."
+    },
+    {
+      "id": "komunalni-2022-582786-a-16",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-5",
+      "answer": "yes",
+      "comment": "Ano, nicméně Brno ovládá exekutorská mafie, musíme se jich nejprve zbavit."
+    },
+    {
+      "id": "komunalni-2022-582786-a-19",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-6",
+      "answer": "no",
+      "comment": "Prevence a kvalitní speciální práce je klíčová pro snižování kriminality, ne fízlování."
+    },
+    {
+      "id": "komunalni-2022-582786-a-22",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-7",
+      "answer": "yes",
+      "comment": "Naprosto a nekompromisně."
+    },
+    {
+      "id": "komunalni-2022-582786-a-25",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-8",
+      "answer": "yes",
+      "comment": "Musíme okamžitě snížit množství aut v centru, Brno má otřesný vzduch a odnášejí to plíce těch nejzranitelnějších - seniorů a dětí."
+    },
+    {
+      "id": "komunalni-2022-582786-a-28",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-9",
+      "answer": "yes",
+      "comment": "Když se chce, skoro vždy se dají udělat bezbariérově. "
+    },
+    {
+      "id": "komunalni-2022-582786-a-31",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-34",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-37",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-12",
+      "answer": "yes",
+      "comment": "Jako pejskař jsem velmi proti a jako milovníka přírody mě vyloženě vytáčí kolik to pozabíjí ptáků. Jako někdo, kdo bydlí po Špilasem upřímně nenávidím ohňostroje, je to jakoby by vám vybuchovali bomby nad hlavou a třesou se vám okna. Je čas přejít na světelné dronové show, laserové efekty a promítání audiovizuálních kompozicí na architekturu. "
+    },
+    {
+      "id": "komunalni-2022-582786-a-40",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-13",
+      "answer": "yes",
+      "comment": "Pokud se město nedokáže postarat o nejslabších a nejzranitelnější, tak naše demokracie selhala. "
+    },
+    {
+      "id": "komunalni-2022-582786-a-43",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-46",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-49",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-16",
+      "answer": "no",
+      "comment": "Nevím, jak artritida úředníků čemukoliv pomůže. Naopak úředníci města potřebují větší wellfare."
+    },
+    {
+      "id": "komunalni-2022-582786-a-52",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-17",
+      "answer": "yes",
+      "comment": "Toto je naprostá zrůdnost a hyenismus. Děti nemají mít exekuce, nežijeme v otroctví."
+    },
+    {
+      "id": "komunalni-2022-582786-a-55",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-18",
+      "answer": "yes",
+      "comment": "Transparentnost by konečně mohla snížit v Brně korupci a zbavit se stok a zrůd jako je Don Pablo."
+    },
+    {
+      "id": "komunalni-2022-582786-a-58",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-19",
+      "answer": "yes",
+      "comment": "Participace občanů je klíčová pro demokracii. V menší míře bych to umožnil i studujícím, ať již coby dospělý občané mají kompetence k participaci. "
+    },
+    {
+      "id": "komunalni-2022-582786-a-61",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-20",
+      "answer": "yes",
+      "comment": "Město je klíčový hráč v regulaci cena nájmů a bytů a toto by měla být priorita číslo jedna města!"
+    },
+    {
+      "id": "komunalni-2022-582786-a-64",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-21",
+      "answer": "yes",
+      "comment": "Nicméně pokud by Brno přešlo na zelenou energii, nebylo by to až to tak potřeba. "
+    },
+    {
+      "id": "komunalni-2022-582786-a-67",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-22",
+      "answer": "yes",
+      "comment": "Naprosto a bez výjimek a měla by jim být umožněno se stravovat podle svých diet, třeba pro alergiky bezlepkově. Současný systém spotřebních košů je au bizarně zastaralý a nezdravý. "
+    },
+    {
+      "id": "komunalni-2022-582786-a-70",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-23",
+      "answer": "yes",
+      "comment": "Musíme snížit množství aut v centru."
+    },
+    {
+      "id": "komunalni-2022-582786-a-73",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-76",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-79",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-26",
+      "answer": "no",
+      "comment": "Naopak, město by mělo vyvinout nástroje jak zabavit byty spekulantů."
+    },
+    {
+      "id": "komunalni-2022-582786-a-82",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-27",
+      "answer": "yes",
+      "comment": "Naprosto, proč by mělo město navyšovat zisk korporací?"
+    },
+    {
+      "id": "komunalni-2022-582786-a-85",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-88",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-29",
+      "answer": "yes",
+      "comment": "Dal bych klidně i daň 100%."
+    },
+    {
+      "id": "komunalni-2022-582786-a-91",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-94",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-97",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-32",
+      "answer": "yes",
+      "comment": "Družstva jsou klíčová pro budoucnost Brna."
+    },
+    {
+      "id": "komunalni-2022-582786-a-100",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-103",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-106",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-109",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-36",
+      "answer": "yes",
+      "comment": "Menstruační chudoba je zlo. "
+    },
+    {
+      "id": "komunalni-2022-582786-a-112",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-115",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-118",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-121",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-40"
+    },
+    {
+      "id": "komunalni-2022-582786-a-124",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-41"
+    },
+    {
+      "id": "komunalni-2022-582786-a-127",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-130",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-133",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-136",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-45",
+      "answer": "no",
+      "comment": "Zvýšit!"
+    },
+    {
+      "id": "komunalni-2022-582786-a-139",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-142",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-145",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-148",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-151",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-154",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-157",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-582786-a-160",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-53",
+      "answer": "yes",
+      "comment": "Čekám na to jak na smilování Boží."
+    },
+    {
+      "id": "komunalni-2022-582786-a-163",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-166",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-169",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-172",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-57",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-175",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-178",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-59",
+      "answer": "yes",
+      "comment": "Hlavně radní z Fakt Brno "
+    },
+    {
+      "id": "komunalni-2022-582786-a-181",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-60",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-582786-a-184",
+      "candidate_id": "komunalni-2022-582786-c-380850",
+      "question_id": "komunalni-2022-582786-q-61"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/585068.json
+++ b/data/kalkulacka/komunalni-2022/585068.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-585068",
   "name": "Zlín",
-  "description": "Zlín - DESCRIPTION",
+  "description": "Zlín",
   "district_code": "585068",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-585068-question-1",
+      "id": "komunalni-2022-585068-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-2",
+      "id": "komunalni-2022-585068-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-3",
+      "id": "komunalni-2022-585068-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-4",
+      "id": "komunalni-2022-585068-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-5",
+      "id": "komunalni-2022-585068-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-6",
+      "id": "komunalni-2022-585068-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-7",
+      "id": "komunalni-2022-585068-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-8",
+      "id": "komunalni-2022-585068-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-9",
+      "id": "komunalni-2022-585068-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-10",
+      "id": "komunalni-2022-585068-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-11",
+      "id": "komunalni-2022-585068-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-12",
+      "id": "komunalni-2022-585068-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-13",
+      "id": "komunalni-2022-585068-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-14",
+      "id": "komunalni-2022-585068-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-15",
+      "id": "komunalni-2022-585068-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-16",
+      "id": "komunalni-2022-585068-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-17",
+      "id": "komunalni-2022-585068-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-18",
+      "id": "komunalni-2022-585068-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-19",
+      "id": "komunalni-2022-585068-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-20",
+      "id": "komunalni-2022-585068-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-21",
+      "id": "komunalni-2022-585068-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-22",
+      "id": "komunalni-2022-585068-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-23",
+      "id": "komunalni-2022-585068-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-24",
+      "id": "komunalni-2022-585068-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-25",
+      "id": "komunalni-2022-585068-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-26",
+      "id": "komunalni-2022-585068-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-27",
+      "id": "komunalni-2022-585068-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-28",
+      "id": "komunalni-2022-585068-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-29",
+      "id": "komunalni-2022-585068-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-30",
+      "id": "komunalni-2022-585068-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-31",
+      "id": "komunalni-2022-585068-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-32",
+      "id": "komunalni-2022-585068-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-33",
+      "id": "komunalni-2022-585068-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-34",
+      "id": "komunalni-2022-585068-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-35",
+      "id": "komunalni-2022-585068-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-36",
+      "id": "komunalni-2022-585068-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-37",
+      "id": "komunalni-2022-585068-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-38",
+      "id": "komunalni-2022-585068-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-39",
+      "id": "komunalni-2022-585068-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-40",
+      "id": "komunalni-2022-585068-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-41",
+      "id": "komunalni-2022-585068-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-42",
+      "id": "komunalni-2022-585068-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-43",
+      "id": "komunalni-2022-585068-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-44",
+      "id": "komunalni-2022-585068-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-45",
+      "id": "komunalni-2022-585068-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-46",
+      "id": "komunalni-2022-585068-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-47",
+      "id": "komunalni-2022-585068-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-585068-question-48",
+      "id": "komunalni-2022-585068-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,10 +399,11 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-585068-candidate-759713",
+      "id": "komunalni-2022-585068-c-759713",
       "name": "Občanská demokratická strana",
       "type": "party",
       "description": "Občanská demokratická strana - DESCRIPTION",
+      "img_url": "ods",
       "contacts": {
         "web": [],
         "facebook": "https://facebook.com/golan.tomas",
@@ -409,7 +412,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-585068-759713-party",
+          "id": "komunalni-2022-585068-c-759713-p",
           "name": "Občanská demokratická strana",
           "description": "Občanská demokratická strana - DESCRIPTION",
           "contacts": {
@@ -423,10 +426,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-585068-candidate-880254",
+      "id": "komunalni-2022-585068-c-880254",
       "name": "ROZHÝBEJME ZLÍN",
       "type": "party",
       "description": "ROZHÝBEJME ZLÍN - DESCRIPTION",
+      "img_url": "trikolora-nk",
       "contacts": {
         "web": [
           {
@@ -443,7 +447,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-585068-880254-party",
+          "id": "komunalni-2022-585068-c-880254-p",
           "name": "ROZHÝBEJME ZLÍN",
           "description": "ROZHÝBEJME ZLÍN - DESCRIPTION",
           "contacts": {
@@ -465,16 +469,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-585068-candidate-121027",
+      "id": "komunalni-2022-585068-c-121027",
       "name": "Zlín sobě",
       "type": "party",
       "description": "Zlín sobě - DESCRIPTION",
+      "img_url": "čssd-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-585068-121027-party",
+          "id": "komunalni-2022-585068-c-121027-p",
           "name": "Zlín sobě",
           "description": "Zlín sobě - DESCRIPTION",
           "contacts": {
@@ -485,16 +490,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-585068-candidate-602014",
+      "id": "komunalni-2022-585068-c-602014",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-585068-602014-party",
+          "id": "komunalni-2022-585068-c-602014-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -505,10 +511,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-585068-candidate-171901",
+      "id": "komunalni-2022-585068-c-171901",
       "name": "Zlín 21",
       "type": "party",
       "description": "Zlín 21 - DESCRIPTION",
+      "img_url": "z21",
       "contacts": {
         "web": [
           {
@@ -522,7 +529,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-585068-171901-party",
+          "id": "komunalni-2022-585068-c-171901-p",
           "name": "Zlín 21",
           "description": "Zlín 21 - DESCRIPTION",
           "contacts": {
@@ -541,16 +548,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-585068-candidate-919562",
+      "id": "komunalni-2022-585068-c-919562",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
       "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "img_url": "stan",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-585068-919562-party",
+          "id": "komunalni-2022-585068-c-919562-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
           "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
           "contacts": {
@@ -561,16 +569,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-585068-candidate-348037",
+      "id": "komunalni-2022-585068-c-348037",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-585068-348037-party",
+          "id": "komunalni-2022-585068-c-348037-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -581,16 +590,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-585068-candidate-456015",
+      "id": "komunalni-2022-585068-c-456015",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-585068-456015-party",
+          "id": "komunalni-2022-585068-c-456015-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -601,16 +611,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-585068-candidate-913309",
+      "id": "komunalni-2022-585068-c-913309",
       "name": "KDU-ČSL s podporou TOP 09 a nezávislých kandidátů",
       "type": "party",
       "description": "KDU-ČSL s podporou TOP 09 a nezávislých kandidátů - DESCRIPTION",
+      "img_url": "kdučsl-top09-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-585068-913309-party",
+          "id": "komunalni-2022-585068-c-913309-p",
           "name": "KDU-ČSL s podporou TOP 09 a nezávislých kandidátů",
           "description": "KDU-ČSL s podporou TOP 09 a nezávislých kandidátů - DESCRIPTION",
           "contacts": {
@@ -623,332 +634,332 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-585068-answer-602014-1",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-1",
+      "id": "komunalni-2022-585068-a-4",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-1",
       "answer": "no",
       "comment": "Není rozumné vytvářet jakákoliv ghetta, ani ghetta bohatých, to vede jen k rozdělení společnosti a to je základ k jakékoli nenávisti."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-2",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-2",
+      "id": "komunalni-2022-585068-a-7",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-2",
       "answer": "yes",
       "comment": "Poplatky musí být ovšem jen velmi nízké, přijatelné pro prakticky všechny sociální skupiny. Ovšem ne zase příliš nízké, aby motivovali občany k třídění odpadu. Nebránil bych se ani tomu, aby se za směsný odpad platilo a naopak za vytříděné druhotné suroviny poskytovala odměna. Kdy by řádně třídil, mohl by si poplatky za směsný odpad vykrýt vytříděným odpadem."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-3",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-3",
+      "id": "komunalni-2022-585068-a-10",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-3",
       "answer": "no",
       "comment": "Takové opatření již není šetřením ale panikou. Dovedu si to představit pouze v případě skutečné války na našem území nebo nějaké živelné katastrofy. Schopnost a ochota postarat se o staré a nemocné je obrazem vyspělosti civilizace."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-4",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-4",
+      "id": "komunalni-2022-585068-a-13",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-4",
       "comment": "Byla by nutná delší a hluboká diskuse s lidmi, kteří tomu opravdu rozumí a zhodnotit všechna pro a proti, ať už z hlediska bezpečnosti, plynulosti dopravy ekologie atd. Nicméně diskusi na toto téma vítám."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-5",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-5",
+      "id": "komunalni-2022-585068-a-16",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-5",
       "answer": "yes",
       "comment": "Bohužel část lidí, a většinou jsou to právě dlužníci města, se dostala mimo standardní společnost a je potřeba je malými, ale pravidelnými kroky přitáhnout zpět. Všem se to nakonec vyplatí."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-6",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-6",
+      "id": "komunalni-2022-585068-a-19",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-6",
       "answer": "no",
       "comment": "Z neustálého sledování nemám dobrý pocit.  To je postup spíše totalitních režimů a tam doufám pořád ještě nejsme."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-7",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-7",
+      "id": "komunalni-2022-585068-a-22",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-7",
       "answer": "yes",
       "comment": "Hazard je jako droga. Je to to samé se stejnými dopady. Současné rozdělení drog, včetně hazardu, na ty které jsou povoleny a které ne, již dle mého dávno neodpovídá skutečným dopadům, ale spíše schopnosti jejich provozovatelů, zajistit si politickou a tedy zákonnou podporu. Zkrátka peníze určují, co je možné a co už ne. Hazard je zlo."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-8",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-8",
+      "id": "komunalni-2022-585068-a-25",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-8",
       "answer": "no",
       "comment": "Pro mne osobně je toto klíčové téma, ovšem ukazuje se, že na dopravu zdarma naše společnost ještě dostatečně nevyspěla. Ceny jízdného a formy úhrady musí být ovšem nastaveny tak, aby využití MHD bylo pro všechny první a nejjednodušší volbou. S tím ovšem souvisí řada dalších věcí, jako je právě úroveň této dopravy, tedy její četnost, pohodlí, jednoduchost úhrady, rychlost přepravy a podobně a naopak nevýhody dopravy individuální, která musí být sice možná, ale měla by být oproti hromadné komplikovanější a dražší, tedy volena jen v nutném případě. Cena dopravy je tak jen kamínkem ve složité mozaice, kterou je potřeba poskládat celou."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-9",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-9",
+      "id": "komunalni-2022-585068-a-28",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-9",
       "answer": "yes",
       "comment": "Obdobně jako u bodu 3"
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-10",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-10",
+      "id": "komunalni-2022-585068-a-31",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-10",
       "comment": "U některých témat rozhodně, ovšem tam, kde by mohl nastoupit strach z veřejného projevu svého názoru, by bylo třeba zůstat u tajného hlasování. Možným řešením by bylo hlasování smíšené. Kdo chce, hlasuje veřejně a kdo nechce, hlasuje tajně a ať pak vysvětlí svým voličům, proč nechce, aby věděli oni nebo někdo jiný, jak hlasoval."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-11",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-11",
+      "id": "komunalni-2022-585068-a-34",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-11",
       "comment": "Stejně jako u 9."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-12",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-12",
+      "id": "komunalni-2022-585068-a-37",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-12",
       "answer": "yes",
       "comment": "Pro tyto účely by mohlo město vyčlenit prostory a podmínky, kde by tyto oslavy nerušily ostatní obyvatele, ať už lidské či zvířecí. "
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-13",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-13",
+      "id": "komunalni-2022-585068-a-40",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-13",
       "comment": "Pokud, tak by to měly být budovy vyhrazené právě pro tento účel. Neměly by to být budovy či prostory, které mají sloužit k jiné činnosti, například vyřizování různých dokumentů atd."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-14",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-14",
+      "id": "komunalni-2022-585068-a-43",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-14",
       "answer": "yes",
       "comment": "Dokud nenajdeme a nezavedeme ekologičtější zdroje energie a osvětlení s minimálními nároky. Řešením jsou například osvětlení využívající solární energii - přes den se nabíjí a v noci svítí."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-15",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-15",
+      "id": "komunalni-2022-585068-a-46",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-15",
       "answer": "no",
       "comment": "Otázka bezpečnosti je důležitější než energetické úspory, ovšem bylo by opět ideální využít co nejekologičtější formy, jako je solární energie."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-16",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-16",
+      "id": "komunalni-2022-585068-a-49",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-16",
       "comment": "Omezit je příliš nekonkrétní pojem. Mělo by se topit tak, aby se tam lidé mohli provozovat činnost, pro kterou je budova určena. Aby se nepřetápělo, kde to není nutné a naopak lidem, zejména pracujícím v budově, nebylo chladno."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-17",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-17",
+      "id": "komunalni-2022-585068-a-52",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-17",
       "comment": "Je to hodně individuální. V tomto směru je potřeba nechat rozhodnutí na konkrétních pracovnících, kteří daný případ dobře znají."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-18",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-18",
+      "id": "komunalni-2022-585068-a-55",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-18",
       "answer": "yes",
       "comment": "Ano, město by mělo umožnit přístup komukoliv do svého účetnictví. Úředníci města pouze hospodaří s penězi, které jim občané svěřili, jsou to tedy peníze daňových poplatníků a není důvod, aby jim bylo cokoliv tajeno."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-19",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-19",
+      "id": "komunalni-2022-585068-a-58",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-19",
       "answer": "yes",
       "comment": "Ano, část rozpočtu by měla být vyčleněna k rozhodování občanům, ovšem může to být jen taková část, a zejména na takové věci, které dokáže řadový občan posoudit a správně rozhodnout. Nelze k tomu přistoupit v neomezené míře."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-20",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-20",
+      "id": "komunalni-2022-585068-a-61",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-20",
       "answer": "yes",
       "comment": "Rozhodně. Rozprodání bytového fondu měst bylo katastrofální chybou, kterou budeme tak 100 až 200 let napravovat. Vlastnictví bytů městem, dává městu, a tedy všem jejím občanům, možnost zasahovat a regulovat cenu bydlení ve městě a tím i ovlivňovat kvalitu života obecně. "
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-21",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-21",
+      "id": "komunalni-2022-585068-a-64",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-21",
       "answer": "no",
       "comment": "V tomto případě nesouhlasím Psychologický dopad na občany by mohl být velmi negativní. Je potřeba občany uklidnit, dodat jim pohodu a důvěru. Když město o Vánocích pohasne, bude to, jako by řeklo, tak a je konec. Už nejsou peníze ani na Vánoce. "
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-22",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-22",
+      "id": "komunalni-2022-585068-a-67",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-22",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-23",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-23"
+      "id": "komunalni-2022-585068-a-70",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-23"
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-24",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-24",
+      "id": "komunalni-2022-585068-a-73",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-24",
       "answer": "no",
       "comment": "Parkování je velký problém související s celou koncepcí přepravy ve městě. Je prokázáno, že rozšiřování možnosti parkovat vede pouze ke krátkodobému odlehčení parkoviště, které se velmi brzy opět zaplní. Jakékoliv uvolnění možnosti parkovat povede pouze k větší koncentraci vozidel a tím snížení úrovně kvality života ve městě."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-25",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-25",
+      "id": "komunalni-2022-585068-a-76",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-25",
       "answer": "no",
       "comment": "Rozhodně ne. Přesně naopak. Město musí intenzivně realizovat vlastní výstavbu, aby dosáhlo cca 20 -25 % podílu na bytovém fondu ve městě. To se ukazuje, jako ideální model vlastnictví bytů ve městech."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-26",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-26",
+      "id": "komunalni-2022-585068-a-79",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-26",
       "answer": "yes",
       "comment": "Rozhodně. Naše město je především městem developerů. Jejich napojení na politickou garnituru je do nebe volající. Je potřeba, aby nesly veškeré náklady související s jejich činností."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-27",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-27",
+      "id": "komunalni-2022-585068-a-82",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-27",
       "answer": "yes",
       "comment": "To je jediná možná cesta. Doba automobilová je pryč. Naše město musíme odebrat automobilům a vrátit jej zpět lidem a zvířatům. Individuální automobilová doprava se ukázala ve větším měřítku jako nepoužitelná. Důsledky slepé výry v automobilismus vidíme dnes a denně a žádné nové silnice ani parkoviště to nezmění."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-28",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-28",
+      "id": "komunalni-2022-585068-a-85",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-28",
       "answer": "yes",
       "comment": "K bytům, stejně jako ke všem ostatním nemovitostem, je potřeba přistupovat jinak než k běžnému majetku. Jedná se o omezené statky, které jsou nezbytné pro život. Nesouhlasím ovšem s žádným znárodňováním, či jinou formou porušování daných pravidel. Majitele takovýchto bytů je třeba motivovat právě formou daní či naopak, v případě efektivního využívání bytů, formou podpory. Osobně bych šel tou cestou, že bych na všechny byty uvalil vysoké daně a u těch, které by byl řádně využívány, poskytl vysokou slevu, či odečty. Tím bychom nikoho netrestali za nevyužití bytu, ale naopak odměňovali za využití, což je vždy lepší cesta."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-29",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-29",
+      "id": "komunalni-2022-585068-a-88",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-29",
       "answer": "yes",
       "comment": "Viz odpověď v bodě 26."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-30",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-30",
+      "id": "komunalni-2022-585068-a-91",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-30",
       "comment": "Složitější téma. Obecně ano, ale je potřeba získat větší množství aktuálních informací od lidí, kteří se touto problematikou zabývají."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-31",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-31",
+      "id": "komunalni-2022-585068-a-94",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-31",
       "answer": "yes",
       "comment": "Ano. Toto je určitý mezistupeň, či doplněk, k tradiční komerční výstavbě a výstavbě městských bytů."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-32",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-32",
+      "id": "komunalni-2022-585068-a-97",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-32",
       "answer": "yes",
       "comment": "Děti jsou jednou ze skupin, pro kterou je potřeba MHD silně zvýhodnit a naučit je ji využívat. Současně tím podpoříme rodiny s dětmi, protože všichni říkáme, aby rodiny měli děti, protože bez nich není budoucnost. Ovšem nestačí to pouze říkat, ale je potřeba těmto rodinám také pomáhat."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-33",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-33",
+      "id": "komunalni-2022-585068-a-100",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-33",
       "answer": "yes",
       "comment": "Pomoci rozhodně. Otázkou je jak? V prvé řadě zejména jednoduchou administrativou, poradenstvím atd. a teprve po tom i finančně. "
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-34",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-34",
+      "id": "komunalni-2022-585068-a-103",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-34",
       "answer": "yes",
       "comment": "Je potřeba pracovat s mládeží, dokud to ještě jde, dokud si nevytvoří předsudky a zábrany či dokonce nenávist. Otevřít, zpřístupnit a vzdělávat všude, kde to jen jde. Nejvíce zla napáchá nevzdělanost, která se promění v obyčejnou lidskou blbost a to je větší problém pro lidstvo něž nějaký Covid."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-35",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-35",
+      "id": "komunalni-2022-585068-a-106",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-35",
       "answer": "yes",
       "comment": "Je to sice intimní téma, kterému se společnost vyhýbá, ale ženy si to nevybraly. Proč musí nést velkou část života tuto zátěž, nejen ve formě bolesti a nepříjemností, ale navíc ještě i finanční? Je ostuda společnosti, tedy zejména mužů, že nechají ženy trpět, místo aby jim pomáhali, kde to jen jde."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-36",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-36",
+      "id": "komunalni-2022-585068-a-109",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-36",
       "answer": "yes",
       "comment": "Viz otázka 35."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-37",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-37",
+      "id": "komunalni-2022-585068-a-112",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-38",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-38",
+      "id": "komunalni-2022-585068-a-115",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-38",
       "answer": "yes",
       "comment": "Jen je potřeba vše řádně legislativně upravit a zabránit nekontrolovatelnému povalování koloběžek po celém městě. Podporovat, ale současně přísně regulovat."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-39",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-39",
+      "id": "komunalni-2022-585068-a-118",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-39",
       "answer": "yes",
       "comment": "Pokud se u nás rozhodně nějaký cizinec žít, je potřeba, aby se z něj stal \"našinec\", jinak si koledujeme o vytváření různých ghett a následně problémů všeho druhu jako v zemích, kde tuto integraci nezvládli."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-40",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-40"
+      "id": "komunalni-2022-585068-a-121",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-40"
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-41",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-41",
+      "id": "komunalni-2022-585068-a-124",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-41",
       "answer": "yes",
       "comment": "Člověk potřebuje přírodu k životu a město musí být místem k životu a ten bez zeleně není možný."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-42",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-42",
+      "id": "komunalni-2022-585068-a-127",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-42",
       "answer": "yes",
       "comment": "Sám na kole nejezdím, ale jsem přesvědčený, že je to ideální dopravní prostředek v našem městě a je potřeba tuto formu dopravy maximálně podporovat."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-43",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-43",
+      "id": "komunalni-2022-585068-a-130",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-43",
       "answer": "no",
       "comment": "Profesionální sport se musí uživit sám, od toho je to sport profesionální."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-44",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-44",
+      "id": "komunalni-2022-585068-a-133",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-44",
       "answer": "no",
       "comment": "Viz má odpověď výše. Zastávám cestu vysokých daní z nemovitosti spojené s jednoduchým systémem slev a bonusů, za její řádné využívání. Pak by se navýšení daní z nemovitosti dotklo pouze těch, kteří svou nemovitost nevyužívají efektivně nebo dokonce vůbec."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-45",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-45",
+      "id": "komunalni-2022-585068-a-136",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-45",
       "answer": "yes",
       "comment": "Je lepší problémům předcházet, než je pak řešit."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-46",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-46",
+      "id": "komunalni-2022-585068-a-139",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-46",
       "answer": "yes",
       "comment": "Viz mé komentáře výše. Vlastní bytový fond v optimální výši se ukazuje jako nezbytný pro fungování bydlení ve městě. Občané musí mít možnost ovlivňovat život ve městě prostřednictvím radnice a ta prostřednictvím vlastnictví části bytů. Klíčová infrastruktura, jako jsou byty, pozemky, voda, energie a podobně musí být alespoň z části v rukou města, jinak se staneme stáváme závislými na libovůli několika málo jedinců, či společností, které nemají na životě v našem městě či naší zemi žádný zájem. Viz Veolia či dnešní problémy s Ruskem."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-47",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-47",
+      "id": "komunalni-2022-585068-a-142",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-47",
       "answer": "yes",
       "comment": "Naprosto nesmyslné. Být sociálně znevýhodněný není trest, který si má dítě odpykat, ale životní smůla, ze které je potřeba dětem pomoci. Musí zapadnout mezi ostatní a stát se již v dětství součástí běžné společnosti a s ní vyrůst v občana bez dalších sociálních problémů. Sdružování takovýchto dětí do oddělených tříd povede jen k jejich segregaci, k vytváření uzavřených skupin se svou nežádoucí kulturou a návyky. Jakékoliv rozdělování lidí je jen počátkem na jehož konci bývají spory, násilí a genocida."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-48",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-48",
+      "id": "komunalni-2022-585068-a-145",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-48",
       "answer": "yes",
       "comment": "Chceme aby rodiny měly děti? Chceme, aby našem město nevymíralo? Pak musíme rodinám s dětmi pomoct."
     },
     {
-      "id": "komunalni-2022-585068-answer-602014-49",
-      "candidate_id": "komunalni-2022-585068-candidate-602014",
-      "question_id": "komunalni-2022-585068-question-49",
+      "id": "komunalni-2022-585068-a-148",
+      "candidate_id": "komunalni-2022-585068-c-602014",
+      "question_id": "komunalni-2022-585068-q-49",
       "comment": "Je to docela dlouhé, ale chápu, že to musí mít nějakou vypovídající hodnotu, ale delší už bych to rozhodně nedělal."
     }
   ]

--- a/data/kalkulacka/komunalni-2022/586846.json
+++ b/data/kalkulacka/komunalni-2022/586846.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-586846",
   "name": "Jihlava",
-  "description": "Jihlava - DESCRIPTION",
+  "description": "Jihlava",
   "district_code": "586846",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-586846-question-1",
+      "id": "komunalni-2022-586846-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-2",
+      "id": "komunalni-2022-586846-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-3",
+      "id": "komunalni-2022-586846-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-4",
+      "id": "komunalni-2022-586846-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-5",
+      "id": "komunalni-2022-586846-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-6",
+      "id": "komunalni-2022-586846-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-7",
+      "id": "komunalni-2022-586846-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-8",
+      "id": "komunalni-2022-586846-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-9",
+      "id": "komunalni-2022-586846-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-10",
+      "id": "komunalni-2022-586846-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-11",
+      "id": "komunalni-2022-586846-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-12",
+      "id": "komunalni-2022-586846-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-13",
+      "id": "komunalni-2022-586846-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-14",
+      "id": "komunalni-2022-586846-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-15",
+      "id": "komunalni-2022-586846-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-16",
+      "id": "komunalni-2022-586846-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-17",
+      "id": "komunalni-2022-586846-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-18",
+      "id": "komunalni-2022-586846-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-19",
+      "id": "komunalni-2022-586846-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-20",
+      "id": "komunalni-2022-586846-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-21",
+      "id": "komunalni-2022-586846-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-22",
+      "id": "komunalni-2022-586846-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-23",
+      "id": "komunalni-2022-586846-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-24",
+      "id": "komunalni-2022-586846-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-25",
+      "id": "komunalni-2022-586846-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-26",
+      "id": "komunalni-2022-586846-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-27",
+      "id": "komunalni-2022-586846-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-28",
+      "id": "komunalni-2022-586846-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-29",
+      "id": "komunalni-2022-586846-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-30",
+      "id": "komunalni-2022-586846-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-31",
+      "id": "komunalni-2022-586846-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-32",
+      "id": "komunalni-2022-586846-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-33",
+      "id": "komunalni-2022-586846-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-34",
+      "id": "komunalni-2022-586846-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-35",
+      "id": "komunalni-2022-586846-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-36",
+      "id": "komunalni-2022-586846-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-37",
+      "id": "komunalni-2022-586846-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-38",
+      "id": "komunalni-2022-586846-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-39",
+      "id": "komunalni-2022-586846-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-40",
+      "id": "komunalni-2022-586846-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-41",
+      "id": "komunalni-2022-586846-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-42",
+      "id": "komunalni-2022-586846-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-43",
+      "id": "komunalni-2022-586846-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-44",
+      "id": "komunalni-2022-586846-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-45",
+      "id": "komunalni-2022-586846-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-46",
+      "id": "komunalni-2022-586846-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-47",
+      "id": "komunalni-2022-586846-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-48",
+      "id": "komunalni-2022-586846-q-48",
       "name": "Bydlení především",
       "title": "Podporuji, aby Jihlava pokračovala v projektu Housing First.",
       "gist": "Projekty Housing First zajišťují stabilní bydlení pro nejohroženější skupinu obyvatel. V Česku díky nim získalo bezpečný domov a podporu sociálních pracovníků více než 700 lidí, z toho 320 dětí. Do projektu se zapojují i další česká i světová města, např. ve Vídni si bydlení udrželo 98 % domácností. Pilotní Brno i přes úspěch i ocenění od projektu postupně ustoupilo. Vedení města argumentovalo vysokými náklady, zastánci projektu ale poukazovali, že je většina výdajů hrazená z fondů EU.",
@@ -395,7 +397,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-586846-question-49",
+      "id": "komunalni-2022-586846-q-49",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -405,16 +407,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-586846-candidate-379165",
+      "id": "komunalni-2022-586846-c-379165",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-586846-379165-party",
+          "id": "komunalni-2022-586846-c-379165-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -425,16 +428,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-586846-candidate-398619",
+      "id": "komunalni-2022-586846-c-398619",
       "name": "Malá strana velkých cílů",
       "type": "party",
       "description": "Malá strana velkých cílů - DESCRIPTION",
+      "img_url": "msvc",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-586846-398619-party",
+          "id": "komunalni-2022-586846-c-398619-p",
           "name": "Malá strana velkých cílů",
           "description": "Malá strana velkých cílů - DESCRIPTION",
           "contacts": {
@@ -445,16 +449,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-586846-candidate-555775",
+      "id": "komunalni-2022-586846-c-555775",
       "name": "ODS a KDU-ČSL",
       "type": "party",
       "description": "ODS a KDU-ČSL - DESCRIPTION",
+      "img_url": "kdu-čsl-ods",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-586846-555775-party",
+          "id": "komunalni-2022-586846-c-555775-p",
           "name": "ODS a KDU-ČSL",
           "description": "ODS a KDU-ČSL - DESCRIPTION",
           "contacts": {
@@ -465,10 +470,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-586846-candidate-783999",
+      "id": "komunalni-2022-586846-c-783999",
       "name": "Piráti a Fórum Jihlava",
       "type": "party",
       "description": "Piráti a Fórum Jihlava - DESCRIPTION",
+      "img_url": "piráti-nk",
       "contacts": {
         "web": [
           {
@@ -484,7 +490,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-586846-783999-party",
+          "id": "komunalni-2022-586846-c-783999-p",
           "name": "Piráti a Fórum Jihlava",
           "description": "Piráti a Fórum Jihlava - DESCRIPTION",
           "contacts": {
@@ -505,16 +511,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-586846-candidate-878763",
+      "id": "komunalni-2022-586846-c-878763",
       "name": "Jihlava srdcem",
       "type": "party",
       "description": "Jihlava srdcem - DESCRIPTION",
+      "img_url": "svobodní-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-586846-878763-party",
+          "id": "komunalni-2022-586846-c-878763-p",
           "name": "Jihlava srdcem",
           "description": "Jihlava srdcem - DESCRIPTION",
           "contacts": {
@@ -525,16 +532,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-586846-candidate-516439",
+      "id": "komunalni-2022-586846-c-516439",
       "name": "Svoboda a přímá demokracie (SPD) s podporou Trikolory",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) s podporou Trikolory - DESCRIPTION",
+      "img_url": "spd-trikolora",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-586846-516439-party",
+          "id": "komunalni-2022-586846-c-516439-p",
           "name": "Svoboda a přímá demokracie (SPD) s podporou Trikolory",
           "description": "Svoboda a přímá demokracie (SPD) s podporou Trikolory - DESCRIPTION",
           "contacts": {
@@ -545,16 +553,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-586846-candidate-900335",
+      "id": "komunalni-2022-586846-c-900335",
       "name": "SPOLEK ZA ZDRAVOU JIHLAVU",
       "type": "party",
       "description": "SPOLEK ZA ZDRAVOU JIHLAVU - DESCRIPTION",
+      "img_url": "szzj",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-586846-900335-party",
+          "id": "komunalni-2022-586846-c-900335-p",
           "name": "SPOLEK ZA ZDRAVOU JIHLAVU",
           "description": "SPOLEK ZA ZDRAVOU JIHLAVU - DESCRIPTION",
           "contacts": {
@@ -565,16 +574,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-586846-candidate-149398",
+      "id": "komunalni-2022-586846-c-149398",
       "name": "Žijeme Jihlavou",
       "type": "party",
       "description": "Žijeme Jihlavou - DESCRIPTION",
+      "img_url": "zelení-top09-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-586846-149398-party",
+          "id": "komunalni-2022-586846-c-149398-p",
           "name": "Žijeme Jihlavou",
           "description": "Žijeme Jihlavou - DESCRIPTION",
           "contacts": {
@@ -585,16 +595,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-586846-candidate-713735",
+      "id": "komunalni-2022-586846-c-713735",
       "name": "STAROSTOVÉ A NEZÁVISLÍ KANDIDÁTI",
       "type": "party",
       "description": "STAROSTOVÉ A NEZÁVISLÍ KANDIDÁTI - DESCRIPTION",
+      "img_url": "stan-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-586846-713735-party",
+          "id": "komunalni-2022-586846-c-713735-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ KANDIDÁTI",
           "description": "STAROSTOVÉ A NEZÁVISLÍ KANDIDÁTI - DESCRIPTION",
           "contacts": {
@@ -605,16 +616,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-586846-candidate-681882",
+      "id": "komunalni-2022-586846-c-681882",
       "name": "Moravské zemské hnutí",
       "type": "party",
       "description": "Moravské zemské hnutí - DESCRIPTION",
+      "img_url": "mzh",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-586846-681882-party",
+          "id": "komunalni-2022-586846-c-681882-p",
           "name": "Moravské zemské hnutí",
           "description": "Moravské zemské hnutí - DESCRIPTION",
           "contacts": {
@@ -625,16 +637,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-586846-candidate-519152",
+      "id": "komunalni-2022-586846-c-519152",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-586846-519152-party",
+          "id": "komunalni-2022-586846-c-519152-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -645,16 +658,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-586846-candidate-107994",
+      "id": "komunalni-2022-586846-c-107994",
       "name": "ČSSD a Levice",
       "type": "party",
       "description": "ČSSD a Levice - DESCRIPTION",
+      "img_url": "čssd-levice",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-586846-107994-party",
+          "id": "komunalni-2022-586846-c-107994-p",
           "name": "ČSSD a Levice",
           "description": "ČSSD a Levice - DESCRIPTION",
           "contacts": {
@@ -667,601 +681,589 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-586846-answer-516439-1",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-1",
+      "id": "komunalni-2022-586846-a-4",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-586846-a-7",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-516439-2",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-2",
-      "answer": "yes"
+      "id": "komunalni-2022-586846-a-10",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-3"
     },
     {
-      "id": "komunalni-2022-586846-answer-516439-3",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-3",
-      "answer": "no"
+      "id": "komunalni-2022-586846-a-13",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-4",
+      "answer": "yes",
+      "comment": "Zvýšení bezpečnosti obyvatel "
     },
     {
-      "id": "komunalni-2022-586846-answer-516439-4",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-4",
-      "answer": "no"
+      "id": "komunalni-2022-586846-a-16",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-5",
+      "answer": "yes",
+      "comment": "Věřím že to může někoho nakopnout splnit své závazky "
     },
     {
-      "id": "komunalni-2022-586846-answer-516439-5",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-5",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-6",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-6",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-7",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-7",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-8",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-8",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-9",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-9",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-10",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-10",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-11",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-11",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-12",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-12",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-13",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-13",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-14",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-14",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-15",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-15",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-16",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-16",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-17",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-17",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-18",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-18",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-19",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-19",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-20",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-20",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-21",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-21",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-22",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-22",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-23",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-23",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-24",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-24",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-25",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-25",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-26",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-26",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-27",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-27",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-28",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-28",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-29",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-29",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-30",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-30",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-31",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-31",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-32",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-32",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-33",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-33",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-34",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-34",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-35",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-35",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-36",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-36",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-37",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-37",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-38",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-38",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-39",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-39",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-40",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-40",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-41",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-41",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-42",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-42",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-43",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-43",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-44",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-44",
+      "id": "komunalni-2022-586846-a-19",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-6",
       "answer": "no",
-      "comment": "Ale rozhodně by se neměla zvyšovat."
+      "comment": "Nemyslím si že bezpecnost obyvatel vyřeší kamery na každém kroku"
     },
     {
-      "id": "komunalni-2022-586846-answer-516439-45",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-45",
-      "answer": "yes"
+      "id": "komunalni-2022-586846-a-22",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-7"
     },
     {
-      "id": "komunalni-2022-586846-answer-516439-46",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-46",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-47",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-47",
+      "id": "komunalni-2022-586846-a-25",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-516439-48",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-48",
+      "id": "komunalni-2022-586846-a-28",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-9"
+    },
+    {
+      "id": "komunalni-2022-586846-a-31",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-10",
+      "answer": "yes",
+      "comment": "Bylo by jasve poznat kdo zastává jaký názor "
+    },
+    {
+      "id": "komunalni-2022-586846-a-34",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-516439-49",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-49",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-516439-50",
-      "candidate_id": "komunalni-2022-586846-candidate-516439",
-      "question_id": "komunalni-2022-586846-question-50"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-681882-1",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-1",
+      "id": "komunalni-2022-586846-a-37",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-12",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-2",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-2",
+      "id": "komunalni-2022-586846-a-40",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-13"
+    },
+    {
+      "id": "komunalni-2022-586846-a-43",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-14"
+    },
+    {
+      "id": "komunalni-2022-586846-a-46",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-15",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-3",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-3",
+      "id": "komunalni-2022-586846-a-49",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-52",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-17"
+    },
+    {
+      "id": "komunalni-2022-586846-a-55",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-58",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-19"
+    },
+    {
+      "id": "komunalni-2022-586846-a-61",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-20"
+    },
+    {
+      "id": "komunalni-2022-586846-a-64",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-67",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-22",
+      "comment": "Do jisté míry zdarma oběd pro všechny podpoří všechny rodiny což je dobře "
+    },
+    {
+      "id": "komunalni-2022-586846-a-70",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-23"
+    },
+    {
+      "id": "komunalni-2022-586846-a-73",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-4",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-4",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-681882-5",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-5",
+      "id": "komunalni-2022-586846-a-76",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-6",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-6",
+      "id": "komunalni-2022-586846-a-79",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-7",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-7",
+      "id": "komunalni-2022-586846-a-82",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-8",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-8",
+      "id": "komunalni-2022-586846-a-85",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-88",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-91",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-30",
+      "comment": "Spíše by to mělo jít od distribučních firem"
+    },
+    {
+      "id": "komunalni-2022-586846-a-94",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-97",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-100",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-33"
+    },
+    {
+      "id": "komunalni-2022-586846-a-103",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-106",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-109",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-36"
+    },
+    {
+      "id": "komunalni-2022-586846-a-112",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-115",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-38",
+      "comment": "Koloběžky jsou dosti nebezpečné a pak se můžou válet po skarpach jako jiných městech "
+    },
+    {
+      "id": "komunalni-2022-586846-a-118",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-121",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-40"
+    },
+    {
+      "id": "komunalni-2022-586846-a-124",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-41",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-9",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-9",
+      "id": "komunalni-2022-586846-a-127",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-42"
+    },
+    {
+      "id": "komunalni-2022-586846-a-130",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-10",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-10",
+      "id": "komunalni-2022-586846-a-133",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-44"
+    },
+    {
+      "id": "komunalni-2022-586846-a-136",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-45",
+      "comment": "Otázka je jak podporovat a proč jim hrozí  hudoba "
+    },
+    {
+      "id": "komunalni-2022-586846-a-139",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-11",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-11",
+      "id": "komunalni-2022-586846-a-142",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-47"
+    },
+    {
+      "id": "komunalni-2022-586846-a-145",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-48",
+      "comment": "Nevím o co přesně jde "
+    },
+    {
+      "id": "komunalni-2022-586846-a-148",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-12",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-12",
-      "answer": "yes"
+      "id": "komunalni-2022-586846-a-151",
+      "candidate_id": "komunalni-2022-586846-c-516439",
+      "question_id": "komunalni-2022-586846-q-50"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-13",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-13",
+      "id": "komunalni-2022-586846-a-4",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-14",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-14",
+      "id": "komunalni-2022-586846-a-7",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-15",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-15",
+      "id": "komunalni-2022-586846-a-10",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-16",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-16",
+      "id": "komunalni-2022-586846-a-13",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-17",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-17",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-681882-18",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-18",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-681882-19",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-19",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-681882-20",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-20",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-681882-21",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-21",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-681882-22",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-22",
+      "id": "komunalni-2022-586846-a-16",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-5",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-23",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-23"
+      "id": "komunalni-2022-586846-a-19",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-6",
+      "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-24",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-24",
+      "id": "komunalni-2022-586846-a-22",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-25",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-25",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-25",
+      "id": "komunalni-2022-586846-a-28",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-31",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-34",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-37",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-40",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-13",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-26",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-26",
+      "id": "komunalni-2022-586846-a-43",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-27",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-27",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-681882-28",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-28",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-681882-29",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-29",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-681882-30",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-30",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-681882-31",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-31",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-681882-32",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-32",
+      "id": "komunalni-2022-586846-a-46",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-15",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-33",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-33",
+      "id": "komunalni-2022-586846-a-49",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-34",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-34",
+      "id": "komunalni-2022-586846-a-52",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-35",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-35",
+      "id": "komunalni-2022-586846-a-55",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-36",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-36",
+      "id": "komunalni-2022-586846-a-58",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-37",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-37",
+      "id": "komunalni-2022-586846-a-61",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-38",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-38",
+      "id": "komunalni-2022-586846-a-64",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-67",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-39",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-39",
-      "answer": "yes"
+      "id": "komunalni-2022-586846-a-70",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-23"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-40",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-40",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-681882-41",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-41",
+      "id": "komunalni-2022-586846-a-73",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-42",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-42",
+      "id": "komunalni-2022-586846-a-76",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-43",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-43",
+      "id": "komunalni-2022-586846-a-79",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-82",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-85",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-88",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-91",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-94",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-97",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-44",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-44",
+      "id": "komunalni-2022-586846-a-100",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-45",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-45",
+      "id": "komunalni-2022-586846-a-103",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-46",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-46",
+      "id": "komunalni-2022-586846-a-106",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-47",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-47",
+      "id": "komunalni-2022-586846-a-109",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-36",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-112",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-115",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-48",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-48"
-    },
-    {
-      "id": "komunalni-2022-586846-answer-681882-49",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-49",
+      "id": "komunalni-2022-586846-a-118",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-586846-answer-681882-50",
-      "candidate_id": "komunalni-2022-586846-candidate-681882",
-      "question_id": "komunalni-2022-586846-question-50"
+      "id": "komunalni-2022-586846-a-121",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-124",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-586846-a-127",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-586846-a-130",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-586846-a-133",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-136",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-139",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-142",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-586846-a-145",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-48"
+    },
+    {
+      "id": "komunalni-2022-586846-a-148",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-586846-a-151",
+      "candidate_id": "komunalni-2022-586846-c-681882",
+      "question_id": "komunalni-2022-586846-q-50"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/589250.json
+++ b/data/kalkulacka/komunalni-2022/589250.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-589250",
   "name": "Prostějov",
-  "description": "Prostějov - DESCRIPTION",
+  "description": "Prostějov",
   "district_code": "589250",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-589250-question-1",
+      "id": "komunalni-2022-589250-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-2",
+      "id": "komunalni-2022-589250-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-3",
+      "id": "komunalni-2022-589250-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-4",
+      "id": "komunalni-2022-589250-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-5",
+      "id": "komunalni-2022-589250-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-6",
+      "id": "komunalni-2022-589250-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-7",
+      "id": "komunalni-2022-589250-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-8",
+      "id": "komunalni-2022-589250-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-9",
+      "id": "komunalni-2022-589250-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-10",
+      "id": "komunalni-2022-589250-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-11",
+      "id": "komunalni-2022-589250-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-12",
+      "id": "komunalni-2022-589250-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-13",
+      "id": "komunalni-2022-589250-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-14",
+      "id": "komunalni-2022-589250-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-15",
+      "id": "komunalni-2022-589250-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-16",
+      "id": "komunalni-2022-589250-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-17",
+      "id": "komunalni-2022-589250-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-18",
+      "id": "komunalni-2022-589250-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-19",
+      "id": "komunalni-2022-589250-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-20",
+      "id": "komunalni-2022-589250-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-21",
+      "id": "komunalni-2022-589250-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-22",
+      "id": "komunalni-2022-589250-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-23",
+      "id": "komunalni-2022-589250-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-24",
+      "id": "komunalni-2022-589250-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-25",
+      "id": "komunalni-2022-589250-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-26",
+      "id": "komunalni-2022-589250-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-27",
+      "id": "komunalni-2022-589250-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-28",
+      "id": "komunalni-2022-589250-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-29",
+      "id": "komunalni-2022-589250-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-30",
+      "id": "komunalni-2022-589250-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-31",
+      "id": "komunalni-2022-589250-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-32",
+      "id": "komunalni-2022-589250-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-33",
+      "id": "komunalni-2022-589250-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-34",
+      "id": "komunalni-2022-589250-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-35",
+      "id": "komunalni-2022-589250-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-36",
+      "id": "komunalni-2022-589250-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-37",
+      "id": "komunalni-2022-589250-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-38",
+      "id": "komunalni-2022-589250-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-39",
+      "id": "komunalni-2022-589250-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-40",
+      "id": "komunalni-2022-589250-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-41",
+      "id": "komunalni-2022-589250-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-42",
+      "id": "komunalni-2022-589250-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-43",
+      "id": "komunalni-2022-589250-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-44",
+      "id": "komunalni-2022-589250-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-45",
+      "id": "komunalni-2022-589250-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-46",
+      "id": "komunalni-2022-589250-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-47",
+      "id": "komunalni-2022-589250-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-589250-question-48",
+      "id": "komunalni-2022-589250-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,16 +399,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-589250-candidate-282221",
+      "id": "komunalni-2022-589250-c-282221",
       "name": "Zvířata potřebují pomoc, sami si nepomohou ― sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
       "type": "party",
       "description": "Zvířata potřebují pomoc, sami si nepomohou ― sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+      "img_url": "dsz-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-589250-282221-party",
+          "id": "komunalni-2022-589250-c-282221-p",
           "name": "Zvířata potřebují pomoc, sami si nepomohou ― sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
           "description": "Zvířata potřebují pomoc, sami si nepomohou ― sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
           "contacts": {
@@ -417,10 +420,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-589250-candidate-845000",
+      "id": "komunalni-2022-589250-c-845000",
       "name": "NA ROVINU! (STAN, TOP 09, ZELENÍ)",
       "type": "party",
       "description": "NA ROVINU! (STAN, TOP 09, ZELENÍ) - DESCRIPTION",
+      "img_url": "zelení-stan-top",
       "contacts": {
         "web": [
           {
@@ -433,7 +437,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-589250-845000-party",
+          "id": "komunalni-2022-589250-c-845000-p",
           "name": "NA ROVINU! (STAN, TOP 09, ZELENÍ)",
           "description": "NA ROVINU! (STAN, TOP 09, ZELENÍ) - DESCRIPTION",
           "contacts": {
@@ -451,16 +455,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-589250-candidate-210818",
+      "id": "komunalni-2022-589250-c-210818",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-589250-210818-party",
+          "id": "komunalni-2022-589250-c-210818-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -471,16 +476,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-589250-candidate-760745",
+      "id": "komunalni-2022-589250-c-760745",
       "name": "Spojenci pro Prostějov",
       "type": "party",
       "description": "Spojenci pro Prostějov - DESCRIPTION",
+      "img_url": "kdu-čsl-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-589250-760745-party",
+          "id": "komunalni-2022-589250-c-760745-p",
           "name": "Spojenci pro Prostějov",
           "description": "Spojenci pro Prostějov - DESCRIPTION",
           "contacts": {
@@ -491,16 +497,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-589250-candidate-118812",
+      "id": "komunalni-2022-589250-c-118812",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-589250-118812-party",
+          "id": "komunalni-2022-589250-c-118812-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -511,16 +518,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-589250-candidate-318819",
+      "id": "komunalni-2022-589250-c-318819",
       "name": "Občanská demokratická strana spolu s nezávislými osobnostmi města Prostějova",
       "type": "party",
       "description": "Občanská demokratická strana spolu s nezávislými osobnostmi města Prostějova - DESCRIPTION",
+      "img_url": "ods-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-589250-318819-party",
+          "id": "komunalni-2022-589250-c-318819-p",
           "name": "Občanská demokratická strana spolu s nezávislými osobnostmi města Prostějova",
           "description": "Občanská demokratická strana spolu s nezávislými osobnostmi města Prostějova - DESCRIPTION",
           "contacts": {
@@ -531,16 +539,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-589250-candidate-360377",
+      "id": "komunalni-2022-589250-c-360377",
       "name": "Levicoví občané Prostějova a KSČM",
       "type": "party",
       "description": "Levicoví občané Prostějova a KSČM - DESCRIPTION",
+      "img_url": "ksčm-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-589250-360377-party",
+          "id": "komunalni-2022-589250-c-360377-p",
           "name": "Levicoví občané Prostějova a KSČM",
           "description": "Levicoví občané Prostějova a KSČM - DESCRIPTION",
           "contacts": {
@@ -551,16 +560,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-589250-candidate-315782",
+      "id": "komunalni-2022-589250-c-315782",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-589250-315782-party",
+          "id": "komunalni-2022-589250-c-315782-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -571,16 +581,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-589250-candidate-351128",
+      "id": "komunalni-2022-589250-c-351128",
       "name": "Pévéčko",
       "type": "party",
       "description": "Pévéčko - DESCRIPTION",
+      "img_url": "pv",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-589250-351128-party",
+          "id": "komunalni-2022-589250-c-351128-p",
           "name": "Pévéčko",
           "description": "Pévéčko - DESCRIPTION",
           "contacts": {
@@ -591,16 +602,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-589250-candidate-346586",
+      "id": "komunalni-2022-589250-c-346586",
       "name": "Česká strana sociálně demokratická",
       "type": "party",
       "description": "Česká strana sociálně demokratická - DESCRIPTION",
+      "img_url": "čssd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-589250-346586-party",
+          "id": "komunalni-2022-589250-c-346586-p",
           "name": "Česká strana sociálně demokratická",
           "description": "Česká strana sociálně demokratická - DESCRIPTION",
           "contacts": {
@@ -613,307 +625,607 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-589250-answer-845000-1",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-1",
+      "id": "komunalni-2022-589250-a-4",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-2",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-2",
+      "id": "komunalni-2022-589250-a-7",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-3",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-3",
+      "id": "komunalni-2022-589250-a-10",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-3",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-4",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-4",
+      "id": "komunalni-2022-589250-a-13",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-5",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-5",
+      "id": "komunalni-2022-589250-a-16",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-6",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-6",
+      "id": "komunalni-2022-589250-a-19",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-7",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-7",
+      "id": "komunalni-2022-589250-a-22",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-8",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-8",
+      "id": "komunalni-2022-589250-a-25",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-8",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-9",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-9",
+      "id": "komunalni-2022-589250-a-28",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-10",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-10",
+      "id": "komunalni-2022-589250-a-31",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-11",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-11",
+      "id": "komunalni-2022-589250-a-34",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-12",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-12",
+      "id": "komunalni-2022-589250-a-37",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-13",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-13",
+      "id": "komunalni-2022-589250-a-40",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-14",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-14",
+      "id": "komunalni-2022-589250-a-43",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-14",
       "answer": "yes",
       "comment": "Nadměrné osvětlení kulturních památek škodí přírodě i veřejnému zdraví. "
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-15",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-15",
+      "id": "komunalni-2022-589250-a-46",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-15",
       "answer": "yes",
       "comment": "Nejen kvůli energiím, ale i kvůli biodiverzitě a zdraví veřejnosti."
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-16",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-16",
+      "id": "komunalni-2022-589250-a-49",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-17",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-17",
+      "id": "komunalni-2022-589250-a-52",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-18",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-18",
+      "id": "komunalni-2022-589250-a-55",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-19",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-19",
+      "id": "komunalni-2022-589250-a-58",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-20",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-20",
+      "id": "komunalni-2022-589250-a-61",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-21",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-21",
+      "id": "komunalni-2022-589250-a-64",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-21",
       "answer": "yes",
       "comment": "Prostějov by měl zrušit i mobilní kluzišťátko, které  plánuje na náměstí a 59 dní provozu stojí miliony korun."
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-22",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-22",
+      "id": "komunalni-2022-589250-a-67",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-22",
       "answer": "no",
       "comment": "Alespoň symbolický poplatek a město má přispívat.  Co je zdarma, je často zneužíváno."
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-23",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-23"
+      "id": "komunalni-2022-589250-a-70",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-23"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-24",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-24",
+      "id": "komunalni-2022-589250-a-73",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-25",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-25",
+      "id": "komunalni-2022-589250-a-76",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-25",
       "answer": "no",
       "comment": "Na příkladu Nového Lískovce je prokázané, že jak vizionářské a moudré vedení dokáže uspořit energii a tím i náklady bytových domů. "
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-26",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-26",
+      "id": "komunalni-2022-589250-a-79",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-27",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-27",
+      "id": "komunalni-2022-589250-a-82",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-27",
       "answer": "yes",
       "comment": "Jednoznačně podporuji bezmotorovou mobilitu. Obce a města jsou přecpaná auty, zahlcená dopravními zplodinami, hlukem a zaskládaná parkujícími plechovkami. "
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-28",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-28"
+      "id": "komunalni-2022-589250-a-85",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-28"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-29",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-29",
+      "id": "komunalni-2022-589250-a-88",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-30",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-30",
+      "id": "komunalni-2022-589250-a-91",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-31",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-31",
+      "id": "komunalni-2022-589250-a-94",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-32",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-32",
+      "id": "komunalni-2022-589250-a-97",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-32",
       "answer": "yes",
       "comment": "Jednoznačně podporuji."
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-33",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-33",
+      "id": "komunalni-2022-589250-a-100",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-33",
       "answer": "yes",
       "comment": "Jedině podpora energetické soběstačnosti řeší energetickou krizi. "
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-34",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-34",
+      "id": "komunalni-2022-589250-a-103",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-35",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-35"
+      "id": "komunalni-2022-589250-a-106",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-35"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-36",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-36"
+      "id": "komunalni-2022-589250-a-109",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-36"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-37",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-37",
+      "id": "komunalni-2022-589250-a-112",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-37",
       "answer": "yes",
       "comment": "S tepelnými čerpadly a bateriovými úložišti jediné řešení energetické i klimatické krize odpojením od fosilních paliv."
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-38",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-38",
+      "id": "komunalni-2022-589250-a-115",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-39",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-39",
+      "id": "komunalni-2022-589250-a-118",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-40",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-40"
+      "id": "komunalni-2022-589250-a-121",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-40"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-41",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-41",
+      "id": "komunalni-2022-589250-a-124",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-41",
       "answer": "yes",
       "comment": "Zelené střechy řeší adaptaci na změnu klimatu a snižují efekt městského tepelného ostrova, pomáhají zadržovat srážkovou vodu na místě spadu."
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-42",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-42",
+      "id": "komunalni-2022-589250-a-127",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-42",
       "answer": "yes",
       "comment": "Jednoznačně. "
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-43",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-43",
+      "id": "komunalni-2022-589250-a-130",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-43",
       "answer": "no",
       "comment": "V Prostějově otřesné zkušenosti s vysáváním městského rozpočtu sportovním byznysem."
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-44",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-44",
+      "id": "komunalni-2022-589250-a-133",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-45",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-45",
+      "id": "komunalni-2022-589250-a-136",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-45",
       "answer": "yes",
       "comment": "Podporu podmiňovat odpovědným chováním ohroženého klienta. "
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-46",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-46",
+      "id": "komunalni-2022-589250-a-139",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-47",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-47",
+      "id": "komunalni-2022-589250-a-142",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-47",
       "answer": "yes",
       "comment": "Město by se mělo soustředit na podporu vzdělání znevýhodněných dětí. Podporovat integraci a účast v kroužcích, oddílech..."
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-48",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-48",
+      "id": "komunalni-2022-589250-a-145",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-589250-answer-845000-49",
-      "candidate_id": "komunalni-2022-589250-candidate-845000",
-      "question_id": "komunalni-2022-589250-question-49",
+      "id": "komunalni-2022-589250-a-148",
+      "candidate_id": "komunalni-2022-589250-c-845000",
+      "question_id": "komunalni-2022-589250-q-49",
       "comment": "Budování obecních energetických zdrojů a bateriových úložišť je cesta z energetické i klimatické krize."
+    },
+    {
+      "id": "komunalni-2022-589250-a-4",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-1",
+      "answer": "no",
+      "comment": "Každý má právo bydlet dle svého uvážení"
+    },
+    {
+      "id": "komunalni-2022-589250-a-7",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-2",
+      "answer": "yes",
+      "comment": "Co je zadarmo dlouhodobě nefunguje a nikdo si toho neváží"
+    },
+    {
+      "id": "komunalni-2022-589250-a-10",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-3",
+      "comment": "Nevím, co to omezení je? topit na 20 st.C"
+    },
+    {
+      "id": "komunalni-2022-589250-a-13",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-4",
+      "comment": "Jak kde, kde nejsou přehledné ulice, tak tam ano"
+    },
+    {
+      "id": "komunalni-2022-589250-a-16",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-5",
+      "answer": "yes",
+      "comment": "Mnoho lidí o tom neví, proto je třeba upozornit"
+    },
+    {
+      "id": "komunalni-2022-589250-a-19",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-6",
+      "answer": "yes",
+      "comment": "zvýší se bezpečnost"
+    },
+    {
+      "id": "komunalni-2022-589250-a-22",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-7",
+      "answer": "yes",
+      "comment": "hazard ničí rodiny, peníze z něho je nenahradí"
+    },
+    {
+      "id": "komunalni-2022-589250-a-25",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-8",
+      "answer": "no",
+      "comment": "zdarma ne, ale výrazně zlevněná po dobu krize cca na 6 Kč pro všechny"
+    },
+    {
+      "id": "komunalni-2022-589250-a-28",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-9"
+    },
+    {
+      "id": "komunalni-2022-589250-a-31",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-10",
+      "answer": "no",
+      "comment": "Ano jen v případě zásadních rozhodnutí, rozpočet, významná investiční akce"
+    },
+    {
+      "id": "komunalni-2022-589250-a-34",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-37",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-40",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-589250-a-43",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-14",
+      "answer": "yes",
+      "comment": "Alespoň po dobu krize"
+    },
+    {
+      "id": "komunalni-2022-589250-a-46",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-49",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-52",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-55",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-58",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-61",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-64",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-67",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-22",
+      "answer": "yes",
+      "comment": "Po dobu krize"
+    },
+    {
+      "id": "komunalni-2022-589250-a-70",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-589250-a-73",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-76",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-589250-a-79",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-26"
+    },
+    {
+      "id": "komunalni-2022-589250-a-82",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-85",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-28"
+    },
+    {
+      "id": "komunalni-2022-589250-a-88",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-29"
+    },
+    {
+      "id": "komunalni-2022-589250-a-91",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-30"
+    },
+    {
+      "id": "komunalni-2022-589250-a-94",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-97",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-100",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-33",
+      "answer": "yes",
+      "comment": "technickou pomocí hlavně"
+    },
+    {
+      "id": "komunalni-2022-589250-a-103",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-106",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-35"
+    },
+    {
+      "id": "komunalni-2022-589250-a-109",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-36"
+    },
+    {
+      "id": "komunalni-2022-589250-a-112",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-37",
+      "answer": "yes",
+      "comment": "Tam, kde je to vhodné a účelné"
+    },
+    {
+      "id": "komunalni-2022-589250-a-115",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-589250-a-118",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-39",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-589250-a-121",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-589250-a-124",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-41",
+      "answer": "yes",
+      "comment": "Kde je to vhodné"
+    },
+    {
+      "id": "komunalni-2022-589250-a-127",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-130",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-43",
+      "answer": "yes",
+      "comment": "částečně, dospělí sportovci jsou vzorem i pro mladé"
+    },
+    {
+      "id": "komunalni-2022-589250-a-133",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-589250-a-136",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-139",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-589250-a-142",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-589250-a-145",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-48",
+      "comment": "dle místní potřeby"
+    },
+    {
+      "id": "komunalni-2022-589250-a-148",
+      "candidate_id": "komunalni-2022-589250-c-760745",
+      "question_id": "komunalni-2022-589250-q-49",
+      "comment": "Je zde mnoho podobných otázek"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/590266.json
+++ b/data/kalkulacka/komunalni-2022/590266.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-590266",
   "name": "Třebíč",
-  "description": "Třebíč - DESCRIPTION",
+  "description": "Třebíč",
   "district_code": "590266",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-590266-question-1",
+      "id": "komunalni-2022-590266-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-2",
+      "id": "komunalni-2022-590266-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-3",
+      "id": "komunalni-2022-590266-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-4",
+      "id": "komunalni-2022-590266-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-5",
+      "id": "komunalni-2022-590266-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-6",
+      "id": "komunalni-2022-590266-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-7",
+      "id": "komunalni-2022-590266-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-8",
+      "id": "komunalni-2022-590266-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-9",
+      "id": "komunalni-2022-590266-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-10",
+      "id": "komunalni-2022-590266-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-11",
+      "id": "komunalni-2022-590266-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-12",
+      "id": "komunalni-2022-590266-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-13",
+      "id": "komunalni-2022-590266-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-14",
+      "id": "komunalni-2022-590266-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-15",
+      "id": "komunalni-2022-590266-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-16",
+      "id": "komunalni-2022-590266-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-17",
+      "id": "komunalni-2022-590266-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-18",
+      "id": "komunalni-2022-590266-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-19",
+      "id": "komunalni-2022-590266-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-20",
+      "id": "komunalni-2022-590266-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-21",
+      "id": "komunalni-2022-590266-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-22",
+      "id": "komunalni-2022-590266-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-23",
+      "id": "komunalni-2022-590266-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-24",
+      "id": "komunalni-2022-590266-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-25",
+      "id": "komunalni-2022-590266-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-26",
+      "id": "komunalni-2022-590266-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-27",
+      "id": "komunalni-2022-590266-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-28",
+      "id": "komunalni-2022-590266-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-29",
+      "id": "komunalni-2022-590266-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-30",
+      "id": "komunalni-2022-590266-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-31",
+      "id": "komunalni-2022-590266-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-32",
+      "id": "komunalni-2022-590266-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-33",
+      "id": "komunalni-2022-590266-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-34",
+      "id": "komunalni-2022-590266-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-35",
+      "id": "komunalni-2022-590266-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-36",
+      "id": "komunalni-2022-590266-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-37",
+      "id": "komunalni-2022-590266-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-38",
+      "id": "komunalni-2022-590266-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-39",
+      "id": "komunalni-2022-590266-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-40",
+      "id": "komunalni-2022-590266-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-41",
+      "id": "komunalni-2022-590266-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-42",
+      "id": "komunalni-2022-590266-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-43",
+      "id": "komunalni-2022-590266-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-44",
+      "id": "komunalni-2022-590266-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-45",
+      "id": "komunalni-2022-590266-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-46",
+      "id": "komunalni-2022-590266-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-47",
+      "id": "komunalni-2022-590266-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-590266-question-48",
+      "id": "komunalni-2022-590266-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,16 +399,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-590266-candidate-860344",
+      "id": "komunalni-2022-590266-c-860344",
       "name": "Třebíč můj domov",
       "type": "party",
       "description": "Třebíč můj domov - DESCRIPTION",
+      "img_url": "snk ed-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-590266-860344-party",
+          "id": "komunalni-2022-590266-c-860344-p",
           "name": "Třebíč můj domov",
           "description": "Třebíč můj domov - DESCRIPTION",
           "contacts": {
@@ -417,10 +420,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-590266-candidate-378973",
+      "id": "komunalni-2022-590266-c-378973",
       "name": "Třebíč Občanům!",
       "type": "party",
       "description": "Třebíč Občanům! - DESCRIPTION",
+      "img_url": "kan-nk",
       "contacts": {
         "web": [
           {
@@ -438,7 +442,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-590266-378973-party",
+          "id": "komunalni-2022-590266-c-378973-p",
           "name": "Třebíč Občanům!",
           "description": "Třebíč Občanům! - DESCRIPTION",
           "contacts": {
@@ -461,16 +465,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-590266-candidate-505803",
+      "id": "komunalni-2022-590266-c-505803",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-590266-505803-party",
+          "id": "komunalni-2022-590266-c-505803-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -481,16 +486,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-590266-candidate-238616",
+      "id": "komunalni-2022-590266-c-238616",
       "name": "Občané patrioti",
       "type": "party",
       "description": "Občané patrioti - DESCRIPTION",
+      "img_url": "opat",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-590266-238616-party",
+          "id": "komunalni-2022-590266-c-238616-p",
           "name": "Občané patrioti",
           "description": "Občané patrioti - DESCRIPTION",
           "contacts": {
@@ -501,16 +507,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-590266-candidate-543213",
+      "id": "komunalni-2022-590266-c-543213",
       "name": "PIRÁTI A NEZÁVISLÍ",
       "type": "party",
       "description": "PIRÁTI A NEZÁVISLÍ - DESCRIPTION",
+      "img_url": "piráti-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-590266-543213-party",
+          "id": "komunalni-2022-590266-c-543213-p",
           "name": "PIRÁTI A NEZÁVISLÍ",
           "description": "PIRÁTI A NEZÁVISLÍ - DESCRIPTION",
           "contacts": {
@@ -521,16 +528,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-590266-candidate-763579",
+      "id": "komunalni-2022-590266-c-763579",
       "name": "KDU-ČSL",
       "type": "party",
       "description": "KDU-ČSL - DESCRIPTION",
+      "img_url": "kdu-čsl",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-590266-763579-party",
+          "id": "komunalni-2022-590266-c-763579-p",
           "name": "KDU-ČSL",
           "description": "KDU-ČSL - DESCRIPTION",
           "contacts": {
@@ -541,16 +549,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-590266-candidate-160320",
+      "id": "komunalni-2022-590266-c-160320",
       "name": "TSD - Třebíč sociálně demokratická",
       "type": "party",
       "description": "TSD - Třebíč sociálně demokratická - DESCRIPTION",
+      "img_url": "čssd-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-590266-160320-party",
+          "id": "komunalni-2022-590266-c-160320-p",
           "name": "TSD - Třebíč sociálně demokratická",
           "description": "TSD - Třebíč sociálně demokratická - DESCRIPTION",
           "contacts": {
@@ -561,16 +570,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-590266-candidate-875906",
+      "id": "komunalni-2022-590266-c-875906",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-590266-875906-party",
+          "id": "komunalni-2022-590266-c-875906-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -581,16 +591,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-590266-candidate-900395",
+      "id": "komunalni-2022-590266-c-900395",
       "name": "Domov pro Třebíč",
       "type": "party",
       "description": "Domov pro Třebíč - DESCRIPTION",
+      "img_url": "domov-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-590266-900395-party",
+          "id": "komunalni-2022-590266-c-900395-p",
           "name": "Domov pro Třebíč",
           "description": "Domov pro Třebíč - DESCRIPTION",
           "contacts": {
@@ -601,16 +612,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-590266-candidate-711663",
+      "id": "komunalni-2022-590266-c-711663",
       "name": "TOP 09",
       "type": "party",
       "description": "TOP 09 - DESCRIPTION",
+      "img_url": "top 09",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-590266-711663-party",
+          "id": "komunalni-2022-590266-c-711663-p",
           "name": "TOP 09",
           "description": "TOP 09 - DESCRIPTION",
           "contacts": {
@@ -621,16 +633,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-590266-candidate-166431",
+      "id": "komunalni-2022-590266-c-166431",
       "name": "Svoboda a přímá demokracie (SPD) s podporou Trikolory",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) s podporou Trikolory - DESCRIPTION",
+      "img_url": "spd-trikolora",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-590266-166431-party",
+          "id": "komunalni-2022-590266-c-166431-p",
           "name": "Svoboda a přímá demokracie (SPD) s podporou Trikolory",
           "description": "Svoboda a přímá demokracie (SPD) s podporou Trikolory - DESCRIPTION",
           "contacts": {
@@ -641,16 +654,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-590266-candidate-180898",
+      "id": "komunalni-2022-590266-c-180898",
       "name": "PRO TŘEBÍČ",
       "type": "party",
       "description": "PRO TŘEBÍČ - DESCRIPTION",
+      "img_url": "stan-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-590266-180898-party",
+          "id": "komunalni-2022-590266-c-180898-p",
           "name": "PRO TŘEBÍČ",
           "description": "PRO TŘEBÍČ - DESCRIPTION",
           "contacts": {
@@ -661,16 +675,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-590266-candidate-934440",
+      "id": "komunalni-2022-590266-c-934440",
       "name": "Občanská demokratická strana a Ta naše Třebíč",
       "type": "party",
       "description": "Občanská demokratická strana a Ta naše Třebíč - DESCRIPTION",
+      "img_url": "ods-tnt",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-590266-934440-party",
+          "id": "komunalni-2022-590266-c-934440-p",
           "name": "Občanská demokratická strana a Ta naše Třebíč",
           "description": "Občanská demokratická strana a Ta naše Třebíč - DESCRIPTION",
           "contacts": {
@@ -681,16 +696,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-590266-candidate-589003",
+      "id": "komunalni-2022-590266-c-589003",
       "name": "Břehy",
       "type": "party",
       "description": "Břehy - DESCRIPTION",
+      "img_url": "zelení-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-590266-589003-party",
+          "id": "komunalni-2022-590266-c-589003-p",
           "name": "Břehy",
           "description": "Břehy - DESCRIPTION",
           "contacts": {
@@ -703,1890 +719,1872 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-590266-answer-589003-1",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-1",
+      "id": "komunalni-2022-590266-a-4",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-1",
       "comment": "nejasně zadaná otázka"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-2",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-2",
+      "id": "komunalni-2022-590266-a-7",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-3",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-3",
+      "id": "komunalni-2022-590266-a-10",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-3",
       "comment": "nejasně zadaná otázka = co znamená \"omezovat\"?"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-4",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-4",
+      "id": "komunalni-2022-590266-a-13",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-4",
       "answer": "yes",
       "comment": "Ano, pokud jsou to obytné zóny"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-5",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-5",
+      "id": "komunalni-2022-590266-a-16",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-5",
       "comment": "nejasně zadaná otázka = co znamená \"individuýlněobeslat\"? "
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-6",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-6",
+      "id": "komunalni-2022-590266-a-19",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-7",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-7",
+      "id": "komunalni-2022-590266-a-22",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-8",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-8",
+      "id": "komunalni-2022-590266-a-25",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-9",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-9",
+      "id": "komunalni-2022-590266-a-28",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-10",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-10",
+      "id": "komunalni-2022-590266-a-31",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-10",
       "comment": "nesmyslná otázka: hlasování se zveřejňuje"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-11",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-11",
+      "id": "komunalni-2022-590266-a-34",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-12",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-12",
+      "id": "komunalni-2022-590266-a-37",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-13",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-13",
+      "id": "komunalni-2022-590266-a-40",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-13",
       "comment": "nejasně zadaná otázka = není zřejmé, o jaké budovy má jít"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-14",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-14",
+      "id": "komunalni-2022-590266-a-43",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-15",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-15",
+      "id": "komunalni-2022-590266-a-46",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-15",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-16",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-16",
+      "id": "komunalni-2022-590266-a-49",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-16",
       "comment": "nejasně zadaná otázka = není zřejmé, o jaké budovy má jít"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-17",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-17",
+      "id": "komunalni-2022-590266-a-52",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-18",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-18",
+      "id": "komunalni-2022-590266-a-55",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-19",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-19",
+      "id": "komunalni-2022-590266-a-58",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-20",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-20",
+      "id": "komunalni-2022-590266-a-61",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-21",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-21",
+      "id": "komunalni-2022-590266-a-64",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-22",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-22",
+      "id": "komunalni-2022-590266-a-67",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-22",
       "comment": "nejasně zadaná otázka: má se to týkat všech dětí, nebo jne některých?"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-23",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-23",
+      "id": "komunalni-2022-590266-a-70",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-24",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-24",
+      "id": "komunalni-2022-590266-a-73",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-24",
       "comment": "nejasně zadaná otázka: v celém městě, nebo jen v některých částech?"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-25",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-25",
+      "id": "komunalni-2022-590266-a-76",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-26",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-26",
+      "id": "komunalni-2022-590266-a-79",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-27",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-27",
+      "id": "komunalni-2022-590266-a-82",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-28",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-28",
+      "id": "komunalni-2022-590266-a-85",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-29",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-29",
+      "id": "komunalni-2022-590266-a-88",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-30",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-30",
+      "id": "komunalni-2022-590266-a-91",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-31",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-31",
+      "id": "komunalni-2022-590266-a-94",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-32",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-32",
+      "id": "komunalni-2022-590266-a-97",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-33",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-33",
+      "id": "komunalni-2022-590266-a-100",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-33",
       "comment": "nejasně zadaná otázka: co znnamená \"pomoci\"?"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-34",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-34",
+      "id": "komunalni-2022-590266-a-103",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-34",
       "comment": "nesmyslná otázka: někde symbolické už je, někde není vůbec"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-35",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-35",
+      "id": "komunalni-2022-590266-a-106",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-35",
       "comment": "špatně položená otázka: mám jednoznačný názor, ale není to ano ani ne, takže nelze odpovědět"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-36",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-36",
+      "id": "komunalni-2022-590266-a-109",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-37",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-37",
+      "id": "komunalni-2022-590266-a-112",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-38",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-38",
+      "id": "komunalni-2022-590266-a-115",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-38",
       "answer": "no",
       "comment": "město má podporovat rozvoj dopravy na skutečných koloběžkách "
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-39",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-39",
+      "id": "komunalni-2022-590266-a-118",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-40",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-40",
+      "id": "komunalni-2022-590266-a-121",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-41",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-41",
+      "id": "komunalni-2022-590266-a-124",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-42",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-42",
+      "id": "komunalni-2022-590266-a-127",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-43",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-43",
+      "id": "komunalni-2022-590266-a-130",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-43",
       "answer": "no",
       "comment": "ne profesionální, ale mládežnický"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-44",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-44",
+      "id": "komunalni-2022-590266-a-133",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-45",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-45",
+      "id": "komunalni-2022-590266-a-136",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-45",
       "comment": "nesmyslná otázka: nejsou jasně zadané pojmy, sociální podpora je přece daná "
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-46",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-46",
+      "id": "komunalni-2022-590266-a-139",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-47",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-47",
+      "id": "komunalni-2022-590266-a-142",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-47",
       "comment": "nesmyslná otázka: každý může zvolit školu podle svého bydliště"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-48",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-48",
+      "id": "komunalni-2022-590266-a-145",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-589003-49",
-      "candidate_id": "komunalni-2022-590266-candidate-589003",
-      "question_id": "komunalni-2022-590266-question-49",
+      "id": "komunalni-2022-590266-a-148",
+      "candidate_id": "komunalni-2022-590266-c-589003",
+      "question_id": "komunalni-2022-590266-q-49",
       "comment": "Kalkulačka je bezcenná, na většinu otázek nelze poctivě odpovědět."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-1",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-1",
+      "id": "komunalni-2022-590266-a-4",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-1",
       "answer": "no",
       "comment": "Podobné čtvrtě v Třebíči nejsou."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-2",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-2",
+      "id": "komunalni-2022-590266-a-7",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-3",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-3",
+      "id": "komunalni-2022-590266-a-10",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-4",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-4",
+      "id": "komunalni-2022-590266-a-13",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-4",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-5",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-5",
+      "id": "komunalni-2022-590266-a-16",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-5",
       "answer": "yes",
       "comment": "Problébem je to, že řada dlužníků má bydliště hlášeno na radnici, tedy je obtížné jim jakoukoli informaci doručit."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-6",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-6",
+      "id": "komunalni-2022-590266-a-19",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-6",
       "answer": "yes",
       "comment": "Byly zakoupeny mobilní kamerové body, které situaci částěně řeší. Vhodná by byla instalace fotopastí např. na místech potenciáního vzniku černých skládek."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-7",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-7",
+      "id": "komunalni-2022-590266-a-22",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-8",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-8",
+      "id": "komunalni-2022-590266-a-25",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-8",
       "answer": "no",
       "comment": "Vzhledem k současné energetické krizi považujeme toto téma za nedměrný a neufinancovatelný zásah do rozpočtu města. "
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-9",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-9",
+      "id": "komunalni-2022-590266-a-28",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-9",
       "answer": "yes",
       "comment": "Uvědomujeme si, že MAD využívají především senioři, kteří mají často s nástupem do autobusu problém."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-10",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-10",
+      "id": "komunalni-2022-590266-a-31",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-10",
       "answer": "yes",
       "comment": "V Třebíči se tak běžně děje."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-11",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-11",
+      "id": "komunalni-2022-590266-a-34",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-11",
       "answer": "no",
       "comment": "Ze zákona je jednání rady města je neveřejné, proto by němělo být veřejné ani jmenovité hlasování."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-12",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-12",
+      "id": "komunalni-2022-590266-a-37",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-12",
       "answer": "yes",
       "comment": "V Třebíči taková vyhláška platí. Buhužel při jejím nedodržování je těžké identifikovat a postihnout pachatele."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-13",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-13",
+      "id": "komunalni-2022-590266-a-40",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-13",
       "comment": "Nerozumíme otázce. V Třebíči je řada budov bez problémů přístupná."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-14",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-14",
+      "id": "komunalni-2022-590266-a-43",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-14",
       "answer": "yes",
       "comment": "Pokud nebudou ceny enerigií klesat, je to jedna z možností úspor."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-15",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-15",
+      "id": "komunalni-2022-590266-a-46",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-15",
       "answer": "yes",
       "comment": "U veřejného osvětlení je možné v některých částech města využít například pohybových čidel.  Nesmí však dojít ke snížení bezpečnosti ve městě."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-16",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-16",
+      "id": "komunalni-2022-590266-a-49",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-16",
       "answer": "yes",
       "comment": "Ano, ale např. pouze mimo provozní dobu, aby nedošlo k zásadnímu snížení konfortu občanů (zaměstnanců, žáků ...)"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-17",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-17",
+      "id": "komunalni-2022-590266-a-52",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-17",
       "comment": "V Třebíči nevíme o takových případech."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-18",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-18"
+      "id": "komunalni-2022-590266-a-55",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-18"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-19",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-19",
+      "id": "komunalni-2022-590266-a-58",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-19",
       "answer": "yes",
       "comment": "Město Třebíč má participatovní rozpočet."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-20",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-20",
+      "id": "komunalni-2022-590266-a-61",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-20",
       "answer": "yes",
       "comment": "Pouze jako startovací bydlení nebo byty pro seniory, sociálně ohrožené a hendikepované."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-21",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-21",
+      "id": "komunalni-2022-590266-a-64",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-21",
       "comment": "Souhlasíme se zachováním vánoční výzdoby v rozsahu z roku 2021 bez dalšího rozšiřování."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-22",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-22",
+      "id": "komunalni-2022-590266-a-67",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-23",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-23",
+      "id": "komunalni-2022-590266-a-70",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-23",
       "answer": "yes",
       "comment": "Myšlenku sdílení dopravních prostředků podporujeme, ale zatím s tím nemáme ve městě přiliš zkušeností."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-24",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-24",
+      "id": "komunalni-2022-590266-a-73",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-25",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-25",
+      "id": "komunalni-2022-590266-a-76",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-25",
       "answer": "no",
       "comment": "Bytový fond města již byl převážně privatizován před řadou let. Město vlastní pouze byty zvláštího určení a sociální byty."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-26",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-26",
+      "id": "komunalni-2022-590266-a-79",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-27",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-27",
+      "id": "komunalni-2022-590266-a-82",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-27",
       "answer": "yes",
       "comment": "Nikoli však upřednostňovat, ale podporovat. Žádný účastník silničního provozu se nesmí cítit diskriminován. Řešením jsou například záchytná parkoviště a jejich návaznost na veřejnou dopravu."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-28",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-28",
+      "id": "komunalni-2022-590266-a-85",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-28",
       "answer": "no",
       "comment": "V Třebíči toto neregistrujeme jako zásadní problém."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-29",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-29",
+      "id": "komunalni-2022-590266-a-88",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-29",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-30",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-30",
+      "id": "komunalni-2022-590266-a-91",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-30",
       "answer": "yes",
       "comment": "V Třebíči se děje."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-31",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-31",
+      "id": "komunalni-2022-590266-a-94",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-32",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-32",
+      "id": "komunalni-2022-590266-a-97",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-33",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-33"
+      "id": "komunalni-2022-590266-a-100",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-33"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-34",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-34",
+      "id": "komunalni-2022-590266-a-103",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-34",
       "answer": "yes",
       "comment": "V Třebíči je snížené vstupné pro děti a studenty běžné."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-35",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-35"
+      "id": "komunalni-2022-590266-a-106",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-35"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-36",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-36"
+      "id": "komunalni-2022-590266-a-109",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-36"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-37",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-37",
+      "id": "komunalni-2022-590266-a-112",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-38",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-38",
+      "id": "komunalni-2022-590266-a-115",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-38",
       "answer": "yes",
       "comment": "Důležitá je však návaznost na další způsoby dopravy a bezpečnost všech účastníků silničního provozu."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-39",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-39",
+      "id": "komunalni-2022-590266-a-118",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-39",
       "answer": "yes",
       "comment": "V Třebíči se běžně děje."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-40",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-40",
+      "id": "komunalni-2022-590266-a-121",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-40",
       "answer": "no",
       "comment": "Počet městských strážníků považujeme za dostatečný."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-41",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-41",
+      "id": "komunalni-2022-590266-a-124",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-42",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-42",
+      "id": "komunalni-2022-590266-a-127",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-42",
       "answer": "yes",
       "comment": "V Třebíči se děje. Důležitá je však návaznost na další způsoby dopravy a bezpečnost všech účastníků silničního provozu."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-43",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-43",
+      "id": "komunalni-2022-590266-a-130",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-43",
       "answer": "no",
       "comment": "Z hlediska pravidel veřejné podory to není možné. Město výrazně podporuje mládežnický sport."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-44",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-44",
+      "id": "komunalni-2022-590266-a-133",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-45",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-45",
+      "id": "komunalni-2022-590266-a-136",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-45",
       "answer": "no",
       "comment": "Město disponuje byty s regulovanýcm nájemným - sociální bydlení - a podporuje neziskové organizace, které problematiku řeší. Domníváme se že záchytná siť státu a nezikových organizací je dostatečná."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-46",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-46",
+      "id": "komunalni-2022-590266-a-139",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-46",
       "answer": "yes",
       "comment": "Pouze jako startovací bydlení nebo byty pro seniory, sociálně ohrožené a hendikepované."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-47",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-47",
+      "id": "komunalni-2022-590266-a-142",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-47",
       "answer": "no",
       "comment": "V Třebíči to není problém."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-48",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-48",
+      "id": "komunalni-2022-590266-a-145",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-48",
       "answer": "no",
       "comment": "Mateřské školy a dětské skupiny běžně tyto děti přijímají."
     },
     {
-      "id": "komunalni-2022-590266-answer-860344-49",
-      "candidate_id": "komunalni-2022-590266-candidate-860344",
-      "question_id": "komunalni-2022-590266-question-49",
+      "id": "komunalni-2022-590266-a-148",
+      "candidate_id": "komunalni-2022-590266-c-860344",
+      "question_id": "komunalni-2022-590266-q-49",
       "comment": "Řada otázek je pro Třebíč zcela nerelevantní a nesmyslná."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-1",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-1",
+      "id": "komunalni-2022-590266-a-4",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-1",
       "answer": "no",
       "comment": "Stejně jako není dobré vytvářet ghetta, není dobré vytvářet ve městech ani zbohatlické VIP zóny. Město patří všem."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-2",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-2",
+      "id": "komunalni-2022-590266-a-7",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-2",
       "answer": "no",
       "comment": "Město má hlavně být vděčné občanům, že má zisky za jimi vytříděný odpad."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-3",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-3",
+      "id": "komunalni-2022-590266-a-10",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-4",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-4",
+      "id": "komunalni-2022-590266-a-13",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-4",
       "answer": "yes",
       "comment": "Ne pro omezování řidičů, ale v konkrétních případech opravdu kvůli bezpečnosti chodců - u mateřských školek, základních škol, před poliklinikami..."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-5",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-5",
+      "id": "komunalni-2022-590266-a-16",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-6",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-6",
+      "id": "komunalni-2022-590266-a-19",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-6",
       "answer": "yes",
       "comment": "Ano, ale ne alibisticky proto, aby pak strážníci nevycházeli na ulici s výmluvou, že přeci máme všude kamery. Kamera nenahradí okamžitou přítomnost strážníka na kritickém místě."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-7",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-7",
+      "id": "komunalni-2022-590266-a-22",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-7",
       "answer": "yes",
       "comment": "Bez milosti veškerý hazard pryč !!! "
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-8",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-8",
+      "id": "komunalni-2022-590266-a-25",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-8",
       "answer": "no",
       "comment": "Nejsme asociálové, do 18 let věku respektujeme zdarma, stejně jako od 60 let výše, ale výdělečně činná generace by měla přispívat na provoz MHD a tudíž i na její kvalitu."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-9",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-9",
+      "id": "komunalni-2022-590266-a-28",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-9",
       "answer": "yes",
       "comment": "Ale i nejlepší bezbariérová zastávka je zbytečná, když k ní přijede nebezbariérový autobus."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-10",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-10",
+      "id": "komunalni-2022-590266-a-31",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-10",
       "answer": "yes",
       "comment": "Ano, zastupitelé nejsou ovce, mají právo se za svůj hlas jmenovitě postavit, ale také se jmenovitě stydět, pokud budou hlasovat proti zájmům občanů."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-11",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-11",
+      "id": "komunalni-2022-590266-a-34",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-11",
       "answer": "yes",
       "comment": "Ano, radní nejsou ovce, mají právo se za svůj hlas jmenovitě postavit, ale také se jmenovitě stydět, pokud budou hlasovat proti zájmům občanů."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-12",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-12",
+      "id": "komunalni-2022-590266-a-37",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-12",
       "answer": "yes",
       "comment": "A i na silvestra jen v budoucí vyhlášce určených místech."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-13",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-13",
+      "id": "komunalni-2022-590266-a-40",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-13",
       "comment": "Pěkná myšlenka, ale muselo by se jasně říci které konkrétně. Některé by byly naprosto nehodné."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-14",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-14",
+      "id": "komunalni-2022-590266-a-43",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-14",
       "answer": "no",
       "comment": "Kulturní památky a dědictví předků nemůže za energetickou krizi vyvolanou politickými rozhodnutími."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-15",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-15",
+      "id": "komunalni-2022-590266-a-46",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-15",
       "answer": "no",
       "comment": "Spořit na veřejném osvětlení znamená dát větší šanci pouliční kriminalitě. "
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-16",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-16",
+      "id": "komunalni-2022-590266-a-49",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-16",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-17",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-17",
+      "id": "komunalni-2022-590266-a-52",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-17",
       "answer": "yes",
       "comment": "Děti by měli dostat šanci a ne je zadlužit dokud jsou děti a nemohou vydělávat peníze na splácení, často se pak z takových dluhů už nevymaní."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-18",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-18",
+      "id": "komunalni-2022-590266-a-55",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-19",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-19",
+      "id": "komunalni-2022-590266-a-58",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-19",
       "answer": "yes",
       "comment": "O části rozpočtu určitě ano, ale kdyby rozhodovali o úplně každé položce a záměru, nikdy by se v reálu uspokojivě nedohodli. Bylo by to hezky demokratické na papíře, ale v praxi nereálné."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-20",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-20",
+      "id": "komunalni-2022-590266-a-61",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-21",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-21",
+      "id": "komunalni-2022-590266-a-64",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-21",
       "answer": "no",
       "comment": "Vánoce jsou jednou za rok a nemohou za energetickou krizi vyvolanou politickými rozhodnutími. Nesahejte lidem na Vánoce, sahejte si do vlastního svědomí."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-22",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-22",
+      "id": "komunalni-2022-590266-a-67",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-22",
       "answer": "yes",
       "comment": "Nechceme zavádět socialistický populismus, na druhou stranu mnoho dětí dnes ve škole na obědy nechodí, protože si to rodiče nemohou dovolit. A po zdražování energií a zoufalé inflaci bude v rodinách ještě hůře. Raději nakrmit zdarma i děti majetných rodičů, než systémově a ziskuchtivě vynechat ty děti, co by na placený oběd přijít nemohly. "
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-23",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-23",
+      "id": "komunalni-2022-590266-a-70",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-23",
       "answer": "no",
       "comment": "Myšlenka je to k zamyšlení, ale rozhodně to není potřeba."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-24",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-24",
+      "id": "komunalni-2022-590266-a-73",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-24",
       "answer": "no",
       "comment": "Podporujeme více parkovacích míst ve městě a v centru na placených parkovištích prvních 30 minut zdarma, ale jsou prostě místa, kde parkovací zóny být musí, jinak by vznikaly vůči mnohým občanům města nespravedlivé a provozu škodlivé situace. Nemělo by to být ale otázkou ziskuchtivosti města vybírat za takové zóny nutně peníze, ale dělat tyto zóny smysluplně jen tam, kde je to nutně zapotřebí."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-25",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-25",
+      "id": "komunalni-2022-590266-a-76",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-25",
       "answer": "no",
       "comment": "Jestli město nemá peníze, nemůže je získávat tím, že se celé rozprodá nebo přímo zaprodá. Pokud však o takový byt požádá člověk, který v něm například prožil 20 a více let a chtěl by jej do vlastnictví třeba pro své děti, myslím, že bychom měli mít i srdce."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-26",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-26",
+      "id": "komunalni-2022-590266-a-79",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-27",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-27",
+      "id": "komunalni-2022-590266-a-82",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-28",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-28",
+      "id": "komunalni-2022-590266-a-85",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-28",
       "answer": "no",
       "comment": "Nemůžeme lidi trestat za to, že mají soukromé vlastnictví a mají s ním nějaký soukromý záměr. Doba komunismu už je za námi."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-29",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-29",
+      "id": "komunalni-2022-590266-a-88",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-30",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-30",
+      "id": "komunalni-2022-590266-a-91",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-30",
       "answer": "no",
       "comment": "Jsme pro ekologii, ale elektromobily jsou ekologické bohužel jen zdánlivě. Jezdí na elektrickou energii, která se do nich musí někde neekologicky vyrábět. Uhlíková stopa výroby elektromobilu je neúnosně vysoká. Dnes jsme schopni vyrábět automobily s tak úspornými a ekologickými spalovacími motory, že elektromobily jsou po sečtení všech výhod a nevýhod jen výsměchem 21. století. Nechceme podporovat z městských peněz rádoby ekologická gesta, která jsou falešná."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-31",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-31",
+      "id": "komunalni-2022-590266-a-94",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-31",
       "answer": "yes",
       "comment": "Ano, ale žádný Squatting. "
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-32",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-32",
+      "id": "komunalni-2022-590266-a-97",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-33",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-33",
+      "id": "komunalni-2022-590266-a-100",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-33",
       "answer": "yes",
       "comment": "Ale nikoliv v historickém centru."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-34",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-34",
+      "id": "komunalni-2022-590266-a-103",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-35",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-35",
+      "id": "komunalni-2022-590266-a-106",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-35",
       "answer": "yes",
       "comment": "Ano, žijeme ve 21. století a ženy potřebují trochu jinou péči na toaletách než muži."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-36",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-36",
+      "id": "komunalni-2022-590266-a-109",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-37",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-37",
+      "id": "komunalni-2022-590266-a-112",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-37",
       "answer": "yes",
       "comment": "Nikoliv však v historickém centru."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-38",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-38",
+      "id": "komunalni-2022-590266-a-115",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-38",
       "answer": "no",
       "comment": "Zkušenosti z měst, kde se například sdílené elektrické koloběžky zavedly jsou otřesné. Této krásné myšlenky s tragickými konci a masivním porušování vyhlášek města i zákona chceme občany uchránit. Nejde ani o ekologický provoz, protože elektrická energie, kterou se musí koloběžky dobíjet se musí neekologicky vyrobit a koloběžky každý den sváží z dojezdových míst a rozváží zpět na určená startovací místa velké naftové dodávky, které tak zaneřádí emise, že je směšné hovořit o ekologickém sdíleném provozu koloběžek ve městě."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-39",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-39",
+      "id": "komunalni-2022-590266-a-118",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-39",
       "comment": "Integraci cizinců ve městě chápeme jako přizpůsobení se cizinců místnímu obyvatelstvu, též zákonům a vyhláškám... nikoliv přizpůsobování se občanů Třebíče cizincům. "
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-40",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-40",
+      "id": "komunalni-2022-590266-a-121",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-40",
       "answer": "no",
       "comment": "Ve městě by nemělo být více strážníků, ale stávající strážníci by měli být více na ulicích."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-41",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-41",
+      "id": "komunalni-2022-590266-a-124",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-41",
       "comment": "Posuzovat se musí každá budova zvlášť, ne hromadně. Krásná myšlenka zelené střechy může být u některých budov naprosto nevhodná."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-42",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-42",
+      "id": "komunalni-2022-590266-a-127",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-42",
       "answer": "yes",
       "comment": "Ale ne na úkor chodců, kteří jdou do práce či do školy. Jinými slovy - cyklisté nemají na chodníku co dělat."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-43",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-43",
+      "id": "komunalni-2022-590266-a-130",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-43",
       "answer": "yes",
       "comment": "Ano, nezapomínat na neprofesionální sport !!!  Profesionální sport si na sebe dokáže hodně vydělat reklamami a sponzory, neprofesionální sport je často odkázán na almužnu z radnice."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-44",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-44",
+      "id": "komunalni-2022-590266-a-133",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-44",
       "answer": "yes",
       "comment": "Daň z nemovitosti je od základu nemorální, protože člověk platí za něco, co je jeho. A vlastně kvůli této dani má trpět za soukromé vlastnictví. Je to poněkud bolševická daň, která nepatří do svobodné společnosti. "
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-45",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-45",
+      "id": "komunalni-2022-590266-a-136",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-45",
       "answer": "yes",
       "comment": "Ano, ale ne plošně, někteří si tuto cestu do chudoby vybrali sami, dobrovolně a odmítají se zapojit do společnosti. Podporu by nesmysluplně utratili za alkohol, cigarety a další... nikoliv na zkvalitnění svého života a sociální začlenění."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-46",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-46",
+      "id": "komunalni-2022-590266-a-139",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-46",
       "answer": "yes",
       "comment": "Ano, je to naděje na lidem cenově dostupné bydlení a zvláště mladí lidé, mladé rodiny s dětmi, osamocení lidé napříč generacemi a zejména pak staří lidé jsou nejvíce ohroženi zda seženou a utáhnou bydlení. Město jim musí nabídnout vlastní cenově dostupné byty."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-47",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-47",
+      "id": "komunalni-2022-590266-a-142",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-47",
       "answer": "yes",
       "comment": "Ano, ale hlavně by mělo řešit, aby sociálně znevýhodněné děti nebyly i mravně škodlivé svému okolí na těchto školách."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-48",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-48",
+      "id": "komunalni-2022-590266-a-145",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-48",
       "comment": "Děti potřebují především mámu, neexistuje zaměstnání, kvůli kterému je lepší zbavit se dítěte a jít předčasně do práce. Nejsme proti jeslím, ale město by mělo podporovat především zájem dítěte, které potřebuje v tomto věku mámu, zodpovědné rodičovství a školky nejdříve od tří let věku."
     },
     {
-      "id": "komunalni-2022-590266-answer-238616-49",
-      "candidate_id": "komunalni-2022-590266-candidate-238616",
-      "question_id": "komunalni-2022-590266-question-49"
+      "id": "komunalni-2022-590266-a-148",
+      "candidate_id": "komunalni-2022-590266-c-238616",
+      "question_id": "komunalni-2022-590266-q-49"
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-1",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-1",
+      "id": "komunalni-2022-590266-a-4",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-2",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-2",
+      "id": "komunalni-2022-590266-a-7",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-2",
       "answer": "yes",
       "comment": "V ideálním případě by občan měl mít svobodu rozhodnutí, zda bude odpad třídit nebo si zaplatí za odvoz netříděného."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-3",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-3",
+      "id": "komunalni-2022-590266-a-10",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-3",
       "answer": "no",
       "comment": "V případě nouze bude nutné omezovat vytápění všude, ale rozhodně by se nemělo začít u domovů pro seniory. "
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-4",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-4",
+      "id": "komunalni-2022-590266-a-13",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-4",
       "answer": "no",
       "comment": "V místech s velkým pohybem chodců má omezení 30 km/h smysl, ale nepředpokládáme, že by v Třebíči bylo nutno tyto zóny masívně rozšiřovat."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-5",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-5",
+      "id": "komunalni-2022-590266-a-16",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-5",
       "answer": "no",
       "comment": "Informovanost o této akci je dostatečná."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-6",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-6",
+      "id": "komunalni-2022-590266-a-19",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-6",
       "answer": "no",
       "comment": "V ojedinělých případech snad ano, ale v současnosti je v Třebíči kamer až dost. "
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-7",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-7",
+      "id": "komunalni-2022-590266-a-22",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-7",
       "answer": "no",
       "comment": "Problémy působí jen herny s hracími automaty. Luxusní kasina a sportovní sázky není důvod na území města zakazovat."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-8",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-8",
+      "id": "komunalni-2022-590266-a-25",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-8",
       "answer": "no",
       "comment": "Hromadná doprava zdarma má své přínosy, ale je to velmi nákladné. I pokud by si to město mohlo dovolit, rozhodně by nemělo jít pouze o rezidenty, ale i o návštěvníky města."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-9",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-9",
+      "id": "komunalni-2022-590266-a-28",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-9",
       "answer": "yes",
       "comment": "Zajisté, bezbariérovost by měla být v dnešní době samozřejmostí."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-10",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-10",
+      "id": "komunalni-2022-590266-a-31",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-10",
       "answer": "yes",
       "comment": "Zasedání zastupitelstva jsou veřejně přístupná a návštěvníci vidí, jak kdo hlasoval. Není tedy důvod, aby stejnou informaci neměli i ostatní."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-11",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-11",
+      "id": "komunalni-2022-590266-a-34",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-11",
       "comment": "Není to nutné, stejně by pak rada měla vystupovat jednotně, pokud má město nějak rozumně řídit."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-12",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-12",
+      "id": "komunalni-2022-590266-a-37",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-12",
       "answer": "no",
       "comment": "Ne, zákazy by se měly týkat jen opravdu nebezpečné zábavní pyrotechniky."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-13",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-13",
+      "id": "komunalni-2022-590266-a-40",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-13",
       "answer": "yes",
       "comment": "Pokud bude až taková nouze, tak je to samozřejmě to nejmenší, jak může město občanům pomoci. "
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-14",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-14",
+      "id": "komunalni-2022-590266-a-43",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-14",
       "answer": "yes",
       "comment": "Samozřejmě osvětlení památek je zbytnou záležitostí. Ale při dnešních úsporných svítidlech se tím až tak velké úspory nedosáhne."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-15",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-15",
+      "id": "komunalni-2022-590266-a-46",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-15",
       "answer": "yes",
       "comment": "Ano, v případě nouze jistě není nutno svítit celou noc. "
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-16",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-16",
+      "id": "komunalni-2022-590266-a-49",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-16",
       "answer": "no",
       "comment": "V případě nouze samozřejmě ano. "
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-17",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-17",
+      "id": "komunalni-2022-590266-a-52",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-17",
       "answer": "no",
       "comment": "Plošně určitě ne. Ale dětské dluhy, které dojdou až do exekucí, jsou naprostým nesmyslem."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-18",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-18",
+      "id": "komunalni-2022-590266-a-55",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-18",
       "comment": "Není to nezbytně nutné, své hospodaření město zveřejňuje."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-19",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-19",
+      "id": "komunalni-2022-590266-a-58",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-19",
       "answer": "yes",
       "comment": "Ano, participativní rozpočty se osvědčují."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-20",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-20",
+      "id": "komunalni-2022-590266-a-61",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-20",
       "answer": "no",
       "comment": "Nějaký počet bytů pro profese, které chce do města přilákat, je třeba mít. Ale výrazné navyšování počtu městských bytů není na místě."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-21",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-21",
+      "id": "komunalni-2022-590266-a-64",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-22",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-22",
+      "id": "komunalni-2022-590266-a-67",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-23",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-23",
+      "id": "komunalni-2022-590266-a-70",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-24",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-24",
+      "id": "komunalni-2022-590266-a-73",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-25",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-25",
+      "id": "komunalni-2022-590266-a-76",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-25",
       "answer": "no",
       "comment": "Třebíč naprostou většinu svých bytů privatizovala již v minulosti."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-26",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-26",
+      "id": "komunalni-2022-590266-a-79",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-26",
       "answer": "no",
       "comment": "Má-li i město zájem na realizaci daného developerském projektu, může ho samozřejmě podpořit i tím, že úhradu veřejných nákladů požadovat nebude."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-27",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-27",
+      "id": "komunalni-2022-590266-a-82",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-27",
       "answer": "no",
       "comment": "Pěší, cyklistická, hromadná i automobilová doprava musí fungovat vedle sebe. "
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-28",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-28",
+      "id": "komunalni-2022-590266-a-85",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-29",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-29",
+      "id": "komunalni-2022-590266-a-88",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-29",
       "comment": "Nutno posuzovat v jednotlivých případech."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-30",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-30",
+      "id": "komunalni-2022-590266-a-91",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-30",
       "answer": "no",
       "comment": "Podpora případně může být v poskytnutí prostoru či vyjednání realizace. Ale rozhodně by město nemělo dobíjecí stanice provozovat, stejně jako neprovozuje čerpací stanice."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-31",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-31",
+      "id": "komunalni-2022-590266-a-94",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-32",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-32",
+      "id": "komunalni-2022-590266-a-97",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-32",
       "answer": "no",
       "comment": "MHD zdarma může být dobrý krok, ale jistě lze najít lepší vymezení než 0-18."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-33",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-33",
+      "id": "komunalni-2022-590266-a-100",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-33",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-34",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-34",
+      "id": "komunalni-2022-590266-a-103",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-34",
       "answer": "no",
       "comment": "Pokud bezplatné nebo symbolické vstupné, tak rozhodně nejen pro mládež, ale např. i pro seniory."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-35",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-35",
+      "id": "komunalni-2022-590266-a-106",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-36",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-36",
+      "id": "komunalni-2022-590266-a-109",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-37",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-37",
+      "id": "komunalni-2022-590266-a-112",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-38",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-38",
+      "id": "komunalni-2022-590266-a-115",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-39",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-39",
+      "id": "komunalni-2022-590266-a-118",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-40",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-40",
+      "id": "komunalni-2022-590266-a-121",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-40",
       "answer": "no",
       "comment": "Hlavním posláním městské policie je dbát na dodržování městských vyhlášek. Nabírání dalších strážníků, kteří suplují činnost PČR, není na místě."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-41",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-41",
+      "id": "komunalni-2022-590266-a-124",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-41",
       "answer": "no",
       "comment": "Tam už přece jsou fotovoltaické panely z otázky 37."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-42",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-42",
+      "id": "komunalni-2022-590266-a-127",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-42",
       "answer": "no",
       "comment": "Ne, město nemůže být schopno zajistit, aby se cyklista po příjezdu měl kde osprchovat a převléknout do nepropoceného oblečení."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-43",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-43",
+      "id": "komunalni-2022-590266-a-130",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-43",
       "answer": "yes",
       "comment": "Podpora profesionálních klubu přináší městu prestiž. Ale většina podpory sportu by měla jít do sportování mládeže a seniorů. "
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-44",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-44",
+      "id": "komunalni-2022-590266-a-133",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-44",
       "answer": "yes",
       "comment": "Snížení daní ano, ale při současném stavu státního rozpočtu na to nyní není vhodná doba."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-45",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-45",
+      "id": "komunalni-2022-590266-a-136",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-45",
       "answer": "no",
       "comment": "Podporu samozřejmě nevylučujeme, ale sociální systém je primárně záležitostí státu, nikoliv města."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-46",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-46",
+      "id": "komunalni-2022-590266-a-139",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-46",
       "answer": "yes",
       "comment": "V nějaké omezené míře samozřejmě ano."
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-47",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-47",
+      "id": "komunalni-2022-590266-a-142",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-47",
       "answer": "no",
       "comment": "Rozhodně by město nemělo takové shromažďování podporovat. Ale není reálné, aby město rozváželo sociálně znevýhodněné děti do škol po celém městě. "
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-48",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-48",
+      "id": "komunalni-2022-590266-a-145",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-711663-49",
-      "candidate_id": "komunalni-2022-590266-candidate-711663",
-      "question_id": "komunalni-2022-590266-question-49"
+      "id": "komunalni-2022-590266-a-148",
+      "candidate_id": "komunalni-2022-590266-c-711663",
+      "question_id": "komunalni-2022-590266-q-49"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-1",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-1",
+      "id": "komunalni-2022-590266-a-4",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-1"
+    },
+    {
+      "id": "komunalni-2022-590266-a-7",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-10",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-2",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-2",
+      "id": "komunalni-2022-590266-a-13",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-4"
+    },
+    {
+      "id": "komunalni-2022-590266-a-16",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-3",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-3",
-      "answer": "no",
-      "comment": "V žádném případě."
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-4",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-4"
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-5",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-5",
-      "answer": "yes",
-      "comment": "Úředníků je na to dost."
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-6",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-6",
-      "answer": "yes",
-      "comment": "Mafie a feťáci budou mít utrum."
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-7",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-7",
-      "answer": "yes",
-      "comment": "Proč dotovat mafii."
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-8",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-8",
-      "answer": "yes",
-      "comment": "Dopravci dostávají dotace."
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-9",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-9"
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-10",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-10",
-      "answer": "yes",
-      "comment": "Vše veřejně..Boj proti korupci."
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-11",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-11",
+      "id": "komunalni-2022-590266-a-19",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-12",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-12",
+      "id": "komunalni-2022-590266-a-22",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-13",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-13",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-14",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-14",
-      "answer": "no",
-      "comment": "Omezí se kriminalita a vandalství."
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-15",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-15",
-      "answer": "no",
-      "comment": "Omezí se kriminalita a vandalství."
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-16",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-16",
-      "answer": "no",
-      "comment": "Nevím proč by měli být omezování občané jen kvůli špatně vládě."
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-17",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-17",
-      "answer": "yes",
-      "comment": "Děti nemohou za rodíče."
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-18",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-18",
-      "answer": "yes",
-      "comment": "Hospodářská soutěž."
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-19",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-19",
-      "answer": "yes",
-      "comment": "Jaké potřeba zrušit mafiánské rozdělení veřejných peněz."
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-20",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-20",
-      "answer": "yes",
-      "comment": "Dostupné bydlení."
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-21",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-21",
+      "id": "komunalni-2022-590266-a-25",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-22",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-22",
-      "answer": "yes",
-      "comment": "Ne všichni na to mají."
+      "id": "komunalni-2022-590266-a-28",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-9",
+      "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-23",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-23",
+      "id": "komunalni-2022-590266-a-31",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-34",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-37",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-12"
+    },
+    {
+      "id": "komunalni-2022-590266-a-40",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-13"
+    },
+    {
+      "id": "komunalni-2022-590266-a-43",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-14",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-24",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-24",
+      "id": "komunalni-2022-590266-a-46",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-15",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-25",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-25",
+      "id": "komunalni-2022-590266-a-49",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-16",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-26",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-26",
+      "id": "komunalni-2022-590266-a-52",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-27",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-27"
+      "id": "komunalni-2022-590266-a-55",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-18",
+      "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-28",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-28",
+      "id": "komunalni-2022-590266-a-58",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-19"
+    },
+    {
+      "id": "komunalni-2022-590266-a-61",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-64",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-21",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-29",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-29",
+      "id": "komunalni-2022-590266-a-67",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-22",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-30",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-30",
-      "answer": "no",
-      "comment": "Je to podvod."
+      "id": "komunalni-2022-590266-a-70",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-23"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-31",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-31",
+      "id": "komunalni-2022-590266-a-73",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-32",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-32",
+      "id": "komunalni-2022-590266-a-76",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-25"
+    },
+    {
+      "id": "komunalni-2022-590266-a-79",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-33",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-33"
+      "id": "komunalni-2022-590266-a-82",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-27"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-34",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-34",
+      "id": "komunalni-2022-590266-a-85",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-590266-a-88",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-35",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-35"
+      "id": "komunalni-2022-590266-a-91",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-30",
+      "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-36",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-36"
+      "id": "komunalni-2022-590266-a-94",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-31",
+      "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-37",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-37"
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-38",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-38"
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-39",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-39",
-      "answer": "no",
-      "comment": "Není to potřeba."
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-40",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-40",
+      "id": "komunalni-2022-590266-a-97",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-41",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-41"
+      "id": "komunalni-2022-590266-a-100",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-33"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-42",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-42",
+      "id": "komunalni-2022-590266-a-103",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-43",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-43"
+      "id": "komunalni-2022-590266-a-106",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-35"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-44",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-44",
+      "id": "komunalni-2022-590266-a-109",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-36"
+    },
+    {
+      "id": "komunalni-2022-590266-a-112",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-590266-a-115",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-590266-a-118",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-39",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-590266-a-121",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-45",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-45",
+      "id": "komunalni-2022-590266-a-124",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-41"
+    },
+    {
+      "id": "komunalni-2022-590266-a-127",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-590266-a-130",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-46",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-46",
+      "id": "komunalni-2022-590266-a-133",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-44",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-47",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-47"
-    },
-    {
-      "id": "komunalni-2022-590266-answer-166431-48",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-48",
+      "id": "komunalni-2022-590266-a-136",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-166431-49",
-      "candidate_id": "komunalni-2022-590266-candidate-166431",
-      "question_id": "komunalni-2022-590266-question-49"
+      "id": "komunalni-2022-590266-a-139",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-46",
+      "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-1",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-1",
+      "id": "komunalni-2022-590266-a-142",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-47"
+    },
+    {
+      "id": "komunalni-2022-590266-a-145",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-590266-a-148",
+      "candidate_id": "komunalni-2022-590266-c-166431",
+      "question_id": "komunalni-2022-590266-q-49"
+    },
+    {
+      "id": "komunalni-2022-590266-a-4",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-1",
       "answer": "yes",
       "comment": "Každý má bydlet tam, kde si to může dovolit."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-2",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-2",
+      "id": "komunalni-2022-590266-a-7",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-2",
       "answer": "yes",
       "comment": "Než vyhazovat peníze za pochybné městské projekty, tak pomožte lidem s touto další daní."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-3",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-3",
+      "id": "komunalni-2022-590266-a-10",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-3",
       "answer": "no",
       "comment": "Město musí žádat vládu, aby neřešila následky, ale příčinu. Tj. zajistit energie a plyn. Všeho je dostatek. Jen si musíme přestat hrát na demokratický plyn a krmení německých důchodců z lipské burzy."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-4",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-4",
+      "id": "komunalni-2022-590266-a-13",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-5",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-5",
+      "id": "komunalni-2022-590266-a-16",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-6",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-6",
+      "id": "komunalni-2022-590266-a-19",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-6",
       "answer": "no",
       "comment": "Už tak jsme sledovaní jak v knize Orwella."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-7",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-7",
+      "id": "komunalni-2022-590266-a-22",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-7",
       "answer": "no",
       "comment": "V rozumné míře a s kontrolou."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-8",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-8",
+      "id": "komunalni-2022-590266-a-25",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-8",
       "answer": "no",
       "comment": "Pro děti do 15ti a dospělé od 65ti."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-9",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-9",
+      "id": "komunalni-2022-590266-a-28",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-9",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-10",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-10",
+      "id": "komunalni-2022-590266-a-31",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-10",
       "answer": "yes",
       "comment": "Ano, aby se odstranilo to, že Okamura všude něco hřímá, ale pak klidně schválí sankce na Rusko. A sankce jsou příčinou našich problémů. "
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-11",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-11",
+      "id": "komunalni-2022-590266-a-34",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-12",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-12",
+      "id": "komunalni-2022-590266-a-37",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-12",
       "answer": "no",
       "comment": "Vlády už toho lidem sebraly dost. Tak proč i tuto tradici."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-13",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-13",
+      "id": "komunalni-2022-590266-a-40",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-13",
       "answer": "no",
       "comment": "Chceme se postupně vrátit do středověku?"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-14",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-14",
+      "id": "komunalni-2022-590266-a-43",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-14",
       "answer": "no",
       "comment": "Odstraňme příčiny energetické krize. Nebudeme muset řešit následky."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-15",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-15",
+      "id": "komunalni-2022-590266-a-46",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-15",
       "answer": "no",
       "comment": "Viz 15"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-16",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-16",
+      "id": "komunalni-2022-590266-a-49",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-16",
       "answer": "no",
       "comment": "Viz 15"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-17",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-17",
+      "id": "komunalni-2022-590266-a-52",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-17",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-18",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-18",
+      "id": "komunalni-2022-590266-a-55",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-18",
       "answer": "yes",
       "comment": "Jak jinak zabránit všem nepravostem."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-19",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-19",
+      "id": "komunalni-2022-590266-a-58",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-19",
       "answer": "yes",
       "comment": "Občané budou za chvíli třít zimu s hladem a radnice Třebíče dá během dvou příštích let 400 milionů Kč (+ kvůli inflaci zcela jistě další) do stavby zimního stadionu."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-20",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-20",
+      "id": "komunalni-2022-590266-a-61",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-20",
       "answer": "yes",
       "comment": "Jak zabránit odchodům potřebných jinam."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-21",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-21",
+      "id": "komunalni-2022-590266-a-64",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-21",
       "answer": "no",
       "comment": "Viz 15"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-22",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-22",
+      "id": "komunalni-2022-590266-a-67",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-22",
       "answer": "no",
       "comment": "Jen ty děti, o nichž management školy ví, že jinak oběd od svých rodičů či opatrovníků nedostanou."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-23",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-23",
+      "id": "komunalni-2022-590266-a-70",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-24",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-24",
+      "id": "komunalni-2022-590266-a-73",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-24",
       "answer": "no",
       "comment": "Parkovací zóny jen např. od osmi sedmi do patnácti. Mezitím volné parkování."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-25",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-25",
+      "id": "komunalni-2022-590266-a-76",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-25",
       "answer": "no",
       "comment": "Viz 20"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-26",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-26",
+      "id": "komunalni-2022-590266-a-79",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-26",
       "answer": "yes",
       "comment": "To je logické."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-27",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-27",
+      "id": "komunalni-2022-590266-a-82",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-27",
       "answer": "no",
       "comment": "Nebuďme papežštější než retardovaná Gréta."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-28",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-28",
+      "id": "komunalni-2022-590266-a-85",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-28",
       "answer": "no",
       "comment": "Je to přece na vlastníkovi. Je to jeho majetek. Ne Pirátské strany."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-29",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-29"
+      "id": "komunalni-2022-590266-a-88",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-29"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-30",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-30",
+      "id": "komunalni-2022-590266-a-91",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-30",
       "answer": "no",
       "comment": "Už teď každý, kdo má v hlavě mozek ví, že nápady bruselských grázlů s elektromobilitou jsou nesmysl. Už teď jsou to zbytečné investice. Proč vyhazovat další."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-31",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-31"
+      "id": "komunalni-2022-590266-a-94",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-31"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-32",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-32",
+      "id": "komunalni-2022-590266-a-97",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-32",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-33",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-33",
+      "id": "komunalni-2022-590266-a-100",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-33",
       "answer": "no",
       "comment": "Stát a vláda mají zajistit všem občanům levnou energii z klasických zdrojů a ne lidem z jejich kapes díky své neschopnosti tahat další peníze."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-34",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-34",
+      "id": "komunalni-2022-590266-a-103",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-34",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-35",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-35",
+      "id": "komunalni-2022-590266-a-106",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-35",
       "answer": "no",
       "comment": "Nevidím důvod. Stačí ty veřejné toalety pro 58 pohlaví."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-36",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-36",
+      "id": "komunalni-2022-590266-a-109",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-36",
       "answer": "no",
       "comment": "Zcela zcestné uvažování. Když už i prezervativy, lahvinky rumu apod."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-37",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-37",
+      "id": "komunalni-2022-590266-a-112",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-37",
       "answer": "no",
       "comment": "Viz 33"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-38",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-38",
+      "id": "komunalni-2022-590266-a-115",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-38",
       "answer": "no",
       "comment": "Zcela zbytečné náklady. Zrušte Green deal, emisní povolenky, Lipskou burzu, berme plyn napřímo z Ruska a ne třikrát dražší, ale zdemokratizovaný Německem, a bude svět normální."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-39",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-39",
+      "id": "komunalni-2022-590266-a-118",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-39",
       "answer": "no",
       "comment": "Chceme tu mít no go zóny, kam se i policie bojí vstoupit? Stockholm, Londýn atd."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-40",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-40",
+      "id": "komunalni-2022-590266-a-121",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-40",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-41",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-41"
+      "id": "komunalni-2022-590266-a-124",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-41"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-42",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-42",
+      "id": "komunalni-2022-590266-a-127",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-42",
       "answer": "no",
       "comment": "Fakt tu chceme zavádět poměry jako v Severní Koreji."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-43",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-43",
+      "id": "komunalni-2022-590266-a-130",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-43",
       "answer": "yes",
       "comment": "Ale profesionální sportovci, kterým město dotuje jejich sportoviště, musí městu řádně přispívat."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-44",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-44",
+      "id": "komunalni-2022-590266-a-133",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-45",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-45",
+      "id": "komunalni-2022-590266-a-136",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-45",
       "answer": "yes",
       "comment": "Když je nyní vláda do chudoby žene, tak ano."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-46",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-46",
+      "id": "komunalni-2022-590266-a-139",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-47",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-47",
+      "id": "komunalni-2022-590266-a-142",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-47",
       "answer": "no",
       "comment": "Systém pomocných škol fungoval skvěle. Šílená inkluze školství rozvrací."
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-48",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-48",
+      "id": "komunalni-2022-590266-a-145",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-590266-answer-900395-49",
-      "candidate_id": "komunalni-2022-590266-candidate-900395",
-      "question_id": "komunalni-2022-590266-question-49",
+      "id": "komunalni-2022-590266-a-148",
+      "candidate_id": "komunalni-2022-590266-c-900395",
+      "question_id": "komunalni-2022-590266-q-49",
       "comment": "Děkuji za zveřejnění."
     }
   ]

--- a/data/kalkulacka/komunalni-2022/593711.json
+++ b/data/kalkulacka/komunalni-2022/593711.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-593711",
   "name": "Znojmo",
-  "description": "Znojmo - DESCRIPTION",
+  "description": "Znojmo",
   "district_code": "593711",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-593711-question-1",
+      "id": "komunalni-2022-593711-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-2",
+      "id": "komunalni-2022-593711-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-3",
+      "id": "komunalni-2022-593711-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-4",
+      "id": "komunalni-2022-593711-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-5",
+      "id": "komunalni-2022-593711-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-6",
+      "id": "komunalni-2022-593711-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-7",
+      "id": "komunalni-2022-593711-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-8",
+      "id": "komunalni-2022-593711-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-9",
+      "id": "komunalni-2022-593711-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-10",
+      "id": "komunalni-2022-593711-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-11",
+      "id": "komunalni-2022-593711-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-12",
+      "id": "komunalni-2022-593711-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-13",
+      "id": "komunalni-2022-593711-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-14",
+      "id": "komunalni-2022-593711-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-15",
+      "id": "komunalni-2022-593711-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-16",
+      "id": "komunalni-2022-593711-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-17",
+      "id": "komunalni-2022-593711-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-18",
+      "id": "komunalni-2022-593711-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-19",
+      "id": "komunalni-2022-593711-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-20",
+      "id": "komunalni-2022-593711-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-21",
+      "id": "komunalni-2022-593711-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-22",
+      "id": "komunalni-2022-593711-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-23",
+      "id": "komunalni-2022-593711-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-24",
+      "id": "komunalni-2022-593711-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-25",
+      "id": "komunalni-2022-593711-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-26",
+      "id": "komunalni-2022-593711-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-27",
+      "id": "komunalni-2022-593711-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-28",
+      "id": "komunalni-2022-593711-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-29",
+      "id": "komunalni-2022-593711-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-30",
+      "id": "komunalni-2022-593711-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-31",
+      "id": "komunalni-2022-593711-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-32",
+      "id": "komunalni-2022-593711-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-33",
+      "id": "komunalni-2022-593711-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-34",
+      "id": "komunalni-2022-593711-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-35",
+      "id": "komunalni-2022-593711-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-36",
+      "id": "komunalni-2022-593711-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-37",
+      "id": "komunalni-2022-593711-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-38",
+      "id": "komunalni-2022-593711-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-39",
+      "id": "komunalni-2022-593711-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-40",
+      "id": "komunalni-2022-593711-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-41",
+      "id": "komunalni-2022-593711-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-42",
+      "id": "komunalni-2022-593711-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-43",
+      "id": "komunalni-2022-593711-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-44",
+      "id": "komunalni-2022-593711-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-45",
+      "id": "komunalni-2022-593711-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-46",
+      "id": "komunalni-2022-593711-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-47",
+      "id": "komunalni-2022-593711-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-593711-question-48",
+      "id": "komunalni-2022-593711-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,17 +399,18 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-593711-candidate-467519",
+      "id": "komunalni-2022-593711-c-467519",
       "name": "ZNOJEMSKÁ KOALICE ČSSD+KSČM+ZEMANOVCI",
       "type": "party",
       "description": "ZNOJEMSKÁ KOALICE ČSSD+KSČM+ZEMANOVCI - DESCRIPTION",
+      "img_url": "čssd-ksčm-spoz",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/KOALICEZnojmo"
       },
       "parties": [
         {
-          "id": "komunalni-2022-593711-467519-party",
+          "id": "komunalni-2022-593711-c-467519-p",
           "name": "ZNOJEMSKÁ KOALICE ČSSD+KSČM+ZEMANOVCI",
           "description": "ZNOJEMSKÁ KOALICE ČSSD+KSČM+ZEMANOVCI - DESCRIPTION",
           "contacts": {
@@ -419,17 +422,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-593711-candidate-152593",
+      "id": "komunalni-2022-593711-c-152593",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/znojmobudelip"
       },
       "parties": [
         {
-          "id": "komunalni-2022-593711-152593-party",
+          "id": "komunalni-2022-593711-c-152593-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -441,16 +445,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-593711-candidate-543025",
+      "id": "komunalni-2022-593711-c-543025",
       "name": "SPD a nezávislé osobnosti",
       "type": "party",
       "description": "SPD a nezávislé osobnosti - DESCRIPTION",
+      "img_url": "spd-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-593711-543025-party",
+          "id": "komunalni-2022-593711-c-543025-p",
           "name": "SPD a nezávislé osobnosti",
           "description": "SPD a nezávislé osobnosti - DESCRIPTION",
           "contacts": {
@@ -461,17 +466,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-593711-candidate-284183",
+      "id": "komunalni-2022-593711-c-284183",
       "name": "Znojmáci - Znojmo srdcem a rozumem",
       "type": "party",
       "description": "Znojmáci - Znojmo srdcem a rozumem - DESCRIPTION",
+      "img_url": "svobodní-nk",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/znojmacisrdcem"
       },
       "parties": [
         {
-          "id": "komunalni-2022-593711-284183-party",
+          "id": "komunalni-2022-593711-c-284183-p",
           "name": "Znojmáci - Znojmo srdcem a rozumem",
           "description": "Znojmáci - Znojmo srdcem a rozumem - DESCRIPTION",
           "contacts": {
@@ -483,17 +489,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-593711-candidate-675084",
+      "id": "komunalni-2022-593711-c-675084",
       "name": "TOP 09",
       "type": "party",
       "description": "TOP 09 - DESCRIPTION",
+      "img_url": "top 09",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/TOP09Znojmo"
       },
       "parties": [
         {
-          "id": "komunalni-2022-593711-675084-party",
+          "id": "komunalni-2022-593711-c-675084-p",
           "name": "TOP 09",
           "description": "TOP 09 - DESCRIPTION",
           "contacts": {
@@ -505,16 +512,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-593711-candidate-408306",
+      "id": "komunalni-2022-593711-c-408306",
       "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
       "type": "party",
       "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
+      "img_url": "přísaha",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-593711-408306-party",
+          "id": "komunalni-2022-593711-c-408306-p",
           "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
           "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
           "contacts": {
@@ -525,17 +533,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-593711-candidate-489263",
+      "id": "komunalni-2022-593711-c-489263",
       "name": "ODS + KDU-ČSL SPOLU",
       "type": "party",
       "description": "ODS + KDU-ČSL SPOLU - DESCRIPTION",
+      "img_url": "kdu-čsl-ods",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/ODSzaZnojmo"
       },
       "parties": [
         {
-          "id": "komunalni-2022-593711-489263-party",
+          "id": "komunalni-2022-593711-c-489263-p",
           "name": "ODS + KDU-ČSL SPOLU",
           "description": "ODS + KDU-ČSL SPOLU - DESCRIPTION",
           "contacts": {
@@ -547,17 +556,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-593711-candidate-677775",
+      "id": "komunalni-2022-593711-c-677775",
       "name": "PRO ZNOJMO s podporou Starostů a nezávislých a Moravského zemského hnutí",
       "type": "party",
       "description": "PRO ZNOJMO s podporou Starostů a nezávislých a Moravského zemského hnutí - DESCRIPTION",
+      "img_url": "stan-mzh-nk",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/proznojmo"
       },
       "parties": [
         {
-          "id": "komunalni-2022-593711-677775-party",
+          "id": "komunalni-2022-593711-c-677775-p",
           "name": "PRO ZNOJMO s podporou Starostů a nezávislých a Moravského zemského hnutí",
           "description": "PRO ZNOJMO s podporou Starostů a nezávislých a Moravského zemského hnutí - DESCRIPTION",
           "contacts": {
@@ -569,16 +579,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-593711-candidate-531306",
+      "id": "komunalni-2022-593711-c-531306",
       "name": "Naše Znojmo",
       "type": "party",
       "description": "Naše Znojmo - DESCRIPTION",
+      "img_url": "som-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-593711-531306-party",
+          "id": "komunalni-2022-593711-c-531306-p",
           "name": "Naše Znojmo",
           "description": "Naše Znojmo - DESCRIPTION",
           "contacts": {
@@ -589,10 +600,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-593711-candidate-132801",
+      "id": "komunalni-2022-593711-c-132801",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": [
           {
@@ -608,7 +620,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-593711-132801-party",
+          "id": "komunalni-2022-593711-c-132801-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -629,16 +641,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-593711-candidate-186364",
+      "id": "komunalni-2022-593711-c-186364",
       "name": "DOMOV",
       "type": "party",
       "description": "DOMOV - DESCRIPTION",
+      "img_url": "domov",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-593711-186364-party",
+          "id": "komunalni-2022-593711-c-186364-p",
           "name": "DOMOV",
           "description": "DOMOV - DESCRIPTION",
           "contacts": {
@@ -651,316 +664,649 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-593711-answer-531306-1",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-1",
+      "id": "komunalni-2022-593711-a-4",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-2",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-2",
+      "id": "komunalni-2022-593711-a-7",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-2",
       "answer": "yes",
       "comment": "Zároveň musí poskytnout slevu obyvatelům, kteří to potřebují."
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-3",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-3",
+      "id": "komunalni-2022-593711-a-10",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-4",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-4",
+      "id": "komunalni-2022-593711-a-13",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-4",
       "answer": "no",
       "comment": "pouze v hustě zastavěných oblastech. Na běžných komunikacích ne."
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-5",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-5",
+      "id": "komunalni-2022-593711-a-16",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-6",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-6",
+      "id": "komunalni-2022-593711-a-19",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-7",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-7",
+      "id": "komunalni-2022-593711-a-22",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-8",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-8",
+      "id": "komunalni-2022-593711-a-25",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-8",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-9",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-9",
+      "id": "komunalni-2022-593711-a-28",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-10",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-10",
+      "id": "komunalni-2022-593711-a-31",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-10",
       "answer": "yes",
       "comment": "již jsme zavedli"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-11",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-11",
+      "id": "komunalni-2022-593711-a-34",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-11",
       "answer": "yes",
       "comment": "již se hlasuje jmenovitě"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-12",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-12",
+      "id": "komunalni-2022-593711-a-37",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-13",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-13",
+      "id": "komunalni-2022-593711-a-40",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-13",
       "answer": "no",
       "comment": "město se o své občany musí postarat jinou formou"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-14",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-14",
+      "id": "komunalni-2022-593711-a-43",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-14",
       "answer": "no",
       "comment": "většina osvětlení je moderního typu s velmi nízkou spotřebou. záleží na vývoji cen."
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-15",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-15",
+      "id": "komunalni-2022-593711-a-46",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-15",
       "answer": "no",
       "comment": "jde o otázku bezpečnosti. veřejné osvětlení se navíc postupně modernizuje za účelem snížení spotřeby."
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-16",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-16",
+      "id": "komunalni-2022-593711-a-49",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-16",
       "answer": "yes",
       "comment": "v budovách úřadu a kulturních domech pokud v nich neprobíhá žádná akce"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-17",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-17",
+      "id": "komunalni-2022-593711-a-52",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-17",
       "answer": "yes",
       "comment": "děti nemohou za chyby svých rodičů. nemají vstupovat do plnoletosti s trestem a znevýhodněním za své rodiče."
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-18",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-18",
+      "id": "komunalni-2022-593711-a-55",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-19",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-19",
+      "id": "komunalni-2022-593711-a-58",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-19",
       "answer": "yes",
       "comment": "již probíhá v participativním rozpočtu Tvoříme Znojmo"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-20",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-20",
+      "id": "komunalni-2022-593711-a-61",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-20",
       "answer": "yes",
       "comment": "tím se docílí nižší ceny nájemného na celém trhu"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-21",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-21",
+      "id": "komunalni-2022-593711-a-64",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-21",
       "answer": "no",
       "comment": "osvětlení je moderního typu s nízkou spotřebou."
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-22",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-22",
+      "id": "komunalni-2022-593711-a-67",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-22",
       "answer": "yes",
       "comment": "pokud si to rodina nemůže dovolit"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-23",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-23",
+      "id": "komunalni-2022-593711-a-70",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-24",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-24",
+      "id": "komunalni-2022-593711-a-73",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-24",
       "answer": "no",
       "comment": "při parkování musí být zvýhodněni občané města"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-25",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-25",
+      "id": "komunalni-2022-593711-a-76",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-26",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-26",
+      "id": "komunalni-2022-593711-a-79",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-27",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-27",
+      "id": "komunalni-2022-593711-a-82",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-27",
       "answer": "no",
       "comment": "hromadnou a pěší dopravu ano. cyklistická má být rovnocenou alternativou."
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-28",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-28",
+      "id": "komunalni-2022-593711-a-85",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-29",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-29",
+      "id": "komunalni-2022-593711-a-88",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-30",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-30",
+      "id": "komunalni-2022-593711-a-91",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-30",
       "answer": "yes",
       "comment": "z dotací"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-31",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-31",
+      "id": "komunalni-2022-593711-a-94",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-32",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-32",
+      "id": "komunalni-2022-593711-a-97",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-33",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-33",
+      "id": "komunalni-2022-593711-a-100",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-34",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-34",
+      "id": "komunalni-2022-593711-a-103",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-35",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-35",
+      "id": "komunalni-2022-593711-a-106",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-36",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-36",
+      "id": "komunalni-2022-593711-a-109",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-37",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-37",
+      "id": "komunalni-2022-593711-a-112",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-38",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-38",
+      "id": "komunalni-2022-593711-a-115",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-38",
       "comment": "záleží na formě podpory"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-39",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-39",
+      "id": "komunalni-2022-593711-a-118",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-40",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-40",
+      "id": "komunalni-2022-593711-a-121",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-41",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-41",
+      "id": "komunalni-2022-593711-a-124",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-42",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-42",
+      "id": "komunalni-2022-593711-a-127",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-43",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-43",
+      "id": "komunalni-2022-593711-a-130",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-43",
       "answer": "yes",
       "comment": "v přiměřené výši."
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-44",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-44",
+      "id": "komunalni-2022-593711-a-133",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-44",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-45",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-45",
+      "id": "komunalni-2022-593711-a-136",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-45",
       "answer": "yes",
       "comment": "zejména děti v oblasti školství."
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-46",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-46",
+      "id": "komunalni-2022-593711-a-139",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-47",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-47",
+      "id": "komunalni-2022-593711-a-142",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-47",
       "answer": "no",
       "comment": "není možné rozřazovat děti do škol podle výše příjmů jejich rodičů"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-48",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-48",
+      "id": "komunalni-2022-593711-a-145",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-593711-answer-531306-49",
-      "candidate_id": "komunalni-2022-593711-candidate-531306",
-      "question_id": "komunalni-2022-593711-question-49"
+      "id": "komunalni-2022-593711-a-148",
+      "candidate_id": "komunalni-2022-593711-c-531306",
+      "question_id": "komunalni-2022-593711-q-49"
+    },
+    {
+      "id": "komunalni-2022-593711-a-4",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-1",
+      "answer": "no",
+      "comment": "Chceme bránit gentrifikaci. Města jsou místem společenské otevřenosti."
+    },
+    {
+      "id": "komunalni-2022-593711-a-7",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-2",
+      "answer": "yes",
+      "comment": "Poplatek za svoz komunálního odpadu lze nahradit případnou vyšší sazbou daně z nemovitosti, avšak český právní řád tomuto řešení moc nenahrává."
+    },
+    {
+      "id": "komunalni-2022-593711-a-10",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-3",
+      "answer": "no",
+      "comment": "Úspora snížením vytápění DPS je vyloženě nevhodná."
+    },
+    {
+      "id": "komunalni-2022-593711-a-13",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-4",
+      "comment": "V rezidentních obalstech by rychlost 30 kmh měla být standartní. Míst, kde by ve Znojmě dávalo omezení rychlosti aktuálně smysl je už poměrně málo.  "
+    },
+    {
+      "id": "komunalni-2022-593711-a-16",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-593711-a-19",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-6",
+      "answer": "no",
+      "comment": "Je třeba nalézt hranici mezi svobodou a bezpečností. Domníváme se, že ve Znojmě je kamer již dostatek."
+    },
+    {
+      "id": "komunalni-2022-593711-a-22",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-593711-a-25",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-8",
+      "answer": "no",
+      "comment": "Městská hromadná doprava by měla mít cenově dostupné předplatní jízdné, ale jízdné zdarma by bylo příliš nákaldné a velmi složitě by se to v rámci IDS JmK implementovalo. Navíc by přínos nebyl odpovídající nákladům."
+    },
+    {
+      "id": "komunalni-2022-593711-a-28",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-593711-a-31",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-10",
+      "answer": "yes",
+      "comment": "Již je implementováno, ale poměrně složitě se to vyhledává. Město by to mělo poskytovat v uživatelsky přívětivé formě."
+    },
+    {
+      "id": "komunalni-2022-593711-a-34",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-11",
+      "answer": "yes",
+      "comment": "Město tuto informaci nepsokytuje automaticky, je velmi složité se k této informaci dostat."
+    },
+    {
+      "id": "komunalni-2022-593711-a-37",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-12",
+      "answer": "yes",
+      "comment": "Ve Znojmě je již zakázáno."
+    },
+    {
+      "id": "komunalni-2022-593711-a-40",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-13",
+      "answer": "yes",
+      "comment": "S dovětkem - pokud to bude potřeba. V základu by měly potřeby (např. pro lidi bez domova) pokrýt již fungující sociální služby."
+    },
+    {
+      "id": "komunalni-2022-593711-a-43",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-14",
+      "answer": "yes",
+      "comment": "Je to jedna z nejlogičtějších a nejjednodušších úspor v současné době."
+    },
+    {
+      "id": "komunalni-2022-593711-a-46",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-593711-a-49",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-16",
+      "answer": "no",
+      "comment": "Určitě lze vytápět na nižší teplotu, ale je třeba zachovat rozumný komfort pro úředníky i občany, kteří na úřad dorazí. Omezení vytápění by vedlo spíše k vyšší nemocnosti a celkově tedy horším službám."
+    },
+    {
+      "id": "komunalni-2022-593711-a-52",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-17",
+      "answer": "yes",
+      "comment": "To už je ve Znojmě provedeno."
+    },
+    {
+      "id": "komunalni-2022-593711-a-55",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-593711-a-58",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-19",
+      "answer": "yes",
+      "comment": "Ve Znojmě je polovičatá implementace, kdy se hlasovaní mohou účastnit i nerezidenti, respketive hlasovat může každý, nejen občan."
+    },
+    {
+      "id": "komunalni-2022-593711-a-61",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-20",
+      "answer": "yes",
+      "comment": "Město by mělo držet výrazný podíl na nájemním trhu a k tomu musí sloužit udržovaný a rozvinutý městský bytový fond."
+    },
+    {
+      "id": "komunalni-2022-593711-a-64",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-21",
+      "answer": "yes",
+      "comment": "Bude-li třeba hledat úspory, je třeba uspořit tam, kde to neovlivňuje poskytování základních městkých služeb."
+    },
+    {
+      "id": "komunalni-2022-593711-a-67",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-22",
+      "comment": "Plošné obědy zdarma by byly pro městský rozpočet nákaldné. Je však zcela zásadní, aby každé dítě mělo možnost obědvat ve školní jídelně. Podporujeme projekt Obědy do škol, který hradí obědy pro děti, jejích rodiče si školní obědy nemohou dovolit."
+    },
+    {
+      "id": "komunalni-2022-593711-a-70",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-23",
+      "answer": "yes",
+      "comment": "Ve Znojmě carshareingový projekt rozhodně chybí. Ve městě je spousta obyvatel, kteří vůz užívájí sporadicky a pokud budou mít adekvátní alternativu, tak si auto nebudou nadále vydržovat a dojde tím pádem k uvolnění veřejného prostoru.  "
+    },
+    {
+      "id": "komunalni-2022-593711-a-73",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-24",
+      "answer": "no",
+      "comment": "Pakrovací zóny výrazně usnadňují parkování pro bydlící a proto vznik parkovacích zón, za splnění podmínyk vybudování P+R parkovišť, podporujeme."
+    },
+    {
+      "id": "komunalni-2022-593711-a-76",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-25",
+      "answer": "no",
+      "comment": "Městký bytový fond má růst, nikoliv se ztenčovat."
+    },
+    {
+      "id": "komunalni-2022-593711-a-79",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-26",
+      "answer": "yes",
+      "comment": "Město a develeper mají být partneři, kteří spolu utváří budoucí podobu města. Součástí tohoto parnerství musí být develeperská smlouva, která město i developera zaváže k podílu na budování veřejné infrastruktury. "
+    },
+    {
+      "id": "komunalni-2022-593711-a-82",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-27",
+      "answer": "yes",
+      "comment": "Pokud se má zklidnit automobilová doprava a vytvořit přívětivější město, tak musí být prvně vybudovány adekvátní alternativy."
+    },
+    {
+      "id": "komunalni-2022-593711-a-85",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-28",
+      "comment": "Tohle nelze dle současných zákonů z pozice města řešit. "
+    },
+    {
+      "id": "komunalni-2022-593711-a-88",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-29",
+      "answer": "yes",
+      "comment": "Obecně je třeba, aby Znojmo začalo s developery lépe jednat. Nesmí to skončit u prodeje pozemku, to má být jen začátek spolupráce."
+    },
+    {
+      "id": "komunalni-2022-593711-a-91",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-30",
+      "answer": "yes",
+      "comment": "Elektromobilita je poměrně zásadní prvek v rámci odchodu od fosilních zdrojů."
+    },
+    {
+      "id": "komunalni-2022-593711-a-94",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-31",
+      "answer": "yes",
+      "comment": "V rámci podpory výstavby by město nemělo upřednostňovat jednu formu před jinou. Cílem je, aby ve městě bylo dostupné bydlení."
+    },
+    {
+      "id": "komunalni-2022-593711-a-97",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-32",
+      "answer": "yes",
+      "comment": "Má to pozitivní aspekt z hlediska zvyku na používání veřejné dopravy a zároveň se tím zabrání zbytečným pokutam pro mladistvé."
+    },
+    {
+      "id": "komunalni-2022-593711-a-100",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-33",
+      "answer": "yes",
+      "comment": "Město má pomoci vlastníkům nejen bytových domů. Město by mělo pomoci s instalací FVE obecně."
+    },
+    {
+      "id": "komunalni-2022-593711-a-103",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-34",
+      "answer": "yes",
+      "comment": "Vstupné by mělo mít motivační charakter."
+    },
+    {
+      "id": "komunalni-2022-593711-a-106",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-35",
+      "answer": "yes",
+      "comment": "Menstruační pomůcky by měly být brány jako standartní součást toalet, stejně jako mýdlo či toaletní papír."
+    },
+    {
+      "id": "komunalni-2022-593711-a-109",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-36",
+      "answer": "no",
+      "comment": "Nemyslíme si, že to je povinnost, která by měla být ukládána zákonem. Ne všechny mravní normy musí být překlopeny v zákon."
+    },
+    {
+      "id": "komunalni-2022-593711-a-112",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-37",
+      "answer": "yes",
+      "comment": "Je zásadní chybou, že v tomto směru město zaspalo. FVE už měly být všude, kde to dává smysl a kde to památkáři dovolí."
+    },
+    {
+      "id": "komunalni-2022-593711-a-115",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-38",
+      "answer": "no",
+      "comment": "Elektrokoloběžky jsou součástí dopravního mixu, ale dost často bývají nebezpečné svým uživatelům a navíc \"koloběžkáři\" dost často jezdí tam, kde nemají. Z hlediska alternativ je prioritní cyklodoprava."
+    },
+    {
+      "id": "komunalni-2022-593711-a-118",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-39",
+      "answer": "yes",
+      "comment": "Město by mělo aktivně podporavat integraci nejen cizinců, ale obecně by mělo podporavat integraci všech sociálně vyloučených."
+    },
+    {
+      "id": "komunalni-2022-593711-a-121",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-40",
+      "answer": "no",
+      "comment": "Počet strážníků považujeme za dostatečný."
+    },
+    {
+      "id": "komunalni-2022-593711-a-124",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-41",
+      "answer": "yes",
+      "comment": "Zelené střechy jsou jedním z důležitých nástrojů městské adaptace na klimatickou změnu."
+    },
+    {
+      "id": "komunalni-2022-593711-a-127",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-42",
+      "answer": "yes",
+      "comment": "Cílem města je dosáhnout zklidnění automobilové dopravy."
+    },
+    {
+      "id": "komunalni-2022-593711-a-130",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-43",
+      "comment": "V omezené míře je to součást reprezentace města."
+    },
+    {
+      "id": "komunalni-2022-593711-a-133",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-44",
+      "answer": "no",
+      "comment": "Nižší daň z nemovitosti už ve Znojmě ex lege být nemůže."
+    },
+    {
+      "id": "komunalni-2022-593711-a-136",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-45",
+      "answer": "yes",
+      "comment": "Město by mělo aktivněji vystupovat v rámci sociálích otázek a pomoci tam, kde selhává státní sociální politika."
+    },
+    {
+      "id": "komunalni-2022-593711-a-139",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-46",
+      "answer": "yes",
+      "comment": "Město potřebuje mít silný bytový fond, aby udrželo dostupné bydlení."
+    },
+    {
+      "id": "komunalni-2022-593711-a-142",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-47",
+      "answer": "yes",
+      "comment": "Shromažďování sociálně znevýhodněných dětí v jedné škole zásadně ovlivňuje jejich pozdější život, dochází k přenosu nevhodných návyků a z toho plynoucích dalších negativních jevů (toxikomanie, kriminalita)."
+    },
+    {
+      "id": "komunalni-2022-593711-a-145",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-48",
+      "answer": "yes",
+      "comment": "Podpora předškolního zařízení pro předškolní od 2 let věku je důležitou součástí prorodinné politiky."
+    },
+    {
+      "id": "komunalni-2022-593711-a-148",
+      "candidate_id": "komunalni-2022-593711-c-132801",
+      "question_id": "komunalni-2022-593711-q-49",
+      "comment": "Chybí Vám tu otázky přímo pro Znojmo, jako je: poporujete stavbu parkovacího domu, rekonstrukci Hroního náměstí a tak. Do budoucna individualizovat. A mail Vám padá do SPAMu."
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/598003.json
+++ b/data/kalkulacka/komunalni-2022/598003.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-598003",
   "name": "Frýdek-Místek",
-  "description": "Frýdek-Místek - DESCRIPTION",
+  "description": "Frýdek-Místek",
   "district_code": "598003",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-598003-question-1",
+      "id": "komunalni-2022-598003-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-2",
+      "id": "komunalni-2022-598003-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-3",
+      "id": "komunalni-2022-598003-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-4",
+      "id": "komunalni-2022-598003-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-5",
+      "id": "komunalni-2022-598003-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-6",
+      "id": "komunalni-2022-598003-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-7",
+      "id": "komunalni-2022-598003-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-8",
+      "id": "komunalni-2022-598003-q-8",
       "name": "MHD zdarma",
       "title": "Měla by zůstat městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-9",
+      "id": "komunalni-2022-598003-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-10",
+      "id": "komunalni-2022-598003-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-11",
+      "id": "komunalni-2022-598003-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-12",
+      "id": "komunalni-2022-598003-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-13",
+      "id": "komunalni-2022-598003-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-14",
+      "id": "komunalni-2022-598003-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-15",
+      "id": "komunalni-2022-598003-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-16",
+      "id": "komunalni-2022-598003-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-17",
+      "id": "komunalni-2022-598003-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-18",
+      "id": "komunalni-2022-598003-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-19",
+      "id": "komunalni-2022-598003-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-20",
+      "id": "komunalni-2022-598003-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-21",
+      "id": "komunalni-2022-598003-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-22",
+      "id": "komunalni-2022-598003-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-23",
+      "id": "komunalni-2022-598003-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-24",
+      "id": "komunalni-2022-598003-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-25",
+      "id": "komunalni-2022-598003-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-26",
+      "id": "komunalni-2022-598003-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-27",
+      "id": "komunalni-2022-598003-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-28",
+      "id": "komunalni-2022-598003-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-29",
+      "id": "komunalni-2022-598003-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-30",
+      "id": "komunalni-2022-598003-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-31",
+      "id": "komunalni-2022-598003-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-32",
+      "id": "komunalni-2022-598003-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "MHD zdarma by měly mít jen děti do 18 let a senioři.",
       "gist": "Zastánci říkají, že by si tím výrazně polepšil městský rozpočet. Odpůrci zavedení placené MHD namítají, že by se zhoršila dopravní situace ve městě.",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-33",
+      "id": "komunalni-2022-598003-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-34",
+      "id": "komunalni-2022-598003-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-35",
+      "id": "komunalni-2022-598003-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-36",
+      "id": "komunalni-2022-598003-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-37",
+      "id": "komunalni-2022-598003-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-38",
+      "id": "komunalni-2022-598003-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-39",
+      "id": "komunalni-2022-598003-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-40",
+      "id": "komunalni-2022-598003-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-41",
+      "id": "komunalni-2022-598003-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-42",
+      "id": "komunalni-2022-598003-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-43",
+      "id": "komunalni-2022-598003-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-44",
+      "id": "komunalni-2022-598003-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-45",
+      "id": "komunalni-2022-598003-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-46",
+      "id": "komunalni-2022-598003-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-47",
+      "id": "komunalni-2022-598003-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-48",
+      "id": "komunalni-2022-598003-q-48",
       "name": "Bydlení především",
       "title": "Podporuji, aby Frýdek-Místek pokračoval v projektu Housing First.",
       "gist": "Projekty Housing First zajišťují stabilní bydlení pro nejohroženější skupinu obyvatel. V Česku díky nim získalo bezpečný domov a podporu sociálních pracovníků více než 700 lidí, z toho 320 dětí. Do projektu se zapojují i další česká i světová města; např. ve Vídni si bydlení udrželo 98 % domácností. Pilotní Brno i přes úspěch i ocenění od projektu postupně ustoupilo. Vedení města argumentovalo vysokými náklady, zastánci projektu ale poukazovali, že je většina výdajů hrazená z fondů EU.",
@@ -395,7 +397,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598003-question-49",
+      "id": "komunalni-2022-598003-q-49",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -405,16 +407,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-598003-candidate-630207",
+      "id": "komunalni-2022-598003-c-630207",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598003-630207-party",
+          "id": "komunalni-2022-598003-c-630207-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -425,10 +428,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-598003-candidate-473858",
+      "id": "komunalni-2022-598003-c-473858",
       "name": "Naše Město F-M",
       "type": "party",
       "description": "Naše Město F-M - DESCRIPTION",
+      "img_url": "nmfm",
       "contacts": {
         "web": [
           {
@@ -440,7 +444,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-598003-473858-party",
+          "id": "komunalni-2022-598003-c-473858-p",
           "name": "Naše Město F-M",
           "description": "Naše Město F-M - DESCRIPTION",
           "contacts": {
@@ -457,17 +461,18 @@
       ]
     },
     {
-      "id": "komunalni-2022-598003-candidate-800798",
+      "id": "komunalni-2022-598003-c-800798",
       "name": "SPOLU - KDU-ČSL, ODS, TOP 09",
       "type": "party",
       "description": "SPOLU - KDU-ČSL, ODS, TOP 09 - DESCRIPTION",
+      "img_url": "kdu-ods-top 09",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/top09fm/"
       },
       "parties": [
         {
-          "id": "komunalni-2022-598003-800798-party",
+          "id": "komunalni-2022-598003-c-800798-p",
           "name": "SPOLU - KDU-ČSL, ODS, TOP 09",
           "description": "SPOLU - KDU-ČSL, ODS, TOP 09 - DESCRIPTION",
           "contacts": {
@@ -479,16 +484,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-598003-candidate-801995",
+      "id": "komunalni-2022-598003-c-801995",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598003-801995-party",
+          "id": "komunalni-2022-598003-c-801995-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -499,16 +505,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-598003-candidate-769376",
+      "id": "komunalni-2022-598003-c-769376",
       "name": "Frýdečané a Místečané",
       "type": "party",
       "description": "Frýdečané a Místečané - DESCRIPTION",
+      "img_url": "fram",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598003-769376-party",
+          "id": "komunalni-2022-598003-c-769376-p",
           "name": "Frýdečané a Místečané",
           "description": "Frýdečané a Místečané - DESCRIPTION",
           "contacts": {
@@ -519,16 +526,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-598003-candidate-866050",
+      "id": "komunalni-2022-598003-c-866050",
       "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
       "type": "party",
       "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+      "img_url": "dsz-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598003-866050-party",
+          "id": "komunalni-2022-598003-c-866050-p",
           "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
           "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
           "contacts": {
@@ -539,16 +547,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-598003-candidate-210291",
+      "id": "komunalni-2022-598003-c-210291",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598003-210291-party",
+          "id": "komunalni-2022-598003-c-210291-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -559,16 +568,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-598003-candidate-876925",
+      "id": "komunalni-2022-598003-c-876925",
       "name": "Přátelé FM",
       "type": "party",
       "description": "Přátelé FM - DESCRIPTION",
+      "img_url": "čssd-„osn“",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598003-876925-party",
+          "id": "komunalni-2022-598003-c-876925-p",
           "name": "Přátelé FM",
           "description": "Přátelé FM - DESCRIPTION",
           "contacts": {
@@ -579,16 +589,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-598003-candidate-246532",
+      "id": "komunalni-2022-598003-c-246532",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598003-246532-party",
+          "id": "komunalni-2022-598003-c-246532-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -601,612 +612,612 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-598003-answer-769376-1",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-1",
+      "id": "komunalni-2022-598003-a-4",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-2",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-2",
+      "id": "komunalni-2022-598003-a-7",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-2",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-3",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-3",
+      "id": "komunalni-2022-598003-a-10",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-4",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-4",
+      "id": "komunalni-2022-598003-a-13",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-5",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-5",
+      "id": "komunalni-2022-598003-a-16",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-6",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-6"
+      "id": "komunalni-2022-598003-a-19",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-6"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-7",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-7",
+      "id": "komunalni-2022-598003-a-22",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-8",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-8",
+      "id": "komunalni-2022-598003-a-25",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-8",
       "answer": "no",
       "comment": "Při současné inflaci a narůstání nákladů je třeba určit strop dotace na MHD"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-9",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-9",
+      "id": "komunalni-2022-598003-a-28",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-10",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-10",
+      "id": "komunalni-2022-598003-a-31",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-11",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-11",
+      "id": "komunalni-2022-598003-a-34",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-12",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-12",
+      "id": "komunalni-2022-598003-a-37",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-13",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-13",
+      "id": "komunalni-2022-598003-a-40",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-14",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-14",
+      "id": "komunalni-2022-598003-a-43",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-15",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-15",
+      "id": "komunalni-2022-598003-a-46",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-15",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-16",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-16",
+      "id": "komunalni-2022-598003-a-49",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-16",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-17",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-17",
+      "id": "komunalni-2022-598003-a-52",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-18",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-18",
+      "id": "komunalni-2022-598003-a-55",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-19",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-19",
+      "id": "komunalni-2022-598003-a-58",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-20",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-20",
+      "id": "komunalni-2022-598003-a-61",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-20",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-21",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-21",
+      "id": "komunalni-2022-598003-a-64",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-22",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-22",
+      "id": "komunalni-2022-598003-a-67",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-22",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-23",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-23"
+      "id": "komunalni-2022-598003-a-70",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-23"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-24",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-24",
+      "id": "komunalni-2022-598003-a-73",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-25",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-25",
+      "id": "komunalni-2022-598003-a-76",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-25",
       "answer": "yes",
       "comment": "Je třeba si určit, kolik bytů má zůstat ve vlastnictví města."
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-26",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-26",
+      "id": "komunalni-2022-598003-a-79",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-27",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-27",
+      "id": "komunalni-2022-598003-a-82",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-28",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-28"
+      "id": "komunalni-2022-598003-a-85",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-28"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-29",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-29",
+      "id": "komunalni-2022-598003-a-88",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-30",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-30"
+      "id": "komunalni-2022-598003-a-91",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-30"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-31",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-31",
+      "id": "komunalni-2022-598003-a-94",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-32",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-32"
+      "id": "komunalni-2022-598003-a-97",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-32"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-33",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-33",
+      "id": "komunalni-2022-598003-a-100",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-34",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-34",
+      "id": "komunalni-2022-598003-a-103",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-35",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-35"
+      "id": "komunalni-2022-598003-a-106",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-35"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-36",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-36",
+      "id": "komunalni-2022-598003-a-109",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-37",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-37"
+      "id": "komunalni-2022-598003-a-112",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-37"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-38",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-38"
+      "id": "komunalni-2022-598003-a-115",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-38"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-39",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-39",
+      "id": "komunalni-2022-598003-a-118",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-40",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-40",
+      "id": "komunalni-2022-598003-a-121",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-40",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-41",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-41",
+      "id": "komunalni-2022-598003-a-124",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-41",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-42",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-42",
+      "id": "komunalni-2022-598003-a-127",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-43",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-43"
+      "id": "komunalni-2022-598003-a-130",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-43"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-44",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-44",
+      "id": "komunalni-2022-598003-a-133",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-45",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-45",
+      "id": "komunalni-2022-598003-a-136",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-45",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-46",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-46",
+      "id": "komunalni-2022-598003-a-139",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-47",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-47",
+      "id": "komunalni-2022-598003-a-142",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-48",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-48"
+      "id": "komunalni-2022-598003-a-145",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-48"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-49",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-49",
+      "id": "komunalni-2022-598003-a-148",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-769376-50",
-      "candidate_id": "komunalni-2022-598003-candidate-769376",
-      "question_id": "komunalni-2022-598003-question-50",
+      "id": "komunalni-2022-598003-a-151",
+      "candidate_id": "komunalni-2022-598003-c-769376",
+      "question_id": "komunalni-2022-598003-q-50",
       "comment": "Otázky jsou často nepřesné, některé si \"konkurují\", mnohé nesedí do našeho města."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-1",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-1",
+      "id": "komunalni-2022-598003-a-4",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-2",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-2",
+      "id": "komunalni-2022-598003-a-7",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-2",
       "answer": "yes",
       "comment": "Dle zásady: čím lépe třídím a méně odpadu produkuji, tím méně platím."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-3",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-3",
+      "id": "komunalni-2022-598003-a-10",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-4",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-4"
+      "id": "komunalni-2022-598003-a-13",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-4"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-5",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-5",
+      "id": "komunalni-2022-598003-a-16",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-6",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-6",
+      "id": "komunalni-2022-598003-a-19",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-6",
       "answer": "no",
       "comment": "Město již má dostatečně rozsáhlý kamerový systém."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-7",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-7",
+      "id": "komunalni-2022-598003-a-22",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-8",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-8",
+      "id": "komunalni-2022-598003-a-25",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-8",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-9",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-9",
+      "id": "komunalni-2022-598003-a-28",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-10",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-10",
+      "id": "komunalni-2022-598003-a-31",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-11",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-11",
+      "id": "komunalni-2022-598003-a-34",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-11",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-12",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-12",
+      "id": "komunalni-2022-598003-a-37",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-13",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-13",
+      "id": "komunalni-2022-598003-a-40",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-13",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-14",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-14",
+      "id": "komunalni-2022-598003-a-43",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-14",
       "answer": "no",
       "comment": "Zatím to není nutné, ale taková situace samozřejmě může nastat."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-15",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-15",
+      "id": "komunalni-2022-598003-a-46",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-15",
       "answer": "yes",
       "comment": "V některých částech města a nočních hodinách."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-16",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-16",
+      "id": "komunalni-2022-598003-a-49",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-16",
       "answer": "no",
       "comment": "V souladu s případným vládním nařízením, bude-li to nutné."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-17",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-17",
+      "id": "komunalni-2022-598003-a-52",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-18",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-18",
+      "id": "komunalni-2022-598003-a-55",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-18",
       "answer": "yes",
       "comment": "Klikací položkový rozpočet máme v programu."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-19",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-19",
+      "id": "komunalni-2022-598003-a-58",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-19",
       "answer": "yes",
       "comment": "Participativní rozpočet jsme již zavedli a chceme participace více uplatňovat i v dalších oblastech."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-20",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-20",
+      "id": "komunalni-2022-598003-a-61",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-20",
       "answer": "yes",
       "comment": "Rozšiřování bytového fondu je jednou z našich programových priorit."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-21",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-21",
+      "id": "komunalni-2022-598003-a-64",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-21",
       "answer": "no",
       "comment": "Zatím to není nutné, může to ale nastat."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-22",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-22",
+      "id": "komunalni-2022-598003-a-67",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-22",
       "answer": "no",
       "comment": "Město by mělo přispívat na obědy dětem ze sociálně slabších rodin."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-23",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-23",
+      "id": "komunalni-2022-598003-a-70",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-23",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-24",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-24",
+      "id": "komunalni-2022-598003-a-73",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-24",
       "answer": "no",
       "comment": "Parkovací zóny naopak zavádíme."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-25",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-25",
+      "id": "komunalni-2022-598003-a-76",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-26",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-26",
+      "id": "komunalni-2022-598003-a-79",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-27",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-27",
+      "id": "komunalni-2022-598003-a-82",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-27",
       "answer": "no",
       "comment": "Město má podporovat všech výše uvedené způsoby dopravy."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-28",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-28",
+      "id": "komunalni-2022-598003-a-85",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-29",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-29",
+      "id": "komunalni-2022-598003-a-88",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-30",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-30",
+      "id": "komunalni-2022-598003-a-91",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-31",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-31",
+      "id": "komunalni-2022-598003-a-94",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-32",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-32",
+      "id": "komunalni-2022-598003-a-97",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-32",
       "answer": "no",
       "comment": "V programu máme zachování MHD zdarma pro všechny obyvatele města."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-33",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-33",
+      "id": "komunalni-2022-598003-a-100",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-33",
       "answer": "yes",
       "comment": "Máme v programu dotačních program na podporu fotovoltaiky na střechách."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-34",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-34",
+      "id": "komunalni-2022-598003-a-103",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-34",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-35",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-35",
+      "id": "komunalni-2022-598003-a-106",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-35",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-36",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-36"
+      "id": "komunalni-2022-598003-a-109",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-36"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-37",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-37",
+      "id": "komunalni-2022-598003-a-112",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-37",
       "answer": "yes",
       "comment": "Ano, máme v programu."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-38",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-38",
+      "id": "komunalni-2022-598003-a-115",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-38",
       "comment": "Podporujeme zejména elektrokola a cargo kola."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-39",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-39",
+      "id": "komunalni-2022-598003-a-118",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-40",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-40",
+      "id": "komunalni-2022-598003-a-121",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-40",
       "answer": "no",
       "comment": "Kvóta je dostatečná, jen se dlouhodobě nedaří najít dostatek vhodných kandidátů k obsazení volných míst."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-41",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-41",
+      "id": "komunalni-2022-598003-a-124",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-41",
       "answer": "yes",
       "comment": "Ano, máme v programu zavedení dotačního programu."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-42",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-42",
+      "id": "komunalni-2022-598003-a-127",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-42",
       "answer": "yes",
       "comment": "Město ji podporuje tím, že rozvíjí cykloinfrastrukturu. "
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-43",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-43",
+      "id": "komunalni-2022-598003-a-130",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-44",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-44",
+      "id": "komunalni-2022-598003-a-133",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-44",
       "answer": "no",
       "comment": "V našem měste je nejnižší možný koeficient."
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-45",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-45",
+      "id": "komunalni-2022-598003-a-136",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-45",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-46",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-46",
+      "id": "komunalni-2022-598003-a-139",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-47",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-47",
+      "id": "komunalni-2022-598003-a-142",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-48",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-48",
+      "id": "komunalni-2022-598003-a-145",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-49",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-49",
+      "id": "komunalni-2022-598003-a-148",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598003-answer-210291-50",
-      "candidate_id": "komunalni-2022-598003-candidate-210291",
-      "question_id": "komunalni-2022-598003-question-50"
+      "id": "komunalni-2022-598003-a-151",
+      "candidate_id": "komunalni-2022-598003-c-210291",
+      "question_id": "komunalni-2022-598003-q-50"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/598810.json
+++ b/data/kalkulacka/komunalni-2022/598810.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-598810",
   "name": "Třinec",
-  "description": "Třinec - DESCRIPTION",
+  "description": "Třinec",
   "district_code": "598810",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-598810-question-1",
+      "id": "komunalni-2022-598810-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-2",
+      "id": "komunalni-2022-598810-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-3",
+      "id": "komunalni-2022-598810-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-4",
+      "id": "komunalni-2022-598810-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-5",
+      "id": "komunalni-2022-598810-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-6",
+      "id": "komunalni-2022-598810-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-7",
+      "id": "komunalni-2022-598810-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-8",
+      "id": "komunalni-2022-598810-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-9",
+      "id": "komunalni-2022-598810-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-10",
+      "id": "komunalni-2022-598810-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-11",
+      "id": "komunalni-2022-598810-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-12",
+      "id": "komunalni-2022-598810-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-13",
+      "id": "komunalni-2022-598810-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-14",
+      "id": "komunalni-2022-598810-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-15",
+      "id": "komunalni-2022-598810-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-16",
+      "id": "komunalni-2022-598810-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-17",
+      "id": "komunalni-2022-598810-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-18",
+      "id": "komunalni-2022-598810-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-19",
+      "id": "komunalni-2022-598810-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-20",
+      "id": "komunalni-2022-598810-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-21",
+      "id": "komunalni-2022-598810-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-22",
+      "id": "komunalni-2022-598810-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-23",
+      "id": "komunalni-2022-598810-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-24",
+      "id": "komunalni-2022-598810-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-25",
+      "id": "komunalni-2022-598810-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-26",
+      "id": "komunalni-2022-598810-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-27",
+      "id": "komunalni-2022-598810-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-28",
+      "id": "komunalni-2022-598810-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-29",
+      "id": "komunalni-2022-598810-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-30",
+      "id": "komunalni-2022-598810-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-31",
+      "id": "komunalni-2022-598810-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-32",
+      "id": "komunalni-2022-598810-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-33",
+      "id": "komunalni-2022-598810-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-34",
+      "id": "komunalni-2022-598810-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-35",
+      "id": "komunalni-2022-598810-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-36",
+      "id": "komunalni-2022-598810-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-37",
+      "id": "komunalni-2022-598810-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-38",
+      "id": "komunalni-2022-598810-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-39",
+      "id": "komunalni-2022-598810-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-40",
+      "id": "komunalni-2022-598810-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-41",
+      "id": "komunalni-2022-598810-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-42",
+      "id": "komunalni-2022-598810-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-43",
+      "id": "komunalni-2022-598810-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-44",
+      "id": "komunalni-2022-598810-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-45",
+      "id": "komunalni-2022-598810-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-46",
+      "id": "komunalni-2022-598810-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-47",
+      "id": "komunalni-2022-598810-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-48",
+      "id": "komunalni-2022-598810-q-48",
       "name": "Bydlení především",
       "title": "Podporuji, aby Třinec pokračoval v projektu Housing First.",
       "gist": "Projekty Housing First zajišťují stabilní bydlení pro nejohroženější skupinu obyvatel. V Česku díky nim získalo bezpečný domov a podporu sociálních pracovníků více než 700 lidí, z toho 320 dětí. Do projektu se zapojují i další česká i světová města; např. ve Vídni si bydlení udrželo 98 % domácností. Pilotní Brno i přes úspěch i ocenění od projektu postupně ustoupilo. Vedení města argumentovalo vysokými náklady, zastánci projektu ale poukazovali, že je většina výdajů hrazená z fondů EU.",
@@ -395,7 +397,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598810-question-49",
+      "id": "komunalni-2022-598810-q-49",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -405,16 +407,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-598810-candidate-693283",
+      "id": "komunalni-2022-598810-c-693283",
       "name": "SPOLEČNĚ PRO TŘINEC",
       "type": "party",
       "description": "SPOLEČNĚ PRO TŘINEC - DESCRIPTION",
+      "img_url": "ods-top 09",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598810-693283-party",
+          "id": "komunalni-2022-598810-c-693283-p",
           "name": "SPOLEČNĚ PRO TŘINEC",
           "description": "SPOLEČNĚ PRO TŘINEC - DESCRIPTION",
           "contacts": {
@@ -425,10 +428,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-598810-candidate-395216",
+      "id": "komunalni-2022-598810-c-395216",
       "name": "NEZÁVISLÍ",
       "type": "party",
       "description": "NEZÁVISLÍ - DESCRIPTION",
+      "img_url": "nez",
       "contacts": {
         "web": [
           {
@@ -440,7 +444,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-598810-395216-party",
+          "id": "komunalni-2022-598810-c-395216-p",
           "name": "NEZÁVISLÍ",
           "description": "NEZÁVISLÍ - DESCRIPTION",
           "contacts": {
@@ -457,16 +461,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-598810-candidate-308831",
+      "id": "komunalni-2022-598810-c-308831",
       "name": "OSOBNOSTI PRO TŘINEC",
       "type": "party",
       "description": "OSOBNOSTI PRO TŘINEC - DESCRIPTION",
+      "img_url": "stan-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598810-308831-party",
+          "id": "komunalni-2022-598810-c-308831-p",
           "name": "OSOBNOSTI PRO TŘINEC",
           "description": "OSOBNOSTI PRO TŘINEC - DESCRIPTION",
           "contacts": {
@@ -477,16 +482,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-598810-candidate-868351",
+      "id": "komunalni-2022-598810-c-868351",
       "name": "ČSSD a nezávislí kandidáti",
       "type": "party",
       "description": "ČSSD a nezávislí kandidáti - DESCRIPTION",
+      "img_url": "čssd-nk",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598810-868351-party",
+          "id": "komunalni-2022-598810-c-868351-p",
           "name": "ČSSD a nezávislí kandidáti",
           "description": "ČSSD a nezávislí kandidáti - DESCRIPTION",
           "contacts": {
@@ -497,16 +503,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-598810-candidate-666483",
+      "id": "komunalni-2022-598810-c-666483",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598810-666483-party",
+          "id": "komunalni-2022-598810-c-666483-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -517,10 +524,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-598810-candidate-929291",
+      "id": "komunalni-2022-598810-c-929291",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": [
           {
@@ -531,7 +539,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-598810-929291-party",
+          "id": "komunalni-2022-598810-c-929291-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -547,10 +555,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-598810-candidate-982553",
+      "id": "komunalni-2022-598810-c-982553",
       "name": "KDU-ČSL",
       "type": "party",
       "description": "KDU-ČSL - DESCRIPTION",
+      "img_url": "kdu-čsl",
       "contacts": {
         "web": [
           {
@@ -563,7 +572,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-598810-982553-party",
+          "id": "komunalni-2022-598810-c-982553-p",
           "name": "KDU-ČSL",
           "description": "KDU-ČSL - DESCRIPTION",
           "contacts": {
@@ -583,305 +592,612 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-598810-answer-666483-1",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-1",
+      "id": "komunalni-2022-598810-a-4",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-2",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-2",
+      "id": "komunalni-2022-598810-a-7",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-2",
       "answer": "yes",
       "comment": "Je to motivace k tomu aby lidé třídili odpad"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-3",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-3",
+      "id": "komunalni-2022-598810-a-10",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-3",
       "answer": "no",
       "comment": "V žádném případě "
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-4",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-4",
+      "id": "komunalni-2022-598810-a-13",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-4",
       "answer": "no",
       "comment": "Město Třinec není na toto přizpůsobeno "
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-5",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-5",
+      "id": "komunalni-2022-598810-a-16",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-5",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-6",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-6",
+      "id": "komunalni-2022-598810-a-19",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-6",
       "comment": "Potřebovali bychom hlubší analýzu "
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-7",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-7",
+      "id": "komunalni-2022-598810-a-22",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-7",
       "answer": "yes",
       "comment": "Hazard do města nepatří "
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-8",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-8",
+      "id": "komunalni-2022-598810-a-25",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-8",
       "comment": "Určitě zdarma pro děti a seniory"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-9",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-9",
+      "id": "komunalni-2022-598810-a-28",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-9",
       "answer": "no",
       "comment": "Tento problém v Třinci není "
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-10",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-10",
+      "id": "komunalni-2022-598810-a-31",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-11",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-11",
+      "id": "komunalni-2022-598810-a-34",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-12",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-12"
+      "id": "komunalni-2022-598810-a-37",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-12"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-13",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-13",
+      "id": "komunalni-2022-598810-a-40",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-13",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-14",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-14",
+      "id": "komunalni-2022-598810-a-43",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-15",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-15",
+      "id": "komunalni-2022-598810-a-46",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-15",
       "answer": "yes",
       "comment": "Omezit intenzitu v pozdějších hodinách "
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-16",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-16"
+      "id": "komunalni-2022-598810-a-49",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-16"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-17",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-17"
+      "id": "komunalni-2022-598810-a-52",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-17"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-18",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-18",
+      "id": "komunalni-2022-598810-a-55",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-19",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-19",
+      "id": "komunalni-2022-598810-a-58",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-19",
       "answer": "yes",
       "comment": "Vyčlenime na to částku osadním vyborum"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-20",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-20"
+      "id": "komunalni-2022-598810-a-61",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-20"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-21",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-21",
+      "id": "komunalni-2022-598810-a-64",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-22",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-22",
+      "id": "komunalni-2022-598810-a-67",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-22",
       "answer": "no",
       "comment": "Ale nechat tuto možnost pro sociálně slabší "
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-23",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-23",
+      "id": "komunalni-2022-598810-a-70",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-24",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-24",
+      "id": "komunalni-2022-598810-a-73",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-24",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-25",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-25",
+      "id": "komunalni-2022-598810-a-76",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-26",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-26",
+      "id": "komunalni-2022-598810-a-79",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-27",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-27",
+      "id": "komunalni-2022-598810-a-82",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-28",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-28"
+      "id": "komunalni-2022-598810-a-85",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-28"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-29",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-29"
+      "id": "komunalni-2022-598810-a-88",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-29"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-30",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-30",
+      "id": "komunalni-2022-598810-a-91",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-30",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-31",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-31",
+      "id": "komunalni-2022-598810-a-94",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-32",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-32",
+      "id": "komunalni-2022-598810-a-97",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-32",
       "answer": "yes",
       "comment": "Ale jen do 15 let"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-33",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-33"
+      "id": "komunalni-2022-598810-a-100",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-33"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-34",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-34",
+      "id": "komunalni-2022-598810-a-103",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-34",
       "answer": "yes",
       "comment": "Galerie a muzea určitě ano"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-35",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-35",
+      "id": "komunalni-2022-598810-a-106",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-36",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-36",
+      "id": "komunalni-2022-598810-a-109",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-37",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-37",
+      "id": "komunalni-2022-598810-a-112",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-38",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-38",
+      "id": "komunalni-2022-598810-a-115",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-38",
       "answer": "yes",
       "comment": "Jsme po sdílená kola"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-39",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-39",
+      "id": "komunalni-2022-598810-a-118",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-40",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-40",
+      "id": "komunalni-2022-598810-a-121",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-41",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-41",
+      "id": "komunalni-2022-598810-a-124",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-41",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-42",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-42",
+      "id": "komunalni-2022-598810-a-127",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-43",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-43",
+      "id": "komunalni-2022-598810-a-130",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-43",
       "answer": "yes",
       "comment": "Ale jen u dětí a juniorů "
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-44",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-44",
+      "id": "komunalni-2022-598810-a-133",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-44",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-45",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-45"
+      "id": "komunalni-2022-598810-a-136",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-45"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-46",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-46",
+      "id": "komunalni-2022-598810-a-139",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-47",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-47"
+      "id": "komunalni-2022-598810-a-142",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-47"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-48",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-48"
+      "id": "komunalni-2022-598810-a-145",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-48"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-49",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-49",
+      "id": "komunalni-2022-598810-a-148",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-49",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598810-answer-666483-50",
-      "candidate_id": "komunalni-2022-598810-candidate-666483",
-      "question_id": "komunalni-2022-598810-question-50"
+      "id": "komunalni-2022-598810-a-151",
+      "candidate_id": "komunalni-2022-598810-c-666483",
+      "question_id": "komunalni-2022-598810-q-50"
+    },
+    {
+      "id": "komunalni-2022-598810-a-4",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-598810-a-7",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-10",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-598810-a-13",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-4",
+      "answer": "yes",
+      "comment": "Existuje několik míst, kde by zařazení zóny 30 bylo bezpečnější"
+    },
+    {
+      "id": "komunalni-2022-598810-a-16",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-19",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-598810-a-22",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-25",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-598810-a-28",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-31",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-34",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-37",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-12",
+      "answer": "yes",
+      "comment": "Je to ekologicky problematické, ruší noční klid a zvířata."
+    },
+    {
+      "id": "komunalni-2022-598810-a-40",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-43",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-46",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-15",
+      "comment": "Záleží na situaci na trhu s energiemi. Ušetřené peníze by město mohlo vhodněji investovat."
+    },
+    {
+      "id": "komunalni-2022-598810-a-49",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-16",
+      "answer": "yes",
+      "comment": "Např. o 2 stupně."
+    },
+    {
+      "id": "komunalni-2022-598810-a-52",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-55",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-58",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-598810-a-61",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-20",
+      "answer": "yes",
+      "comment": "Je to pro rozvoj Třince zcela zásadní."
+    },
+    {
+      "id": "komunalni-2022-598810-a-64",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-21",
+      "comment": "Záleží na aktuální situaci."
+    },
+    {
+      "id": "komunalni-2022-598810-a-67",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-22",
+      "answer": "no",
+      "comment": "Podpora by měla být cílená na děti ze sociálně slabých rodin."
+    },
+    {
+      "id": "komunalni-2022-598810-a-70",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-73",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-24",
+      "answer": "yes",
+      "comment": "Hlavně na vytížených místech."
+    },
+    {
+      "id": "komunalni-2022-598810-a-76",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-598810-a-79",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-82",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-85",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-88",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-91",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-94",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-31",
+      "answer": "yes",
+      "comment": "Město bude podporovat všechny pro-sociálně orientované projekty zaměřené na bydlení."
+    },
+    {
+      "id": "komunalni-2022-598810-a-97",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-100",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-33",
+      "answer": "yes",
+      "comment": "Ano, formou konzultací, pomoci s projektem, bezúročné půjčky."
+    },
+    {
+      "id": "komunalni-2022-598810-a-103",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-106",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-109",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-598810-a-112",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-115",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-118",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-121",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-124",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-127",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-130",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-598810-a-133",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-598810-a-136",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-139",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-142",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-145",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-148",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-598810-a-151",
+      "candidate_id": "komunalni-2022-598810-c-868351",
+      "question_id": "komunalni-2022-598810-q-50"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/598917.json
+++ b/data/kalkulacka/komunalni-2022/598917.json
@@ -1,17 +1,19 @@
 {
   "id": "komunalni-2022-598917",
   "name": "Karviná",
-  "description": "Karviná - DESCRIPTION",
+  "description": "Karviná",
   "district_code": "598917",
   "election": {
     "id": "komunalni-2022",
     "key": "komunalni-2022",
-    "name": "komunalni-2022",
-    "description": "komunalni-2022"
+    "name": "Komunální volby 2022",
+    "description": "K dispozici je 35 kalkulaček pro největší města.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "komunalni-2022-598917-question-1",
+      "id": "komunalni-2022-598917-q-1",
       "name": "Gentrifikace",
       "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
       "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
@@ -19,7 +21,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-2",
+      "id": "komunalni-2022-598917-q-2",
       "name": "Poplatek za popelnice",
       "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
       "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
@@ -27,7 +29,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-3",
+      "id": "komunalni-2022-598917-q-3",
       "name": "Omezení vytápění",
       "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
       "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
@@ -35,7 +37,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-4",
+      "id": "komunalni-2022-598917-q-4",
       "name": "Zóny 30 km/h",
       "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
       "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
@@ -43,7 +45,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-5",
+      "id": "komunalni-2022-598917-q-5",
       "name": "Milostivé léto",
       "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
       "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
@@ -51,7 +53,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-6",
+      "id": "komunalni-2022-598917-q-6",
       "name": "Více kamer",
       "title": "Měly by být ve městě instalovány další kamery?",
       "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
@@ -59,7 +61,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-7",
+      "id": "komunalni-2022-598917-q-7",
       "name": "Hazard zakázán",
       "title": "Jste pro úplný zákaz hazardu na území města?",
       "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
@@ -67,7 +69,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-8",
+      "id": "komunalni-2022-598917-q-8",
       "name": "MHD zdarma",
       "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
       "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
@@ -75,7 +77,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-9",
+      "id": "komunalni-2022-598917-q-9",
       "name": "Bezbariérové zastávky MHD",
       "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
       "gist": "",
@@ -83,7 +85,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-10",
+      "id": "komunalni-2022-598917-q-10",
       "name": "Jmenovité výsledky hlasování zastupitelstva",
       "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
@@ -91,7 +93,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-11",
+      "id": "komunalni-2022-598917-q-11",
       "name": "Jmenovité výsledky hlasování rady",
       "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
       "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
@@ -99,7 +101,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-12",
+      "id": "komunalni-2022-598917-q-12",
       "name": "Regulace zábavní pyrotechniky",
       "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
       "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
@@ -107,7 +109,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-13",
+      "id": "komunalni-2022-598917-q-13",
       "name": "Přístupné veřejné budovy v chladnu",
       "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
       "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
@@ -115,7 +117,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-14",
+      "id": "komunalni-2022-598917-q-14",
       "name": "Úspora energií – světelná výzdoba",
       "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
       "gist": "",
@@ -123,7 +125,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-15",
+      "id": "komunalni-2022-598917-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
@@ -131,7 +133,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-16",
+      "id": "komunalni-2022-598917-q-16",
       "name": "Úspora energií – omezení vytápění",
       "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
       "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
@@ -139,7 +141,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-17",
+      "id": "komunalni-2022-598917-q-17",
       "name": "Konec dětských exekucí",
       "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
       "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
@@ -147,7 +149,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-18",
+      "id": "komunalni-2022-598917-q-18",
       "name": "Městské transparentní účty",
       "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
       "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
@@ -155,7 +157,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-19",
+      "id": "komunalni-2022-598917-q-19",
       "name": "Participativní rozpočet",
       "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
       "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
@@ -163,7 +165,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-20",
+      "id": "komunalni-2022-598917-q-20",
       "name": "Zvýšení počtu městských bytů",
       "title": "Město by mělo zvyšovat počty bytů ve svém vlastnictví.",
       "gist": "Některá města se snaží o odkup nebo výstavbu bytů do svého vlastnictví. Důvodem mj. je, že se jim nedostává bytů pro lékaře a zdravotní sestry, policisty, učitele či seniory a potřebné. Kritici namítají, že údržba městských bytů zatěžuje rozpočet.",
@@ -171,7 +173,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-21",
+      "id": "komunalni-2022-598917-q-21",
       "name": "Omezení vánoční výzdoby",
       "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
       "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
@@ -179,7 +181,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-22",
+      "id": "komunalni-2022-598917-q-22",
       "name": "Obědy zdarma",
       "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
       "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
@@ -187,7 +189,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-23",
+      "id": "komunalni-2022-598917-q-23",
       "name": "Sdílení aut",
       "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
       "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
@@ -195,7 +197,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-24",
+      "id": "komunalni-2022-598917-q-24",
       "name": "Žádné parkovací zóny",
       "title": "Parkování ve městě má být neomezené parkovacími zónami.",
       "gist": "Zastánci říkají, že zóny placeného státní přinášejí jistotu parkování rezidentům a že odvádějí z města auta, která do něj nezajíždějí, ale zůstávají v okrajových částech. Kritici namítají, že se parkování jen přelévá jinam a auty se zaplňují dříve klidné oblasti města. Vadí také, že zóny rezidentům parkovací místo automaticky nezaručí.",
@@ -203,7 +205,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-25",
+      "id": "komunalni-2022-598917-q-25",
       "name": "Privatizace bytů",
       "title": "Město má privatizovat své byty.",
       "gist": "Podle zastánců přináší privatizace bytů velké finanční prostředky pro město. Kritici chtějí, aby město mohlo s byty nakládat dle vlastního uvážení a potřeb občanů.",
@@ -211,7 +213,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-26",
+      "id": "komunalni-2022-598917-q-26",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
       "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
@@ -219,7 +221,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-27",
+      "id": "komunalni-2022-598917-q-27",
       "name": "Cyklodoprava",
       "title": "Má město upřednostňovat dopravu pěší, cyklistickou a hromadnou před dopravou automobilovou?",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -227,7 +229,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-28",
+      "id": "komunalni-2022-598917-q-28",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -235,7 +237,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-29",
+      "id": "komunalni-2022-598917-q-29",
       "name": "Podíl developerů na veřejných výdajích",
       "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
       "gist": "",
@@ -243,7 +245,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-30",
+      "id": "komunalni-2022-598917-q-30",
       "name": "Dobíjecí místa pro elektromobily",
       "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
       "gist": "",
@@ -251,7 +253,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-31",
+      "id": "komunalni-2022-598917-q-31",
       "name": "Podpora družstevního bydlení",
       "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
       "gist": "",
@@ -259,7 +261,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-32",
+      "id": "komunalni-2022-598917-q-32",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
       "gist": "",
@@ -267,7 +269,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-33",
+      "id": "komunalni-2022-598917-q-33",
       "name": "Fotovoltaika na soukromých střechách",
       "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
       "gist": "",
@@ -275,7 +277,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-34",
+      "id": "komunalni-2022-598917-q-34",
       "name": "Vstupné na kulturu a sport",
       "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
       "gist": "",
@@ -283,7 +285,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-35",
+      "id": "komunalni-2022-598917-q-35",
       "name": "Menstruační pomůcky v městských budovách",
       "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
       "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
@@ -291,7 +293,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-36",
+      "id": "komunalni-2022-598917-q-36",
       "name": "Menstruační pomůcky –vydávání zdarma",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -299,7 +301,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-37",
+      "id": "komunalni-2022-598917-q-37",
       "name": "Fotovoltaika na městské budovy",
       "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
       "gist": "",
@@ -307,7 +309,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-38",
+      "id": "komunalni-2022-598917-q-38",
       "name": "Elektrické koloběžky",
       "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
       "gist": "",
@@ -315,7 +317,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-39",
+      "id": "komunalni-2022-598917-q-39",
       "name": "Integrace cizinců",
       "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
       "gist": "",
@@ -323,7 +325,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-40",
+      "id": "komunalni-2022-598917-q-40",
       "name": "Více strážníků",
       "title": "Mělo by být více městských strážníků?",
       "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
@@ -331,7 +333,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-41",
+      "id": "komunalni-2022-598917-q-41",
       "name": "Zelené střechy",
       "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
       "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
@@ -339,7 +341,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-42",
+      "id": "komunalni-2022-598917-q-42",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
@@ -347,7 +349,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-43",
+      "id": "komunalni-2022-598917-q-43",
       "name": "Podpora profesionálního sportu",
       "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
       "gist": "",
@@ -355,7 +357,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-44",
+      "id": "komunalni-2022-598917-q-44",
       "name": "Daň z nemovitosti",
       "title": "Daň z nemovitosti by se měla snížit.",
       "gist": "Město má relativně velkou volnost v nastavení výše daně z nemovitostí. Ta je celá příjmem města. Zastánci vyšší daně argumentují tím, že v porovnání s jinými zeměmi jsou české daně spíše nízké. Odpůrci daně často argumentují tím, že dochází ke zdanění již zdaněného.",
@@ -363,7 +365,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-45",
+      "id": "komunalni-2022-598917-q-45",
       "name": "Podpora chudých",
       "title": "Má podle vás město finančně podporovat sociálně slabé občany, aby se nepropadli do chudoby?",
       "gist": "",
@@ -371,7 +373,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-46",
+      "id": "komunalni-2022-598917-q-46",
       "name": "Bytový fond",
       "title": "Město má budovat a udržovat vlastní bytový fond",
       "gist": "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe. Např. ve Vídni je cca čtvrtina bytů přímo v obecním vlastnictví a stejná část patří obecně prospěšným stavebním společnostem. Ty dostávají na výstavbu výhodné půjčky od města a na oplátku se zavazují držet nájmy na přijatelné úrovni i pro další generace. Výnosy musí investovat do výstavby nebo oprav bytů.",
@@ -379,7 +381,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-47",
+      "id": "komunalni-2022-598917-q-47",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
@@ -387,7 +389,7 @@
       "tags": []
     },
     {
-      "id": "komunalni-2022-598917-question-48",
+      "id": "komunalni-2022-598917-q-48",
       "name": "Sociální pomoc",
       "title": "Město má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě školek, dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
@@ -397,16 +399,17 @@
   ],
   "candidates": [
     {
-      "id": "komunalni-2022-598917-candidate-934669",
+      "id": "komunalni-2022-598917-c-934669",
       "name": "ANO 2011",
       "type": "party",
       "description": "ANO 2011 - DESCRIPTION",
+      "img_url": "ano",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598917-934669-party",
+          "id": "komunalni-2022-598917-c-934669-p",
           "name": "ANO 2011",
           "description": "ANO 2011 - DESCRIPTION",
           "contacts": {
@@ -417,16 +420,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-598917-candidate-410314",
+      "id": "komunalni-2022-598917-c-410314",
       "name": "Česká pirátská strana",
       "type": "party",
       "description": "Česká pirátská strana - DESCRIPTION",
+      "img_url": "piráti",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598917-410314-party",
+          "id": "komunalni-2022-598917-c-410314-p",
           "name": "Česká pirátská strana",
           "description": "Česká pirátská strana - DESCRIPTION",
           "contacts": {
@@ -437,16 +441,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-598917-candidate-804761",
+      "id": "komunalni-2022-598917-c-804761",
       "name": "Česká strana sociálně demokratická",
       "type": "party",
       "description": "Česká strana sociálně demokratická - DESCRIPTION",
+      "img_url": "čssd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598917-804761-party",
+          "id": "komunalni-2022-598917-c-804761-p",
           "name": "Česká strana sociálně demokratická",
           "description": "Česká strana sociálně demokratická - DESCRIPTION",
           "contacts": {
@@ -457,16 +462,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-598917-candidate-702950",
+      "id": "komunalni-2022-598917-c-702950",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
       "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "img_url": "ksčm",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598917-702950-party",
+          "id": "komunalni-2022-598917-c-702950-p",
           "name": "Komunistická strana Čech a Moravy",
           "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
           "contacts": {
@@ -477,16 +483,17 @@
       ]
     },
     {
-      "id": "komunalni-2022-598917-candidate-687752",
+      "id": "komunalni-2022-598917-c-687752",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
       "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "img_url": "spd",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "komunalni-2022-598917-687752-party",
+          "id": "komunalni-2022-598917-c-687752-p",
           "name": "Svoboda a přímá demokracie (SPD)",
           "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
           "contacts": {
@@ -497,10 +504,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-598917-candidate-191723",
+      "id": "komunalni-2022-598917-c-191723",
       "name": "SPOLU",
       "type": "party",
       "description": "SPOLU - DESCRIPTION",
+      "img_url": "kdu-ods-top 09",
       "contacts": {
         "web": [
           {
@@ -511,7 +519,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-598917-191723-party",
+          "id": "komunalni-2022-598917-c-191723-p",
           "name": "SPOLU",
           "description": "SPOLU - DESCRIPTION",
           "contacts": {
@@ -527,10 +535,11 @@
       ]
     },
     {
-      "id": "komunalni-2022-598917-candidate-825401",
+      "id": "komunalni-2022-598917-c-825401",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
       "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "img_url": "stan",
       "contacts": {
         "web": [
           {
@@ -542,7 +551,7 @@
       },
       "parties": [
         {
-          "id": "komunalni-2022-598917-825401-party",
+          "id": "komunalni-2022-598917-c-825401-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
           "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
           "contacts": {
@@ -561,908 +570,908 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-598917-answer-410314-1",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-1",
+      "id": "komunalni-2022-598917-a-4",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-1",
       "answer": "no",
       "comment": "Nejsme pro budování chudinských čtvrtí ani čtvrtí pro bohaté. Naopak město by s mělo snažit o to, aby se bydlelo všude dobře. Aktuální politika, kdy vedení města podporuje dotacemi ve výši 150 tisíc pouze ty nejbohatší, kteří mají prostředky na výstavbu rodinných domů, podle nás není férová. Stejně jako mnohamilionové investice do přípravy lokalit opět pro výstavbu několika desítek rodinných domů. My bychom chtěli stavět a nabízet moderní dostupné městské byty pro všechny skupiny obyvatel a vytvářet tak konkurenci dominantnímu Heimstadenu i obchodníkům s chudobou."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-2",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-2",
+      "id": "komunalni-2022-598917-a-7",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-2",
       "answer": "yes",
       "comment": "Přestože vedení města tvrdí, že odpady jsou zadarmo, ve skutečnosti ročně stojí město více než 50 milionů z veřejných (tedy také našich) peněz. Poplatky za likvidaci odpadu významně porostou a je neudržitelné, aby byly zcela zdarma. Poplatek 500 korun ročně považujeme za přiměřený, získané peníze bychom investovali do rozvoje moderních odpadových systémů motivujících k redukci odpadu a třídění. Město nyní nemá prostředky na investice do zlepšení prostředí kontejnerových stání nebo instalaci velkokapacitních podzemních kontejnerů, které zamezují \"vyhrabávání\" odpadu, které je v Karviné problémem."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-3",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-3",
+      "id": "komunalni-2022-598917-a-10",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-3",
       "comment": "Senioři musí mít zajištěny komfortní podmínky pro svůj pobyt, na druhou stranu přetápění interiéru není zdravé, ekologické ani ekonomické. Pro regulaci vytápění by se měly instalovat inteligentní systémy s termostaty, které automaticky regulují teplotu. Někomu stačí v pokoji 20 stupňů, jiný potřebuje více. Problémem je, pokud je interiér přetopený kupříkladu na 26 stupňů a v pokojích se větrá."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-4",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-4",
+      "id": "komunalni-2022-598917-a-13",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-4",
       "comment": "Určitě jsou místa, kde by snížení rychlosti přispělo k bezpečnému provozu a nižším emisím. Toto by ovšem měli posoudit dopravní odborníci a opatření by mělo vycházet také z potřeb občanů."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-5",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-5",
+      "id": "komunalni-2022-598917-a-16",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-5",
       "answer": "yes",
       "comment": "Karviná bohužel má s exekucemi obrovský problém, patříme k městům s nejvyšším podílem lidí v exekuci. Oznámit lidem, že si mohou část dluhů vyřešit v rámci Milostivého léta je naprosté minimum, které město může pro své občany udělat."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-6",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-6",
+      "id": "komunalni-2022-598917-a-19",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-6",
       "answer": "no",
       "comment": "Město je kamerovým systémem doslova prošpikováno, my chceme více strážníků v ulicích, nikoliv jen další a další kamery."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-7",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-7",
+      "id": "komunalni-2022-598917-a-22",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-7",
       "answer": "no",
       "comment": "Jsme rozhodně pro přísnou regulaci a rušení heren, které vedení město slíbilo již před čtyřmi lety a dodnes k ní nedošlo. Naopak byla otevřeny herny nové. Ve městě by mohly podle nás zůstat maximálně např. dvě kasina. Nechceme ale hernu na každém rohu a v každé druhé hospodě a zejména v sociálně vyloučených lokalitách. Hrát mohou ti, kteří si to mohou dovolit. V Karviné došlo k tomu, že se herny pouze formálně přejmenovaly na kasina a podmínku živé hry plní např. tak, že se tam údajně jednou týdně hrají kostky nebo poker, ale reálně jde primárně o klasické výherní automaty. Přibýt by měly také dluhové a adiktologické poradny, které pomohou řešit závislosti."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-8",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-8",
+      "id": "komunalni-2022-598917-a-25",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-8",
       "answer": "no",
       "comment": "V aktuální situaci si to podle nás město nemůže dovolit. Bavíme se o nákladech v desítkách milionů každý rok. Byli bychom pro některé linky zdarma a hlavně zkvalitnění MHD i posílení meziměstských spojů, které zlepší dopravní dostupnost."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-9",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-9",
+      "id": "komunalni-2022-598917-a-28",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-10",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-10",
+      "id": "komunalni-2022-598917-a-31",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-10",
       "answer": "yes",
       "comment": "Dlouhodobě se snažíme o větší transparentnost, bohužel bezvýsledně. Kromě zveřejňování jmenovitého hlasování bychom byli i pro online přenosy ze zasedání. V minulosti jsme prosadili přesun zastupitelstva na odpolední hodiny, aby se ho mohlo zúčastnit více občanů."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-11",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-11",
+      "id": "komunalni-2022-598917-a-34",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-11",
       "answer": "yes",
       "comment": "Toto je pro nás samozřejmost, politici by měli nést odpovědnost za svá rozhodnutí."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-12",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-12",
+      "id": "komunalni-2022-598917-a-37",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-12",
       "answer": "yes",
       "comment": "Nevidíme důvod k tomu, aby kromě Silvestra byli občané i zvířata rušeni výbuchy zábavní pyrotechniky."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-13",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-13",
+      "id": "komunalni-2022-598917-a-40",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-13",
       "comment": "Město by mělo řešit energetickou chudobu a sociální problémy systémově."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-14",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-14",
+      "id": "komunalni-2022-598917-a-43",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-14",
       "answer": "yes",
       "comment": "V současné době je potřeba hledat úspory všude tam, kde nemají přímý dopad na občany. Zaměřili bychom se na úspornost osvětlení celkově, nedomníváme se, že pouhým ztlumením osvětlení památek dosáhneme výrazných úspor, ale každá koruna dobrá:-)"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-15",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-15",
+      "id": "komunalni-2022-598917-a-46",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-15",
       "comment": "Toto je potřeba nejprve analyzovat a vyhodnotit s odborníky. Spíše než omezování bychom se snažili zvolit moderní úsporné technologie, které kupříkladu reagují na pohyb apod."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-16",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-16",
+      "id": "komunalni-2022-598917-a-49",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-16",
       "answer": "yes",
       "comment": "Přetápění je chronickým problémem v celém Česku, vytápět interiéry na 25 stupňů kupříkladu rozhodně není zdravé, ekonomické ani ekologické.  Je potřeba investovat do moderních technologií a chytrých termostatů tak, abVytvořili bychom také systémy Smart Grids po vzoru Budišova nad Budišovkou, kdy se městské budovy propojí a chytře nakládají s energiemi. Například zatímco ve škole se o víkendu tolik topit nemusí, v kulturním domě je tomu naopak, smart grids umožňují toky energie mezi jednotlivými budovami maximálně efektivně využívat a my můžeme tedy ušetřit, aniž bychom snižili komfort občanů i zaměstnanců."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-17",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-17",
+      "id": "komunalni-2022-598917-a-52",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-17",
       "answer": "yes",
       "comment": "Piráti dlouhodobě bojují proti dětským exekucím, toto je pro nás naprosto nepochopitelná praxe. Prosadili jsme také změnu legislativy, která měla zastavit zadlužování dětí. https://www.pirati.cz/tiskove-zpravy/pirati-iniciovali-konec-detskych-dluhu.html"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-18",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-18",
+      "id": "komunalni-2022-598917-a-55",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-18",
       "answer": "yes",
       "comment": "Ano jsme jednoznačně pro to, aby mělo město otevřený rozklikávací rozpočet na úroveň faktury a také transparentní účty."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-19",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-19",
+      "id": "komunalni-2022-598917-a-58",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-19",
       "answer": "yes",
       "comment": "Několikrát jsme se pokusili prosadit participativní rozpočet, bohužel bezvýsledně. Vedení města to odmítlo a přistoupilo pouze na hlasování o již připravených projektech. Smyslem participace je ale umožnit občanům přicházet s vlastními návrhy."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-20",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-20",
+      "id": "komunalni-2022-598917-a-61",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-20",
       "answer": "yes",
       "comment": "Jednoznačně, toto je naše priorita. Chtěli bychom vystavět 100 nových moderních městskch bytů, rekonstruovat stávající bytový fond a využít dotační program Ministra pro místní rozvoj Ivana Bartoše, který toto pro obce připravil."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-21",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-21",
+      "id": "komunalni-2022-598917-a-64",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-21",
       "comment": "Hledat úspory ano, zrušit Vánoce ne. Pokud lze osvětlení udělat úsporněji, jsme pro. Můžeme např. zvolit led diody apod. Zrušení osvětlení ne."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-22",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-22",
+      "id": "komunalni-2022-598917-a-67",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-22",
       "answer": "yes",
       "comment": "V současné situaci čelíme pracující chudobě, kdy i děti pracujících rodičů mohou mít problém. Samozřejmě je nutné systém správně a férově nastavit. Hladové děti ale nejsou něco, na co bychom si měli chtít v moderní společnosti zvykat."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-23",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-23",
+      "id": "komunalni-2022-598917-a-70",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-23",
       "answer": "yes",
       "comment": "Ano, tohle chceme, stejně jako bikesharing. Vzhledem k tomu, že podle posledního průzkumu ohledně mobility v Karviné, polovina domácnosti vozidlo nevlastní, je carsharing skvělá možnost. Sdílená auta jsou ekologickým i ekonomicky zajímavým řešením podpory individuální dopravy ve městech."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-24",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-24",
+      "id": "komunalni-2022-598917-a-73",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-24",
       "answer": "no",
       "comment": "Parkování ve městě musí být zpoplatněno a regulováno, jinak místo ulic, zeleně a náměstí budme mít jen parkoviště."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-25",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-25",
+      "id": "komunalni-2022-598917-a-76",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-25",
       "answer": "no",
       "comment": "Město už prodalo téměř celý bytový fond a teď na to doplácí. Ceny nájmů určuje Heimstaden a obchodníci s chudobou. Toto chceme změnit a naopak obnovit městský bytový fond."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-26",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-26",
+      "id": "komunalni-2022-598917-a-79",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-27",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-27",
+      "id": "komunalni-2022-598917-a-82",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-27",
       "comment": "Všechny druhy dopravy mají své místo a opodstatnění, máme koncepci rozvoje městské mobility a z té vychází, že bychom se měli zaměřit na podporu cyklodopravy, mikromobility a MHD. "
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-28",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-28"
+      "id": "komunalni-2022-598917-a-85",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-28"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-29",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-29",
+      "id": "komunalni-2022-598917-a-88",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-30",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-30",
+      "id": "komunalni-2022-598917-a-91",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-31",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-31",
+      "id": "komunalni-2022-598917-a-94",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-32",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-32",
+      "id": "komunalni-2022-598917-a-97",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-32",
       "answer": "no",
       "comment": "V současné situaci není prostor pro "
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-33",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-33",
+      "id": "komunalni-2022-598917-a-100",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-34",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-34",
+      "id": "komunalni-2022-598917-a-103",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-35",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-35",
+      "id": "komunalni-2022-598917-a-106",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-35",
       "comment": "Jsou země, kde je to běžné, na druhou stranu je potřeba spočítat náklady na toto opatření. Není to pro nás v současné situaci priorita a nechceme bez odhadu nákladu říkat ano, či ne."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-36",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-36",
+      "id": "komunalni-2022-598917-a-109",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-37",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-37",
+      "id": "komunalni-2022-598917-a-112",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-37",
       "answer": "yes",
       "comment": "Toto už mělo být dávno. Město musí jít v tomto příkadem."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-38",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-38",
+      "id": "komunalni-2022-598917-a-115",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-39",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-39",
+      "id": "komunalni-2022-598917-a-118",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-40",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-40",
+      "id": "komunalni-2022-598917-a-121",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-40",
       "answer": "yes",
       "comment": "Bezpečnost je v Karviné velké téma, domníváme se, že strážníci v ulicích by pro prevenci kriminality udělali více než kamery a Petr Slezák jako její vedoucí."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-41",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-41",
+      "id": "komunalni-2022-598917-a-124",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-42",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-42",
+      "id": "komunalni-2022-598917-a-127",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-43",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-43",
+      "id": "komunalni-2022-598917-a-130",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-43",
       "comment": "Podporovat ano, ale ne tolik jako doposud. Někdy se zdá, že sport je pro město priorita, domníváme se, že město má aktuálně jiné zásadnější úkoly."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-44",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-44",
+      "id": "komunalni-2022-598917-a-133",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-44",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-45",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-45",
+      "id": "komunalni-2022-598917-a-136",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-45",
       "answer": "no",
       "comment": "Město nemůže finančně podporovat jednotlivce, k tomu slouží státní systém sociální podpory, ale má problém řešit systémově, například nabídkou startovacích bytů, spoluprácí s potravinovou bankou a sítí podpůrných sociálních služeb."
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-46",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-46",
+      "id": "komunalni-2022-598917-a-139",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-47",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-47",
+      "id": "komunalni-2022-598917-a-142",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-48",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-48",
+      "id": "komunalni-2022-598917-a-145",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-410314-49",
-      "candidate_id": "komunalni-2022-598917-candidate-410314",
-      "question_id": "komunalni-2022-598917-question-49",
+      "id": "komunalni-2022-598917-a-148",
+      "candidate_id": "komunalni-2022-598917-c-410314",
+      "question_id": "komunalni-2022-598917-q-49",
       "comment": "Část otázek chybí. Poslední text je u čísla 49."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-1",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-1",
+      "id": "komunalni-2022-598917-a-4",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-1",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-2",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-2",
+      "id": "komunalni-2022-598917-a-7",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-2",
       "answer": "no",
       "comment": "Odpady zdarma podporujeme. Samozřejmě pouze ale jen pro ty, kdo nemá vůči městu nějaký dluh."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-3",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-3",
+      "id": "komunalni-2022-598917-a-10",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-3",
       "answer": "no",
       "comment": "Toto je velmi citlivé téma. Pokud to jen půjde, musí být teplota zachována."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-4",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-4",
+      "id": "komunalni-2022-598917-a-13",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-4",
       "answer": "no",
       "comment": "Myslím, že těchto zón je po městě dostatek. Hlavně by měly být kontrolovány, zda se rychlost dodržuje."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-5",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-5",
+      "id": "komunalni-2022-598917-a-16",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-5",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-6",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-6",
+      "id": "komunalni-2022-598917-a-19",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-6",
       "answer": "yes",
       "comment": "Instalovány nové a případně měněny ty stávající, které nesplňují technologické standardy."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-7",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-7",
+      "id": "komunalni-2022-598917-a-22",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-7",
       "answer": "yes",
       "comment": "Zrušení hazardu ve městě je klíč i k větší bezpečnosti v ulicích."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-8",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-8",
+      "id": "komunalni-2022-598917-a-25",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-8",
       "comment": "Já bych byl každopádně pro. Ale nevím, zda je to momentálně možné. Je třeba si to opravdu hodně promyslet a propočítat, jelikož se nám nyní i velice zdražují energie a pohonné hmoty a město bude potřebovat peníze kvůli energiím jinde, především školy, školky, úřady, domy s pečovatelskou službou a podobně."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-9",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-9",
+      "id": "komunalni-2022-598917-a-28",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-10",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-10",
+      "id": "komunalni-2022-598917-a-31",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-11",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-11",
+      "id": "komunalni-2022-598917-a-34",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-11",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-12",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-12"
+      "id": "komunalni-2022-598917-a-37",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-12"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-13",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-13"
+      "id": "komunalni-2022-598917-a-40",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-13"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-14",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-14",
+      "id": "komunalni-2022-598917-a-43",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-14",
       "comment": "Pokud bude třeba, tak klidně ano."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-15",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-15",
+      "id": "komunalni-2022-598917-a-46",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-15",
       "answer": "no",
       "comment": "Veřejně osvětlení je v noci potřeba. Hlavně tedy kvůli bezpečnosti občanů."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-16",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-16",
+      "id": "komunalni-2022-598917-a-49",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-16",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-17",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-17",
+      "id": "komunalni-2022-598917-a-52",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-17",
       "comment": "To je velice složitá otázka. Ale děti by obecně neměly mít dluhy, takže se přikláním k tomu, aby se odpouštěly dluhy dětem."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-18",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-18",
+      "id": "komunalni-2022-598917-a-55",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-19",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-19",
+      "id": "komunalni-2022-598917-a-58",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-19",
       "answer": "yes",
       "comment": "Tady jsem určitě pro. Chtěli bychom zapojit občany více do dění ve městě."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-20",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-20",
+      "id": "komunalni-2022-598917-a-61",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-20",
       "answer": "yes",
       "comment": "Vzhledem k tržnímu prostředí a možnosti regulovaného nájmu by to tak mělo být."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-21",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-21"
+      "id": "komunalni-2022-598917-a-64",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-21"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-22",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-22"
+      "id": "komunalni-2022-598917-a-67",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-22"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-23",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-23"
+      "id": "komunalni-2022-598917-a-70",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-23"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-24",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-24",
+      "id": "komunalni-2022-598917-a-73",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-25",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-25",
+      "id": "komunalni-2022-598917-a-76",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-26",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-26",
+      "id": "komunalni-2022-598917-a-79",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-27",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-27",
+      "id": "komunalni-2022-598917-a-82",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-28",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-28"
+      "id": "komunalni-2022-598917-a-85",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-28"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-29",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-29"
+      "id": "komunalni-2022-598917-a-88",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-29"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-30",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-30"
+      "id": "komunalni-2022-598917-a-91",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-30"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-31",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-31",
+      "id": "komunalni-2022-598917-a-94",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-32",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-32",
+      "id": "komunalni-2022-598917-a-97",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-33",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-33",
+      "id": "komunalni-2022-598917-a-100",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-33",
       "answer": "yes",
       "comment": "Nemyslím tím finanční výpomoc, na to město nemá zbytečné prostředky, ale poradenskou výpomocí určitě."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-34",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-34",
+      "id": "komunalni-2022-598917-a-103",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-34",
       "comment": "Mládež má pro některé objekty již nyní zvýhodněné vstupné, takže bych to nejspíše takto zachoval."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-35",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-35"
+      "id": "komunalni-2022-598917-a-106",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-35"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-36",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-36"
+      "id": "komunalni-2022-598917-a-109",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-36"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-37",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-37",
+      "id": "komunalni-2022-598917-a-112",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-38",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-38",
+      "id": "komunalni-2022-598917-a-115",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-38",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-39",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-39",
+      "id": "komunalni-2022-598917-a-118",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-39",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-40",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-40",
+      "id": "komunalni-2022-598917-a-121",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-40",
       "answer": "yes",
       "comment": "Myslím, že máme stále podstav strážníků městské policie a já bych rád, aby se stav navýšil a strážníci byli viděni více v ulicích."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-41",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-41",
+      "id": "komunalni-2022-598917-a-124",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-41",
       "answer": "yes",
       "comment": "Zelená střecha má určitě velice dobrou přidanou hodnotu a já jsem tedy pro."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-42",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-42"
+      "id": "komunalni-2022-598917-a-127",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-42"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-43",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-43",
+      "id": "komunalni-2022-598917-a-130",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-44",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-44",
+      "id": "komunalni-2022-598917-a-133",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-44",
       "comment": "Daň z nemovitosti může být tak vysoká, jak nám to dovolí legislativa. Mohla by se dočasně snížit jako pomoc občanům v nynější tíživé situaci."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-45",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-45",
+      "id": "komunalni-2022-598917-a-136",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-45",
       "answer": "yes",
       "comment": "Sociálně slabým občanům je nutné pomáhat, ale je třeba nastavit správně pravidla čerpání."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-46",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-46",
+      "id": "komunalni-2022-598917-a-139",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-46",
       "answer": "yes",
       "comment": "Městských bytů není mnoho a bylo by tedy dobré mít konkurenci vůči Heimstadenu s regulovaným nájemným. Pokud by byl o toto zájem, jsme pro."
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-47",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-47",
+      "id": "komunalni-2022-598917-a-142",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-47",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-48",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-48",
+      "id": "komunalni-2022-598917-a-145",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-687752-49",
-      "candidate_id": "komunalni-2022-598917-candidate-687752",
-      "question_id": "komunalni-2022-598917-question-49"
+      "id": "komunalni-2022-598917-a-148",
+      "candidate_id": "komunalni-2022-598917-c-687752",
+      "question_id": "komunalni-2022-598917-q-49"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-1",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-1",
+      "id": "komunalni-2022-598917-a-4",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-1",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-2",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-2",
+      "id": "komunalni-2022-598917-a-7",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-2",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-3",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-3",
+      "id": "komunalni-2022-598917-a-10",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-4",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-4",
+      "id": "komunalni-2022-598917-a-13",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-4",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-5",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-5",
+      "id": "komunalni-2022-598917-a-16",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-5",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-6",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-6",
+      "id": "komunalni-2022-598917-a-19",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-6",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-7",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-7",
+      "id": "komunalni-2022-598917-a-22",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-7",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-8",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-8",
+      "id": "komunalni-2022-598917-a-25",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-8",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-9",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-9",
+      "id": "komunalni-2022-598917-a-28",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-9",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-10",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-10",
+      "id": "komunalni-2022-598917-a-31",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-10",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-11",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-11",
+      "id": "komunalni-2022-598917-a-34",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-11",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-12",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-12",
+      "id": "komunalni-2022-598917-a-37",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-12",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-13",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-13",
+      "id": "komunalni-2022-598917-a-40",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-13",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-14",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-14",
+      "id": "komunalni-2022-598917-a-43",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-14",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-15",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-15",
+      "id": "komunalni-2022-598917-a-46",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-15",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-16",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-16",
+      "id": "komunalni-2022-598917-a-49",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-16",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-17",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-17",
+      "id": "komunalni-2022-598917-a-52",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-17",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-18",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-18",
+      "id": "komunalni-2022-598917-a-55",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-18",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-19",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-19",
+      "id": "komunalni-2022-598917-a-58",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-19",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-20",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-20",
+      "id": "komunalni-2022-598917-a-61",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-21",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-21",
+      "id": "komunalni-2022-598917-a-64",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-21",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-22",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-22",
+      "id": "komunalni-2022-598917-a-67",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-22",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-23",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-23",
+      "id": "komunalni-2022-598917-a-70",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-23",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-24",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-24",
+      "id": "komunalni-2022-598917-a-73",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-24",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-25",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-25",
+      "id": "komunalni-2022-598917-a-76",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-25",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-26",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-26",
+      "id": "komunalni-2022-598917-a-79",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-26",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-27",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-27",
+      "id": "komunalni-2022-598917-a-82",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-27",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-28",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-28",
+      "id": "komunalni-2022-598917-a-85",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-28",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-29",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-29",
+      "id": "komunalni-2022-598917-a-88",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-29",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-30",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-30",
+      "id": "komunalni-2022-598917-a-91",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-30",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-31",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-31",
+      "id": "komunalni-2022-598917-a-94",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-31",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-32",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-32",
+      "id": "komunalni-2022-598917-a-97",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-32",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-33",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-33",
+      "id": "komunalni-2022-598917-a-100",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-33",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-34",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-34",
+      "id": "komunalni-2022-598917-a-103",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-35",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-35",
+      "id": "komunalni-2022-598917-a-106",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-35",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-36",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-36",
+      "id": "komunalni-2022-598917-a-109",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-36",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-37",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-37",
+      "id": "komunalni-2022-598917-a-112",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-37",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-38",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-38",
+      "id": "komunalni-2022-598917-a-115",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-38",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-39",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-39",
+      "id": "komunalni-2022-598917-a-118",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-39",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-40",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-40",
+      "id": "komunalni-2022-598917-a-121",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-40",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-41",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-41",
+      "id": "komunalni-2022-598917-a-124",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-41",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-42",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-42",
+      "id": "komunalni-2022-598917-a-127",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-42",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-43",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-43",
+      "id": "komunalni-2022-598917-a-130",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-43",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-44",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-44",
+      "id": "komunalni-2022-598917-a-133",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-44",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-45",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-45",
+      "id": "komunalni-2022-598917-a-136",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-45",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-46",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-46",
+      "id": "komunalni-2022-598917-a-139",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-46",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-47",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-47",
+      "id": "komunalni-2022-598917-a-142",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-47",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-48",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-48",
+      "id": "komunalni-2022-598917-a-145",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-48",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-598917-answer-702950-49",
-      "candidate_id": "komunalni-2022-598917-candidate-702950",
-      "question_id": "komunalni-2022-598917-question-49"
+      "id": "komunalni-2022-598917-a-148",
+      "candidate_id": "komunalni-2022-598917-c-702950",
+      "question_id": "komunalni-2022-598917-q-49"
     }
   ]
 }

--- a/data/kalkulacka/senatni-2022/1.json
+++ b/data/kalkulacka/senatni-2022/1.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-1",
-  "name": "1",
-  "description": "1 - DESCRIPTION",
+  "name": "Karlovy Vary",
+  "description": "Karlovy Vary",
   "district_code": "1",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-1-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-1-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-1-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-1-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-1-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-1-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-1-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-1-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-1-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-1-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-1-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-1-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-1-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-1-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-1-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-1-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-1-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-1-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-1-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-1-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-1-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-1-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-1-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-1-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-1-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-1-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-1-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-1-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-1-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-1-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-1-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-1-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-1-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-1-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-1-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-1-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-1-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-1-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-1-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-1-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-1-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-1-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-1-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-1-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-1-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-1-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-1-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-1-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-1-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-1-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-1-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-1-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-1-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-1-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-1-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-1-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-1-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-1-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-1-candidate-965208",
+      "id": "senatni-2022-1-c-965208",
       "name": "Pavel Petričko",
-      "type": "party",
+      "type": "person",
       "description": "Pavel Petričko - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -488,7 +490,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-1-965208-party",
+          "id": "senatni-2022-1-c-965208-p",
           "name": "Pavel Petričko",
           "description": "Pavel Petričko - DESCRIPTION",
           "contacts": {
@@ -501,9 +503,9 @@
       ]
     },
     {
-      "id": "senatni-2022-1-candidate-872946",
+      "id": "senatni-2022-1-c-872946",
       "name": "Eva Chromcová",
-      "type": "party",
+      "type": "person",
       "description": "Eva Chromcová - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -511,7 +513,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-1-872946-party",
+          "id": "senatni-2022-1-c-872946-p",
           "name": "Eva Chromcová",
           "description": "Eva Chromcová - DESCRIPTION",
           "contacts": {
@@ -523,9 +525,9 @@
       ]
     },
     {
-      "id": "senatni-2022-1-candidate-107987",
+      "id": "senatni-2022-1-c-107987",
       "name": "Bohdan Vaněk",
-      "type": "party",
+      "type": "person",
       "description": "Bohdan Vaněk - DESCRIPTION",
       "contacts": {
         "web": [
@@ -543,7 +545,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-1-107987-party",
+          "id": "senatni-2022-1-c-107987-p",
           "name": "Bohdan Vaněk",
           "description": "Bohdan Vaněk - DESCRIPTION",
           "contacts": {
@@ -565,9 +567,9 @@
       ]
     },
     {
-      "id": "senatni-2022-1-candidate-578851",
+      "id": "senatni-2022-1-c-578851",
       "name": "Bedřich Šmudla",
-      "type": "party",
+      "type": "person",
       "description": "Bedřich Šmudla - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -575,7 +577,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-1-578851-party",
+          "id": "senatni-2022-1-c-578851-p",
           "name": "Bedřich Šmudla",
           "description": "Bedřich Šmudla - DESCRIPTION",
           "contacts": {
@@ -587,9 +589,9 @@
       ]
     },
     {
-      "id": "senatni-2022-1-candidate-128673",
+      "id": "senatni-2022-1-c-128673",
       "name": "Věra Procházková",
-      "type": "party",
+      "type": "person",
       "description": "Věra Procházková - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -598,7 +600,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-1-128673-party",
+          "id": "senatni-2022-1-c-128673-p",
           "name": "Věra Procházková",
           "description": "Věra Procházková - DESCRIPTION",
           "contacts": {
@@ -611,9 +613,9 @@
       ]
     },
     {
-      "id": "senatni-2022-1-candidate-329053",
+      "id": "senatni-2022-1-c-329053",
       "name": "Petr Kulhánek",
-      "type": "party",
+      "type": "person",
       "description": "Petr Kulhánek - DESCRIPTION",
       "contacts": {
         "web": [
@@ -628,7 +630,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-1-329053-party",
+          "id": "senatni-2022-1-c-329053-p",
           "name": "Petr Kulhánek",
           "description": "Petr Kulhánek - DESCRIPTION",
           "contacts": {
@@ -647,16 +649,16 @@
       ]
     },
     {
-      "id": "senatni-2022-1-candidate-200693",
+      "id": "senatni-2022-1-c-200693",
       "name": "Jan Havel",
-      "type": "party",
+      "type": "person",
       "description": "Jan Havel - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-1-200693-party",
+          "id": "senatni-2022-1-c-200693-p",
           "name": "Jan Havel",
           "description": "Jan Havel - DESCRIPTION",
           "contacts": {
@@ -667,9 +669,9 @@
       ]
     },
     {
-      "id": "senatni-2022-1-candidate-174710",
+      "id": "senatni-2022-1-c-174710",
       "name": "Petr Ajšman",
-      "type": "party",
+      "type": "person",
       "description": "Petr Ajšman - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -679,7 +681,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-1-174710-party",
+          "id": "senatni-2022-1-c-174710-p",
           "name": "Petr Ajšman",
           "description": "Petr Ajšman - DESCRIPTION",
           "contacts": {
@@ -693,9 +695,9 @@
       ]
     },
     {
-      "id": "senatni-2022-1-candidate-755869",
+      "id": "senatni-2022-1-c-755869",
       "name": "Martin Maleček",
-      "type": "party",
+      "type": "person",
       "description": "Martin Maleček - DESCRIPTION",
       "contacts": {
         "web": [
@@ -708,7 +710,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-1-755869-party",
+          "id": "senatni-2022-1-c-755869-p",
           "name": "Martin Maleček",
           "description": "Martin Maleček - DESCRIPTION",
           "contacts": {
@@ -725,9 +727,9 @@
       ]
     },
     {
-      "id": "senatni-2022-1-candidate-306348",
+      "id": "senatni-2022-1-c-306348",
       "name": "Václav Slavík",
-      "type": "party",
+      "type": "person",
       "description": "Václav Slavík - DESCRIPTION",
       "contacts": {
         "web": [
@@ -750,7 +752,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-1-306348-party",
+          "id": "senatni-2022-1-c-306348-p",
           "name": "Václav Slavík",
           "description": "Václav Slavík - DESCRIPTION",
           "contacts": {
@@ -777,9 +779,9 @@
       ]
     },
     {
-      "id": "senatni-2022-1-candidate-742303",
+      "id": "senatni-2022-1-c-742303",
       "name": "Jan Horník",
-      "type": "party",
+      "type": "person",
       "description": "Jan Horník - DESCRIPTION",
       "contacts": {
         "web": [
@@ -798,7 +800,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-1-742303-party",
+          "id": "senatni-2022-1-c-742303-p",
           "name": "Jan Horník",
           "description": "Jan Horník - DESCRIPTION",
           "contacts": {
@@ -821,5 +823,2181 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-4",
+      "answer": "no",
+      "comment": "Upřednostňovat nikoliv, ale dostat se do vyvážené pozice ve vztahu k další dopravní infrastruktuře jednoznačně ano."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-6",
+      "answer": "no",
+      "comment": "Nikoliv přehrady (až na výjimky, kde jsou ve shodě všichni aktéři), ale soustředit se na drobnější, ale četností masivnější, opatření zadržující vodu v krajině."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-7",
+      "comment": "Proti sobě stojí zatím druhotné využití a ekonomika celého systému"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-11",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-12",
+      "answer": "yes",
+      "comment": "V maximální míře, kde je možné to ovlivnit/regulovat."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-13",
+      "answer": "yes",
+      "comment": "Ale vnímám kolizi s prokazováním a hranicí co ještě není a už je fake news"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-15",
+      "answer": "no",
+      "comment": "Ale podrobněji specifikovány a kontrolovány podmínky jejich fungování"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-17"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-19",
+      "answer": "yes",
+      "comment": "Myšleno sociálními byty modelu prostupného bydlení, nebo pro potřebné ve složité hmotné, zdravotní, životní situaci."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-20",
+      "answer": "no",
+      "comment": "Tato sociální práce je primární úloha obcí."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-22"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-24",
+      "answer": "no",
+      "comment": "Tím myslím finanční podporu. Úkol pro stát je najít motivací pro studenty přihlásit se technické obory - argumentace budoucího uplatnění a poptávky po jejich znalostech."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-25",
+      "answer": "yes",
+      "comment": "Pokud nejde o případy, kdy společné studium je nemožné a vyžaduje individuální/skupinové řešení"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-32",
+      "answer": "yes",
+      "comment": "Přiměření velikosti a významu naší země"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-33",
+      "answer": "no",
+      "comment": "Pokud nelze usnadnit udělení u osob s válečných oblastí, osob pronásledovaných kvůli jejich přesvědčení, názoru, náboženství..."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-36"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-45"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-50",
+      "answer": "yes",
+      "comment": "Podporuji, pokud to bude realistické a významně to nepoškodí/nezhorší podmínky v řadě oblastí života"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-54",
+      "comment": "Primární cíl by měl být rovný přístup k podpoře bez ohledu na velikost"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-1-c-329053",
+      "question_id": "senatni-2022-1-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-1",
+      "answer": "no",
+      "comment": "Jde o zásah do vlastnických práv. Naopak úlohou státu je zajistit startovací a sociální byty."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-2",
+      "answer": "no",
+      "comment": "Jde o zásah do vlastnických práv. Naopak úlohou státu je zajistit startovací a sociální byty s adresnou pomocí tam, kde je to nutné."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-3",
+      "answer": "yes",
+      "comment": "Jsem pro osvědčený švýcarský model, tedy 50.000 podpisů pod peticí."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-4",
+      "answer": "no",
+      "comment": "Jako důležitější téma vidím dálnice a silnice v České republice."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-5",
+      "answer": "no",
+      "comment": "Odchod do penze by se měl naopak vrátit na 60 let. Navíc pro ženy s odpočtem za počet dětí. Při současných technologiích není nutné věkový limit zvyšovat, vždyť už měla být i kratší pracovní doba."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-6",
+      "answer": "yes",
+      "comment": "Jsme střechou Evropy a pitná voda je strategická surovina již dnes."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-7",
+      "answer": "yes",
+      "comment": "Třídění těchto odpadů konečně dostane nějaký smysl."
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-8",
+      "answer": "no",
+      "comment": "Nevidím jediný důvod, proč by úspěšní měli být trestáni. Statistika za posledních 30 let navíc ukazuje, že pokud jsou daně nižší a jednotné, tak je i výběr daně efektivnější. "
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-9",
+      "answer": "yes",
+      "comment": "Konopí je již delší dobu démonizováno."
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-10",
+      "answer": "yes",
+      "comment": "Prokázané násilí je nutné potrestat tak, aby výše trestu byla odstrašující."
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-11",
+      "answer": "yes",
+      "comment": "Pokud generují zisk na území České republiky, musí mít stejné podmínky jako ostatní."
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-12",
+      "answer": "no",
+      "comment": "Tyto sítě mají naopak umožnit názorovou pestrost. Pokud někdo porušuje zákon, má jednat Policie."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-13",
+      "answer": "no",
+      "comment": "Již třetím rokem vymazávají tzv. \"ověřovatelé faktů\" zprávy a to je obyčejná cenzura."
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-14",
+      "answer": "yes",
+      "comment": "Třetím rokem předvádí \"veřejnopráví média\", že slouží pouze vládě. Tedy zrušme koncesionářské poplatky a navažme jejich rozpočty na ten státní."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-15",
+      "answer": "no",
+      "comment": "Takřka všechny regulace ze strany státu proti soukromé sféře křiví trh, konkurenceschopnost a v konečné fázi i ceny."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-16",
+      "answer": "no",
+      "comment": "Manželství je vztah ženy a muže. Partnerství je vztah stejnopohlavních párů. Zákonné právo např. na dědění nebo osvojení dítěte by však mělo být stejné. Dnešní přívlastek \"registrované\" je dehonestující."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-17",
+      "answer": "yes",
+      "comment": "Produktivita není zakázané slovo ani pro exekutory, navíc se odstraní i jiné náklady."
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-18",
+      "answer": "yes",
+      "comment": "Jednoznačně, protože dnes se lidé ztrácí pod jejich množstvím. Forma losu zajistí rovné příležitosti pro všechny exekutory."
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-19",
+      "answer": "yes",
+      "comment": "Je to jedna ze zásadních úloh státu."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-20",
+      "answer": "no",
+      "comment": "Pravidla by měla být natolik jednoduchá a dostatečně veřejná, aby ten kdo má oprávněný nárok se o něj mohl přihlásit sám. "
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-21",
+      "answer": "yes",
+      "comment": "Zamezí se centralismu a přinese to nová pracovní místa i možnost pro mladou generaci uplatnit se ve svém regionu."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-22",
+      "answer": "no",
+      "comment": "Nejdřív se postarejme o důstojný život všech našich občanů a poté se zapisujme do světových dějin vědy."
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-23",
+      "answer": "no",
+      "comment": "Při současných možnostech ovlivnění elektronických dat to není ten správný způsob volby. Jednou za čtyři až šest let může k volbám osobně dojít každý. "
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-24",
+      "answer": "yes",
+      "comment": "Položte si otázku. Je pro Vás důležitější např. funkční automobil nebo názor na jakýkoliv politický směr. Za mne je to technika, Byla, je a bude vždy pokrokem lidstva."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-25",
+      "answer": "no",
+      "comment": "Stát by měl zajistit speciální školy pro ty, kteří to potřebují. "
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-26",
+      "answer": "no",
+      "comment": "Při současném stavu vzdělávání je tzv. inkluze pouze líbivé politické rozhodnutí."
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-27",
+      "answer": "yes",
+      "comment": "EU již není tím útvarem, který hájí národní zájmy svých členů. Evropa byla, je a doufám i bude nadále unikátní světadíl. "
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-28",
+      "answer": "no",
+      "comment": "Euro je pouze politické rozhodnutí velkých států k ovládnutí těch malých."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-29",
+      "answer": "yes",
+      "comment": "Je to spolek, který vedl a vede války na celém světě pro získání surovin jen pro vyvolené. "
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-30",
+      "answer": "no",
+      "comment": "Společná armáda? Společná policie? Děkuji nemám zájem."
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-31",
+      "answer": "yes",
+      "comment": "Protože jsme všichni lidé a každý někdy potřebuje pomoc."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-32",
+      "answer": "no",
+      "comment": "Změna klimatu je jenom strašák k ovládání lidstva."
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-33",
+      "comment": "Nemám dostatečné informace pro jednoznačné stanovisko."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-34",
+      "answer": "yes",
+      "comment": "I jako nečlenský stát můžeme být tou pátou zemí, která má zaručený volný pohyb."
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-35",
+      "answer": "no",
+      "comment": "Měli bychom se soustředit na odstranění ekonomických dopadů z posledních tří let."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-36",
+      "answer": "no",
+      "comment": "Dítě není věc, ale lidská bytost."
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-37",
+      "comment": "Nemám dostatečné informace pro jednoznačný názor."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-38",
+      "answer": "yes",
+      "comment": "Souhlasím s centry ve fakultních nemocnicích v krajích. Jejich rozložení po krajích zajistí kvatitní a dostupnou zdravotní péči."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-40",
+      "answer": "no",
+      "comment": "Systém by měl ale rozlišovat tzv. společenskou nebezpečnost."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-41",
+      "answer": "yes",
+      "comment": "Je to jenom další systém k ovládání a perzekuci lidí."
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-42",
+      "answer": "no",
+      "comment": "Ukrajina nesplňuje zásadní kriteria (zejména korupcí a definicí právního státu) a navíc by to byl předstupeň pro její vstup do NATO."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-43",
+      "answer": "no",
+      "comment": "Hranice mezi západem a východem se již nesmí posouvat."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-44",
+      "answer": "yes",
+      "comment": "Až na hranici nákupu Německa, tedy jeho přímého nákupu z Ruska. Dnešní poměr je 1:13 v neprospěch České republiky."
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-45",
+      "comment": "Nemám dostatek informací pro jednoznačnou odpověď."
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-46",
+      "answer": "no",
+      "comment": "Jak se ukazuje, tak následky tzv. restrikcí proti Rusku nesou řadoví občané členských států EU."
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-47",
+      "answer": "no",
+      "comment": "Čeští zákonodárci by měli sloužit českým občanům a zajistit jim důstojný život na úrovni roku 2022."
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-48",
+      "comment": "Nemám dostatečné informace pro jednoznačné stanovisko. Obecně jsem pro zvýšení trestů za násilí proti ženám."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-49",
+      "answer": "no",
+      "comment": "Dnes mají uhelné elektrárny taková technická řešení, že zátěž je minimální. A ta se do budoucna opět sníží."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-50",
+      "answer": "no",
+      "comment": "Tzv. \"Zelený úděl\" je světová mantra pro ovládání lidí."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-51",
+      "answer": "yes",
+      "comment": "Podle mezinárodních úmluv je jakékoliv území oprávněno rozhodnout o své samostatnosti. Obyvatelé Krymu se svobodně v referendu rozhodli pro přičlenění k Rusku."
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-52",
+      "answer": "yes",
+      "comment": "Přímý nákup ropy i plynu z Ruska je pro nás strategicky důležilý. Ostatně Německo udělalo to samé. "
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-53",
+      "answer": "no",
+      "comment": "Hranice mezi NATO a RF se již nesmí posouvat."
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-54",
+      "answer": "yes",
+      "comment": "Současná situace likviduje naše drobné a střední zemědělce a tím si likvidujeme i vlastní potravinovou soběstačnost."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-55",
+      "answer": "no",
+      "comment": "Úlohou státu je zajistit adresnou pomoc těm, kteří to potřebují."
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-56",
+      "answer": "yes",
+      "comment": "Navíc by měl i pořizovat startovní a sociální byty, aby lidé měli kde bydlet."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-57",
+      "comment": "Nemám dostatečné informace pro jednoznačnou odpověď. Nevím zda se jedná o území Ukrajiny, když po rozpadu Sovětského svazu o uznání svých hranic nikdy nepožádala."
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-1-c-578851",
+      "question_id": "senatni-2022-1-q-58",
+      "comment": "Nemám dostatečné informace pro jednoznačnou odpověď. Nevím, co znamená termín bezvýsledná exekuce."
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-2",
+      "answer": "yes",
+      "comment": "V případě čerpání sociálního příspěvku na bydlení nutno zavést regionální cenové mapy obvyklé výše nájemného."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-6",
+      "comment": "Nutno řešit s odborníky v oblasti vodohospodářství."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-8",
+      "answer": "no",
+      "comment": "Každý z občanů by měl mít nastavené stejné podmínky. Výše odvodu je závislá na výši výdělku."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-9"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-11",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-15"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-16",
+      "comment": "Souhlasím s novelizací Zákona o registrovaném partnerství vzhledem k majetkoprávním vztahům, děditství a výchovy dětí."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-19",
+      "answer": "no",
+      "comment": "Tuto otázku ponechat na obcích a městech. Více podpořit obce při výstavbě nájemních bytů."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-20",
+      "comment": "Tuto problematiku musí přesně vymezit Ministerstvo práce a sociálních věcí."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-21"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-23",
+      "answer": "yes",
+      "comment": "S využítím datové schránky z důvodu identifikace voliče."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-25",
+      "answer": "no",
+      "comment": "Nemám problém se vzděláváním na víceletých gymnáziích, ale s větším nárokem na přijímací řízení za podmínek stanovených Ministerstvem školství."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-26"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-30",
+      "comment": "Nesmí být potlačovány zásadní národní zájmy České republiky. Je potřeba více a razantněji tyto zájmy v rámci legitimních procesů Evropské unie prosazovat."
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-31",
+      "comment": "Současná ekonomická situace nám to moc nedovoluje. Abychom mohli více pomáhat mimo hranice naší republiky, musí být zajištěna přijatelná životní úroveň našich občanů."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-32",
+      "comment": "Toto téma musí byt podrobeno široké diskuzi nejen v oblasti ochrany životního prostředí, ale i zajištění energetických služeb pro hospodářství a domácnosti. Nemůžou rozhodovat laici, ale odborníci."
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-33",
+      "answer": "no",
+      "comment": "Současný právní systém si myslím je dostačující."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-35"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-36"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-40",
+      "answer": "no",
+      "comment": "Vzhledem k regulaci rychlosti v obcích na rizikových úsecích s uvedeným systémem souhlasím."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-41"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-42",
+      "answer": "no",
+      "comment": "V současné době nesplňuje podmínky. Již mnoho let čekají na vstup balkánské země bývalé Jugoslávie a určitě jsou lépe připraveni."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-45"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-50"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-52"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-54",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-56"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-1-c-755869",
+      "question_id": "senatni-2022-1-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-4"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-7"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-8"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-9"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-15"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-16"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-18"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-21"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-22"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-24"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-28"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-33"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-38"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-41"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-48"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-50"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-55"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-1-c-306348",
+      "question_id": "senatni-2022-1-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-5",
+      "answer": "yes",
+      "comment": "Do 67 let, ale s výjimkou"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-6"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-11",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-16"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-25",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-31"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-32",
+      "answer": "yes",
+      "comment": "Ale, pokud tak učiní i ostatní země"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-33",
+      "comment": "Je to případ od případu"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-37"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-38"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-42",
+      "answer": "yes",
+      "comment": "Ale bude to dlouhodobý proces"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-43"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-49",
+      "comment": "V probíhající energetické krizi na otázku nejde jednoznačně odpovědět"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-1-c-742303",
+      "question_id": "senatni-2022-1-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-1",
+      "answer": "yes",
+      "comment": "Jde spíše o daňové zvýhodnění bytů užívaných k trvalému bydlení. K tomu byty mají sloužit především. K uložení peněz slouži jiné instrumenty. Prázdné bytové domy jsou drahé i pro město - musí platit infrastrukturu lidem, kteří bydlí jinde."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-2",
+      "answer": "no",
+      "comment": "Stát není dobrý regulátor něčeho, co se liší v různých částech země. Na druhou stranu je na obcích jaké nájemné si stanoví pro nájemce ve svých bytech s přihlédnutím k jejich individuální situaci. Proto má smysl, aby obce byly vybaveny bytovým fondem."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-3",
+      "answer": "yes",
+      "comment": "Jde o možnost. Už samotná možnost kultivuje politické prostředí. A na nastavení parametrů je, aby omezily možnost zneužití."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-4",
+      "answer": "no",
+      "comment": "Nemělo by se tak dít na úkor ostatní důležité dopravní infrastruktury. Spolu s výstavbou sítě VRT je možné vybudovat další relevantní sítě pro maximální využití kapacit tak, aby se stavělo promyšleně, efektivně a v logických celcích."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-5",
+      "answer": "no",
+      "comment": "Spíše je vhodné odměňovat ty, co se dobrovolně rozhodnou přesluhovat nebo pracovat i v důchodu, protože to je výhodné pro stát i seniory. "
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-6",
+      "answer": "no",
+      "comment": "Toto je důležité posuzovat v širších souvislostech a z hlediska dlouhodobých dopadů. Je přínosné využití geografických možností, ale nepovažuji za vhodné stavět přehrady na každém využitelném místě. "
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-7",
+      "answer": "no",
+      "comment": "Domnívám se, že povinné zálohování PET lahví a plechovek by nyní nepřineslo významné zlepšení v třídění a recyklaci odpadu. S vývojem nových technologií se to může změnit."
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-8",
+      "answer": "yes",
+      "comment": "Jsem spíše pro daňové zvýhodnění osob s nižšími příjmy."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-9",
+      "answer": "yes",
+      "comment": "Je důležité zavést regulaci dosud černého trhu. To omezí organizovaný zločin, přinese nové příjmy do státního rozpočtu a zároveň přispěje k ochraně dětí a mladistvých."
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-10",
+      "answer": "yes",
+      "comment": "Nejde ani tak o rozsah trestů vymezených zákonem, ale skutečnou výši udělovaných trestů v trestním řízení. Je potřeba napravit definici znásilnění tak, aby zahrnovala i situace, kdy oběť nedokáže projevit odpor, nebo zažívá paralýzu. Zároveň je třeba změnit přístup k obětem, které druhotně trpí i při následném vyšetřování. "
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-11",
+      "answer": "yes",
+      "comment": "Podporuji zavedení globální minimální daně, která odstraní nerovné postavení vedle \"daňových rájů\". "
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-12",
+      "answer": "no",
+      "comment": "Obecná právní odpovědnost sociálních sítí za obsah jejich uživatelů by vedla nejen k nepřiměřenému omezování svobody slova, ale i k enormní právní nejistotě. Postačují povinnosti odstranění nežádoucího obsahu na příkaz odpovědné osoby."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-13",
+      "answer": "no",
+      "comment": "Stát má občany chránit před nebezpečím, ne před nesmysly na internetu. Pokud ovšem někdo využívá dezinformace k šíření nenávistného projevu, jehož důsledkem mohou být další zločiny z nenávisti, tak proti těmto producentům stát musí zasáhnout."
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-14",
+      "answer": "no",
+      "comment": "Je třeba zajistit stabilní financování veřejnoprávních médií, která jsou v naší společnosti důležitým článkem objektivního zpravodajství. Zároveň je nutné zajistit, aby jejich hospodaření podléhalo náležité veřejné kontrole. "
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-15",
+      "answer": "no",
+      "comment": "Problémem není pracovní agentura jako taková, ale nelegální agentury, které nedodržují pravidla.  "
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-16",
+      "answer": "yes",
+      "comment": "Rovné manželství pomůže tisícům párů a jejich dětem, neohrozí nikoho. Současný stav, kdy mezi registrovaným manželstvím a partnerstvím existuje řada rozdílů, je nespravedlivý. V sekulárním státě, kde všichni platí daně a mají stejné povinnosti, mají mít i rovná práva."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-17",
+      "answer": "yes",
+      "comment": "Zavedením místní příslušnosti se zvýší dohled krajského soudu nad jednotlivými exekutory a tím se zajistí co největší přezkoumatelnost činnosti exekutorů, zvýší se efektivita vymáhání dluhů a zajistí se sjednocený přístup exekutorů v celé ČR."
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-18",
+      "answer": "yes",
+      "comment": "Mělo by docházet ke slučování dluhů všech exekucí dlužníka pod jednoho exekutora. "
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-19",
+      "answer": "no",
+      "comment": "Sociální bydlení by mělo být navázáno potřebu v konkrétní lokalitě a rozhodovat o něm by si měly municipality. Důležité je mít dostatek bytů, kterými budou obce disponovat. Množství sociálního bydlení pak již závisí na místní situaci. "
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-20",
+      "answer": "no",
+      "comment": "Stát má zlepšit informovanost o možnostech podpory, snažit se dostat jasné, přehledné, srozumitelné informace k lidem. A zároveň umožnit potřebným tyto možnosti snadno využít. Ale není reálně v moci státu se aktivně starat o každého jednotlivce. "
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-21",
+      "comment": "Podporuji myšlenku omezit centralizaci všech institucí z důvodu vyrovnávání atraktivity regionů, na druhou stranu není žádoucí, aby to vedlo ke snížení efektivity jejich fungování. Toto je ke zvážení pro konkrétní státní instituce jednotlivě."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-22",
+      "answer": "yes",
+      "comment": "Zapojení do mezinárodních vesmírných programů včetně kolonizace Marsu je důležitým prvkem pro udržení konkurenceschopnosti průmyslu i vysoké úrovně vědeckého bádání."
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-23",
+      "answer": "yes",
+      "comment": "Zcela zásadní je zde bezpečnost a spolehlivost technické realizace elektronických voleb."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-24",
+      "answer": "no",
+      "comment": "Zásadní je dostupnost informací o vzdělávací nabídce, perspektivě budoucího uplatnění a kariérové poradenství. Ale není zdaleka zřejmé, že nynější technické vzdělávání je přínosné pro životní dráhu současných studentů více než jiné obory."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-25",
+      "answer": "no",
+      "comment": "Svobodu vzdělávání považuji za důležitou. Podporuji alternativní možnosti vzdělávání jako je individuální vzdělávání, homeschooling nebo unschooling. Podstatný je zde cíl, stanovení toho, co od základního vzdělávání očekáváme, ne tak samotná cesta."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-26",
+      "answer": "yes",
+      "comment": "Samotná inkluze je přínosná, protože spojuje společnost. Nicméně nastavení u nás je vhodné přehodnotit a poskytnout školám náležitou podporu, aby inkluzí nedocházelo ke snížení hodnoty vzdělávání."
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-27",
+      "answer": "no",
+      "comment": "EU je pro nás jednoznačně přínosná, jak politicky, tak ekonomicky. Má smysl přemýšlet o zlepšení jejího fungování, ale ne o vystoupení."
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-28",
+      "answer": "yes",
+      "comment": "Z dlouhodobého hlediska je společná měna jednoznačně přínosná jak hospodářsky tak psychologicky."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-29",
+      "answer": "no",
+      "comment": "NATO je zásadním posílením naší vojenské bezpečnosti. Toto nejsme schopni odpovídajícím způsobem nahradit."
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-30",
+      "answer": "yes",
+      "comment": "ČR je otevřená ekonomika významně navázaná na ostatní evropské země. Užší integrace je pro nás jednoznačně přínosná."
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-31",
+      "answer": "yes",
+      "comment": "Podpora zahraniční rozvojové spolupráce a humanitární pomoci významně zlepšuje naše mezinárodní postavení, posiluje naši bezpečnost a zvyšuje ochotu ostatních s námi spolupracovat."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-32",
+      "answer": "yes",
+      "comment": "Není úplně zřejmé, co se zde myslí, nicméně ohled na ostatní, které svým jednáním na společné planetě ovlivňujeme, je samozřejmý."
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-33",
+      "answer": "yes",
+      "comment": "Žádost o azyl musí být především zefektivněna tak, abychom byli schopni vyřídit větší množství žádostí o azyl bez vyvolání humanitární krize. Azylové řízení musí samozřejmě nadále splňovat požadavky na bezpečnostní kontrolu příchozích, stejně jako preference sjednocování rodin."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-34",
+      "answer": "yes",
+      "comment": "Volný pohyb ve svobodném světě považuji dnes už za samozřejmost."
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-35",
+      "answer": "yes",
+      "comment": "Na vlastní bezpečnosti bychom se měli podílet poměrem odpovídajícím existujícím rizikům."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-36",
+      "answer": "no",
+      "comment": "Tuto možnost nepovažuji při současné kulturní úrovni za eticky vhodnou."
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-37",
+      "answer": "yes",
+      "comment": "Je to rozšíření svobodného rozhodování, které jiné neomezuje."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-38",
+      "comment": "Záleží na míře specializace - počtu dotčených pacientů. Má smysl, aby nejvíce specializovaná péče byla plně centralizovaná. Ale běžná specializovaná péče může být dostupná v každé nemocnici."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-39",
+      "answer": "yes",
+      "comment": "Ano, ale je to vytržený jeden prvek z mnoha. Dává smysl všechny prokázaně škodlivé látky postupně eliminovat. Na druhou stranu to nelze provést naráz a se všemi, protože na to naše zemědělství a průmysl nejsou připraveny."
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-40",
+      "answer": "no",
+      "comment": "Nejedná se o nadbytečné omezování svobody a soukromí. Je ovšem třeba vždy zvážit umístění těchto systémů - zda skutečně přispívají ke zvýšení bezpečnosti, plynulosti provozu, apod., a neslouží jen k šikaně v místech, kde daný rychlostní limit nedává smysl."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-41",
+      "answer": "yes",
+      "comment": "Jedná se nyní o problematickou technologii s vysokým rizikem zneužití. Lze ho jen obtížně veřejně kontrolovat. Bezpečnostní přínosy nepovažuji za dostatečné k vyvážení těchto rizik."
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-42",
+      "answer": "yes",
+      "comment": "Je zcela v našem zájmu, aby Ukrajina fungovala za srovnatelných pravidel a hodnot. Ze stability Ukrajiny a užší spolupráce s ní může EU pouze těžit. "
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-43",
+      "answer": "yes",
+      "comment": "NATO je bezpečnostní a obranná organizace sdružující státy podobných hodnot, které chtějí společně bránit. Ukrajina sdílí naše hodnoty lidských práv a demokracie, a jako taková by měla být součástí našeho obranného uskupení."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-44",
+      "comment": "Nejsem si jist, jestli je toto nejlepší řešení. Může být přechodné, ale může také přinést jiné komplikace, které samotné zastropování nevyřeší. Doporučuji mít v záloze více cest a možností, mezi kterými budeme moct vybírat podle vývoje situace."
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-45",
+      "answer": "no",
+      "comment": "Ombudsman má chránit práva lidí bez rozdílů, což bohužel dlouhodobě nečiní. Naopak opakovaně šíří předsudky a xenofobii ve společnosti. Stanislav Křeček není schopný vykonávat úřad ombudsmana v souladu se svým slibem, tedy nezávisle a nestranně."
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-46",
+      "answer": "yes",
+      "comment": "Jedná se jednoznačně o porušení mezinárodního práva a je v našem zájmu požadovat jeho dodržování."
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-47",
+      "answer": "no",
+      "comment": "Ruská administrativa na okupovaném Krymu není řádným partnerem pro českou stranu."
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-48",
+      "answer": "yes",
+      "comment": "Istanbulská úmluva od států vyžaduje lepší ochranu obětí a efektivní stíhání pachatelů. Přijetí úmluvy je symbolem a zároveň závazkem potírat tyto formy násilí."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-49",
+      "comment": "Bylo by to velmi vhodné, nejsem si však jist, zda je to opravdu reálné. Budu podporovat kroky, které ke dřívějšímu ukončení spalování uhlí povedou, ale nikoliv za každou cenu."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-50",
+      "answer": "yes",
+      "comment": "Zásadní snižování emisí skleníkových plynů je nutné a musíme se o něj snažit na všech úrovních. Z dlouhodobého hlediska pouze klimatická neutralita je udržitelná."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-51",
+      "answer": "no",
+      "comment": "ČR nesmí schvalovat porušování mezinárodních pravidel."
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-52",
+      "answer": "no",
+      "comment": "ČR by tím svoji pozici oslabila a zásadně podlomila mezinárodní důvěryhodnost."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-53",
+      "answer": "yes",
+      "comment": "NATO je bezpečnostní a obranná organizace sdružující státy podobných hodnot, které chtějí společně bránit. Finsko a Švédsko sdílí naše hodnoty lidských práv a demokracie, a jako takové by měly být součástí našeho obranného uskupení."
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-54",
+      "answer": "yes",
+      "comment": "Smyslem dotací je napravovat selhání trhu. Podpora malých farem je jednou z obran proti selhání trhu. "
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-55",
+      "comment": "Nejsem si jist, nakolik je toto tak závažný problém, aby ho bylo nutno řešit zákonem."
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-56",
+      "answer": "no",
+      "comment": "Obce a města mají lepší znalost potřeb bydlení pro své občany a měly by si svou bytovou politiku určovat samy. Stát může zajistit legislativní rámec, metodickou podporu a pomoct efektivnímu fungování trhu."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-57",
+      "answer": "no",
+      "comment": "Jednoznačně podporuji respektování mezinárodních dohod a pravidel, nikoliv zákon džungle a právo každého dobýt si vojensky, na co stačí."
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-1-c-107987",
+      "question_id": "senatni-2022-1-q-58",
+      "answer": "yes",
+      "comment": "Nedává smysl pokračovat v bezvýsledné činnosti, je to zátěž pro obě strany."
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/10.json
+++ b/data/kalkulacka/senatni-2022/10.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-10",
-  "name": "10",
-  "description": "10 - DESCRIPTION",
+  "name": "",
+  "description": "",
   "district_code": "10",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-10-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-10-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-10-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-10-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-10-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-10-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-10-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-10-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-10-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-10-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-10-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-10-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-10-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-10-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-10-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-10-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-10-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-10-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-10-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-10-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-10-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-10-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-10-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-10-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-10-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-10-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-10-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-10-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-10-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-10-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-10-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-10-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-10-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-10-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-10-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-10-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-10-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-10-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-10-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-10-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-10-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-10-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-10-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-10-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-10-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-10-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-10-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-10-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-10-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-10-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-10-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-10-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-10-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-10-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-10-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-10-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-10-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-10-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-10-candidate-908666",
+      "id": "senatni-2022-10-c-908666",
       "name": "Robert Huneš",
-      "type": "party",
+      "type": "person",
       "description": "Robert Huneš - DESCRIPTION",
       "contacts": {
         "web": [
@@ -500,7 +502,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-10-908666-party",
+          "id": "senatni-2022-10-c-908666-p",
           "name": "Robert Huneš",
           "description": "Robert Huneš - DESCRIPTION",
           "contacts": {
@@ -525,9 +527,9 @@
       ]
     },
     {
-      "id": "senatni-2022-10-candidate-593117",
+      "id": "senatni-2022-10-c-593117",
       "name": "Tomáš Jirsa",
-      "type": "party",
+      "type": "person",
       "description": "Tomáš Jirsa - DESCRIPTION",
       "contacts": {
         "web": [
@@ -546,7 +548,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-10-593117-party",
+          "id": "senatni-2022-10-c-593117-p",
           "name": "Tomáš Jirsa",
           "description": "Tomáš Jirsa - DESCRIPTION",
           "contacts": {
@@ -569,9 +571,9 @@
       ]
     },
     {
-      "id": "senatni-2022-10-candidate-974997",
+      "id": "senatni-2022-10-c-974997",
       "name": "Dalibor Uhlíř",
-      "type": "party",
+      "type": "person",
       "description": "Dalibor Uhlíř - DESCRIPTION",
       "contacts": {
         "web": [
@@ -589,7 +591,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-10-974997-party",
+          "id": "senatni-2022-10-c-974997-p",
           "name": "Dalibor Uhlíř",
           "description": "Dalibor Uhlíř - DESCRIPTION",
           "contacts": {
@@ -611,16 +613,16 @@
       ]
     },
     {
-      "id": "senatni-2022-10-candidate-488789",
+      "id": "senatni-2022-10-c-488789",
       "name": "Miroslav Lorenc",
-      "type": "party",
+      "type": "person",
       "description": "Miroslav Lorenc - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-10-488789-party",
+          "id": "senatni-2022-10-c-488789-p",
           "name": "Miroslav Lorenc",
           "description": "Miroslav Lorenc - DESCRIPTION",
           "contacts": {
@@ -631,9 +633,9 @@
       ]
     },
     {
-      "id": "senatni-2022-10-candidate-310539",
+      "id": "senatni-2022-10-c-310539",
       "name": "Václav Mikeš",
-      "type": "party",
+      "type": "person",
       "description": "Václav Mikeš - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -641,7 +643,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-10-310539-party",
+          "id": "senatni-2022-10-c-310539-p",
           "name": "Václav Mikeš",
           "description": "Václav Mikeš - DESCRIPTION",
           "contacts": {

--- a/data/kalkulacka/senatni-2022/13.json
+++ b/data/kalkulacka/senatni-2022/13.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-13",
-  "name": "13",
-  "description": "13 - DESCRIPTION",
+  "name": "Tábor",
+  "description": "Tábor",
   "district_code": "13",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-13-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-13-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-13-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-13-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-13-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-13-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-13-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-13-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-13-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-13-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-13-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-13-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-13-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-13-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-13-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-13-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-13-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-13-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-13-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-13-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-13-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-13-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-13-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-13-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-13-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-13-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-13-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-13-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-13-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-13-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-13-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-13-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-13-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-13-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-13-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-13-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-13-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-13-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-13-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-13-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-13-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-13-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-13-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-13-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-13-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-13-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-13-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-13-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-13-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-13-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-13-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-13-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-13-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-13-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-13-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-13-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-13-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-13-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-13-candidate-440713",
+      "id": "senatni-2022-13-c-440713",
       "name": "Marek Slabý",
-      "type": "party",
+      "type": "person",
       "description": "Marek Slabý - DESCRIPTION",
       "contacts": {
         "web": [
@@ -493,7 +495,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-13-440713-party",
+          "id": "senatni-2022-13-c-440713-p",
           "name": "Marek Slabý",
           "description": "Marek Slabý - DESCRIPTION",
           "contacts": {
@@ -511,9 +513,9 @@
       ]
     },
     {
-      "id": "senatni-2022-13-candidate-203124",
+      "id": "senatni-2022-13-c-203124",
       "name": "Martin Kákona",
-      "type": "party",
+      "type": "person",
       "description": "Martin Kákona - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -522,7 +524,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-13-203124-party",
+          "id": "senatni-2022-13-c-203124-p",
           "name": "Martin Kákona",
           "description": "Martin Kákona - DESCRIPTION",
           "contacts": {
@@ -535,9 +537,9 @@
       ]
     },
     {
-      "id": "senatni-2022-13-candidate-941147",
+      "id": "senatni-2022-13-c-941147",
       "name": "Jaroslav Větrovský",
-      "type": "party",
+      "type": "person",
       "description": "Jaroslav Větrovský - DESCRIPTION",
       "contacts": {
         "web": [
@@ -549,7 +551,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-13-941147-party",
+          "id": "senatni-2022-13-c-941147-p",
           "name": "Jaroslav Větrovský",
           "description": "Jaroslav Větrovský - DESCRIPTION",
           "contacts": {
@@ -565,9 +567,9 @@
       ]
     },
     {
-      "id": "senatni-2022-13-candidate-420091",
+      "id": "senatni-2022-13-c-420091",
       "name": "Jiří Machač",
-      "type": "party",
+      "type": "person",
       "description": "Jiří Machač - DESCRIPTION",
       "contacts": {
         "web": [
@@ -586,7 +588,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-13-420091-party",
+          "id": "senatni-2022-13-c-420091-p",
           "name": "Jiří Machač",
           "description": "Jiří Machač - DESCRIPTION",
           "contacts": {
@@ -609,9 +611,9 @@
       ]
     },
     {
-      "id": "senatni-2022-13-candidate-940838",
+      "id": "senatni-2022-13-c-940838",
       "name": "Martin Kupec",
-      "type": "party",
+      "type": "person",
       "description": "Martin Kupec - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -619,7 +621,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-13-940838-party",
+          "id": "senatni-2022-13-c-940838-p",
           "name": "Martin Kupec",
           "description": "Martin Kupec - DESCRIPTION",
           "contacts": {
@@ -631,16 +633,16 @@
       ]
     },
     {
-      "id": "senatni-2022-13-candidate-338969",
+      "id": "senatni-2022-13-c-338969",
       "name": "Jiří Šimánek",
-      "type": "party",
+      "type": "person",
       "description": "Jiří Šimánek - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-13-338969-party",
+          "id": "senatni-2022-13-c-338969-p",
           "name": "Jiří Šimánek",
           "description": "Jiří Šimánek - DESCRIPTION",
           "contacts": {
@@ -651,9 +653,9 @@
       ]
     },
     {
-      "id": "senatni-2022-13-candidate-459651",
+      "id": "senatni-2022-13-c-459651",
       "name": "Evžen Zadražil",
-      "type": "party",
+      "type": "person",
       "description": "Evžen Zadražil - DESCRIPTION",
       "contacts": {
         "web": [
@@ -666,7 +668,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-13-459651-party",
+          "id": "senatni-2022-13-c-459651-p",
           "name": "Evžen Zadražil",
           "description": "Evžen Zadražil - DESCRIPTION",
           "contacts": {
@@ -683,9 +685,9 @@
       ]
     },
     {
-      "id": "senatni-2022-13-candidate-267821",
+      "id": "senatni-2022-13-c-267821",
       "name": "Olga Bastlová",
-      "type": "party",
+      "type": "person",
       "description": "Olga Bastlová - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -693,7 +695,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-13-267821-party",
+          "id": "senatni-2022-13-c-267821-p",
           "name": "Olga Bastlová",
           "description": "Olga Bastlová - DESCRIPTION",
           "contacts": {
@@ -705,16 +707,16 @@
       ]
     },
     {
-      "id": "senatni-2022-13-candidate-545048",
+      "id": "senatni-2022-13-c-545048",
       "name": "Miloš Zábranský",
-      "type": "party",
+      "type": "person",
       "description": "Miloš Zábranský - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-13-545048-party",
+          "id": "senatni-2022-13-c-545048-p",
           "name": "Miloš Zábranský",
           "description": "Miloš Zábranský - DESCRIPTION",
           "contacts": {
@@ -725,5 +727,1454 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-9"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-11"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-13"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-16"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-17",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-22"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-25",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-28",
+      "answer": "yes",
+      "comment": "Ano, ale ne v současné době"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-31"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-32"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-36"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-40"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-50",
+      "comment": "v současné době v podstatě nelze objektivně odpovědět, v době růstu cen energií"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-52"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-54",
+      "answer": "no",
+      "comment": "zemědělské dotace by měly být pro všechny zemědělce, kteří produkují "
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-13-c-941147",
+      "question_id": "senatni-2022-13-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-4",
+      "answer": "no",
+      "comment": "V  našich podmínkách bychom se spíše než na rychlovlaky měli zaměřit na celkovou modernizaci dráhy ale především dostavění rozdělaných silničních spojení, která už měla být dávno postavená."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-6"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-8",
+      "answer": "no",
+      "comment": "Lidé s vyššími příjmy by za ně neměli být trestáni."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-9",
+      "answer": "yes",
+      "comment": "Jsem pro dekriminalizaci konopí"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-10",
+      "answer": "yes",
+      "comment": "Je k smíchu, že je v naší zemi možné, aby za čin tzv. bez oběti, jako je pěstování návykových látek byla stanovena vyšší trestní sazba, než za tak ohavný čin, jakým je znásilnění."
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-11",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-12",
+      "answer": "no",
+      "comment": "Za obsah na sítích, které umožňují uživatelům prezentaci jejich názorů, mají být odpovědní hlavně uživatelé. "
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-13",
+      "answer": "no",
+      "comment": "Je na dané síti, jaký obsah pustí do světa. Ideální je taková, která necenzuruje nic a nechá uživatele samotného si rozhodnout, co je a co není pravda. Trestat se mají pouze viditelné nenávistné projevy či podněcování k tresným činům. I to může být ale ošemetné. "
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-14",
+      "answer": "yes",
+      "comment": "Ano. Zrušme koncesionářské poplatky."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-15"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-16"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-19",
+      "answer": "no",
+      "comment": "Soukromá určitě ne. Je na soukromém vlastníkovi, jak si své byty zařídí. "
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-20",
+      "answer": "no",
+      "comment": "Je na lidech v nouzi, aby měli sami potřebu tuto nouzi řešit. Náš sociální systém jim pomoc umožňuje. "
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-21",
+      "comment": "Státní instituce by se měly hlavně decentralizovat. Jejich rozmístění pak nebude takový problém. "
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-22",
+      "answer": "no",
+      "comment": "ČR má teď mnohem větší věci na práci, než řešit kolonizaci Marsu. "
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-23",
+      "answer": "no",
+      "comment": "Náš volební zákon a systém, jakým se k volbám chodí, je v pořádku. Elektronizací se otevírají dvěře pro potenciální volební machinace. "
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-24",
+      "answer": "no",
+      "comment": "Technické vzdělávání je potřeba vylepšit hlavně na úrovni učňovského školství. Vysoké a střední školství by mělo být podporováno rovnoměrně a hlavně kvalitě. "
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-25",
+      "answer": "no",
+      "comment": "Děti se speciálním nadáním by měly mít co největší možnost rozvíjet svůj potenciál a růst. Netřeba je inkluzí zbytečně držet zkrátka. "
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-26",
+      "answer": "no",
+      "comment": "ne, viz předchozí odpověď. "
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-27",
+      "answer": "yes",
+      "comment": "V tuto dobu a za současné krize se jedná zřejmě o zbožné přání, ale přál bych si a zasadil se o srovnání právního rámce tak, abychom vrátily stav věcí před přijetí Lisabonské smlouvy, která umocnila demokratický deficit celé EU. Protože si ale myslím, že to v dnešní byrokratické Unii již není reálné, byl bych pro vystoupení, nebo pro vyškrtnutí článku 10a z naší Ústavy, a vrátil tak českému právu jeho sílu. "
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-28",
+      "answer": "no",
+      "comment": "Přijetí eura bych nepodpořil. V tuto dobu máme stav, kdy je možné platit eurem, tak korunou, a o své měně si rozhodujeme sami. Proč se tedy zbavovat suverenity v této oblasti a zbytečně odevzdávat další kompetence do Bruselu. Česká koruna k nám patří a měly bychom si ji zachovat."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-29",
+      "answer": "no",
+      "comment": "Přestože má NATO spoustu chyb a naprosto se mi nelíbí, co předvádělo v 90. letech na Balkáně, naše armáda není ve stavu, aby např. jako Rakousko mohlo mít samostatnou sílu. Je třeba upozorňovat na chyby NATO a snažit se o jeho zlepšení, v případě, že bude existovat lepší alternativa, jsem pro vystoupení. "
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-30",
+      "answer": "no",
+      "comment": "Místo ČR je tady u nás a případně u stolu s ostatními státy, které chtějí mezinárodně a diplomaticky jednat, a to rovnocenně. "
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-31"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-32"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-33"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-35",
+      "answer": "no",
+      "comment": "Ne, rozhodně ne v tuto chvíli. Je třeba méně peněz lidem brát a ty co jsou již vybrány, investovat na důležitější věci, než je armáda. "
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-38",
+      "answer": "no",
+      "comment": "Není-li to nutné, např. z finančních či dalších důvodů, není asi k centralizaci důvod."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-39",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-40",
+      "answer": "no",
+      "comment": "Ne. Jsem však pro zahájení úvahy nad úpravou dovolených rychlostí mimo obce a na dálnicích. "
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-41",
+      "answer": "yes",
+      "comment": "Ano. Nechtějme se dostat do podobného systému, jaký je nastolen v Číně.."
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-42",
+      "answer": "no",
+      "comment": "Ukrajina naprosto není v kondici, aby mohla být přijata do EU. Je to stát s jednou z nejvyšších korupcí na světě a slabou ekonomikou. Pokud podmínky nesplňuje, což nesplňuje, nemůže být přijatata pouze z solidárních důvodů. "
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-44",
+      "answer": "no",
+      "comment": "Problém se zastropováním cen je ten, že v momentě, kdy k němu dojde, nenastane kýžený efekt - místo toho, aby byl plyn levnějším, stane se nedostupnějším. V historii již došlo k zastropování cen na jiné zboží, stačí se ale podívat, co to ve finále způsobilo. Místo zlevnění nastal nedostatek.  "
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-45"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-47"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-48",
+      "answer": "no",
+      "comment": "Směrnice EU nemají nahrazovat národní zákony, přestože souhlasím s tím, aby se s situací ohledně domácího násilí něco dělalo. Pojďme to však vyřešit na tuzemské úrovni. "
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-49",
+      "answer": "no",
+      "comment": "V momentě, kdy zuří energetická krize, je stanovování cílů, kdy ani nevíme, jestli budeme v daném roce mít dostatek ostatních zdrojů, naprostá utopie. Cíle musíme stanovovat s vědeckým poznáním, a ne politicky podle toho, jak se nám to zrovna líbí. "
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-50",
+      "answer": "no",
+      "comment": "EU se musí vymanit ze svého iluzorního stavu, kdy největšími znečišťovately jsou rozvojové státy, Čína a USA. Pokud chce EU něco dělat s tímto stavem, měla by se zaměřit tímto směrem na tyto státy, a ne otravovat svoje občany nesmyslným green dealem a dalšími hloupostmi. "
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-51"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-53",
+      "answer": "yes",
+      "comment": "Finsko a Švédsko splnily vstupní podmínky, takže proč ne. "
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-54",
+      "answer": "no",
+      "comment": "Zemědělské dotace by se měly hlavně zrušit, neboť už naše zemědělství poničily více než dost. Malé firmy mají být podporovány z pozice regionu, usnadnění prodeje ze dvora a marketingově. Dotace by také měly být směřovány, když už je tedy máme, na efektivní hospodaření a ne na plochu. "
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-56",
+      "answer": "no",
+      "comment": "Ne, neboť stát je zpravidla špatný hospodář a nedovedu si moc představit, že by je spravoval bez korupce či přebytečného vyhazování peněz. "
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-13-c-459651",
+      "question_id": "senatni-2022-13-q-58",
+      "answer": "yes",
+      "comment": "Ano, avšak s přihlédnutím k osobě dlužníka."
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-1",
+      "comment": "Při zdanění by se mělo jednat o skutečně dlouhodobé prázdné byty. Pokud si drží prázdný byt rodiče pro svoje děti, není důvod ho více zdaňovat. Pokud se jedná o \"kšeftování\" s byty a vydělávání na jejich nedostatku, tak by mělo větší zdanění nastoupit.   \n"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-2",
+      "answer": "yes",
+      "comment": "Ano, ale jen u malých bytů. U velkých bytů bych regulaci neřešil.  "
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-3",
+      "answer": "yes",
+      "comment": "Mělo by se týkat skutečně závažných rozhodnutí, ne na každou maličkost a s příslušným počtem podpisů. Ne všechno lze řešit referendem, to by potom byly volené orgány zbytečné a rozhodnutí by trvalo neskutečně dlouho.   "
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-4",
+      "answer": "no",
+      "comment": "To bychom spojili jenom hlavní centra a ve zbytku republiky bychom neřešili ani základní dopravní infrastrukturu.  "
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-5",
+      "answer": "no",
+      "comment": "V řadě povolání je uvedená hranice únosná, v některých už je za hranicí."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-6",
+      "answer": "yes",
+      "comment": "Pokud chceme řešit zvyšující se nedostatek vody, musíme ji v krajině zadržet. Snažíme se o to v malém ve městech a obcích, ale je třeba to řešit komplexně. Dostatek vody je velice důležité pro celou krajinu.  "
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-7",
+      "answer": "yes",
+      "comment": "Dobrovolný sběr PET lahví a nápojových plechovek dosáhl určité hranice. Pokud chceme recyklaci navýšit, tak toho dosáhneme zřejmě pouze jejich zálohováním.  "
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-8",
+      "answer": "no",
+      "comment": "Z vyššího příjmu se čistě matematicky odvádí v absolutní částce větší daň. "
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-9",
+      "answer": "no",
+      "comment": "Kdo určí tu správnou hranici vlastní spotřeby? Léky s přísadou konopí ke koupi potřebným, to by mělo být zcela legální.   "
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-10",
+      "answer": "yes",
+      "comment": "Důležitost vyplývá už ze samé podstaty činu."
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-11",
+      "answer": "yes",
+      "comment": "Odvádění zisků zahraničních firem různým způsobem do zahraniční by se mělo dostat pod řádnou kontrolu.  "
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-12",
+      "answer": "yes",
+      "comment": "Každý by měl být zodpovědný za své chování a podnikání. "
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-13",
+      "answer": "yes",
+      "comment": "Samozřejmě po prověření."
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-14",
+      "answer": "no",
+      "comment": "Ale veřejnoprávní vysílání by mělo být skutečně veřejnoprávní bez vnucování názoru ze strany redaktorů."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-15",
+      "answer": "no",
+      "comment": "Zaplňují trh s pracovní silou, mají svůj význam."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-16",
+      "comment": "Zastávám tradiční hodnoty, to znamená, že manželství je svazkem ženy a muže. Vytvořme pro svazek dvojice stejného pohlaví nový institut a nemusí to být zrovna registrované partnerství, ve kterém by měla dvojice stejná práva a povinnosti jako manželé.   "
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-17",
+      "answer": "yes",
+      "comment": "Znalost místního prostředí by měla být výhodou."
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-18",
+      "answer": "yes",
+      "comment": "Pokud je myšleno, že jednoho dlužníka bude řešit jeden exekutor, tak je to v pořádku. Na druhou stranu jeden exekutor nemůže řešit jenom jednoho dlužníka.   "
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-19",
+      "answer": "no",
+      "comment": "Obecní a státní výstavba jednoznačně, ale nařizovat při soukromé výstavbě podíl sociálních bytů, to ne. Při větších developerských celcích bych spíše soukromníkům nařídil výstavbu občanské vybavenosti, která potom často chybí a financuje ji obec.   "
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-20",
+      "answer": "no",
+      "comment": "Pokud máme zaveden pouze trvalý pobyt v obci či ve městě a velké množství lidí bydlí zcela jinde a neexistuje povinnost přechodného pobytu, tak je vyhledávání prakticky nemožné."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-21",
+      "answer": "yes",
+      "comment": "Přílišná centralizace není dobrá."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-22",
+      "answer": "no",
+      "comment": "Řešme problémy, které nás skutečně trápí. Kolonizace Marsu mezi ně určitě nepatří."
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-23",
+      "answer": "yes",
+      "comment": "Samozřejmě s příslušným zabezpečením proti manipulaci s hlasy. Bylo by to jednodušší, levnější a rychlejší."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-24",
+      "answer": "yes",
+      "comment": "Ano v určitém období. A nyní se v tomto období nacházíme. To nemusí být dogma na celou věčnost."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-25",
+      "answer": "no",
+      "comment": "Není důvod potírat talenty ve třídách. Mělo by se jednat skutečně o talenty, se kterými je vhodné pracovat samostatně. Průměrnosti a nevyčnívání z davu bylo již v minulosti dost.  "
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-26",
+      "answer": "no",
+      "comment": "Ten, kdo chce skutečně vidět některé výsledky inkluze v praxi, tak by se k tomuto problému stavěl jinak. Nejedná se o slabší žáky, ti přece do normální třídy patří. V řadě případů se jedná o různě postižené, nemocné děti a mělo by být na odborníkovi určit zda půjdou do normální nebo jiné třídy. Větší objem inkluze ve třídě zhoršuje vzdělávání a celková úroveň kolektivu jde potom dolů.     "
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-27",
+      "answer": "no",
+      "comment": "Mohou se nám některé věci nelíbit, nemusíme s něčím souhlasit, ale je na našich zástupcích co pro Českou republiku vybojují. Celý život je jeden velký kompromis a v rámci EU se o ně musíme snažit rovněž. "
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-28",
+      "answer": "yes",
+      "comment": "Je třeba ovšem vybrat ten správný okamžik."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-29",
+      "answer": "no",
+      "comment": "Nejsme schopni ufinancovat odpovídající armádu. Armády členských zemí by se měly v rámci NATO více specializovat a dohromady vytvořit silnou bojeschopnou armádu, která bude bránit zájmy EU.     "
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-30",
+      "answer": "yes",
+      "comment": "Pokud nechceme být na okraji zájmu, na okraji rozhodování a chceme ovlivňovat další vývoj EU musíme být aktivní.     "
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-31",
+      "comment": "Jde o to, aby rozvoj zahraniční spolupráce a humanitární pomoci byl v souladu s rozvojem České republiky. Upřednostňovat zahraniční pomoc na úkor domácích problémů lze jednorázově při výjimečných událostech. Nemohu rozdělovat více než vydělám, a to platí nejen při zahraniční pomoci.    "
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-32",
+      "answer": "no",
+      "comment": "Pokud bude platit řada zákonů např. v oblasti změn klimatu jen v České republice nebo jen v Evropě, tak to rozhodně problém neřeší a navíc nás zbytek světa ekonomicky převálcuje. "
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-33",
+      "answer": "no",
+      "comment": "Všichni jsem viděli, co udělal příliv imigrantů bez řízeného procesu v celé řadě zemí EU."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-34",
+      "answer": "yes",
+      "comment": "V rámci Schengenu ano, ale hranice Schengenu by se měly více chránit. "
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-35",
+      "comment": "Souvisí to se specializací armád jednotlivých členských zemí NATO. Pokud by došlo ke specializaci, potom by zřejmě k navyšování nemuselo docházet. "
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-36",
+      "answer": "no",
+      "comment": "Zastávám tradiční hodnoty, tohle už je skutečně velký zásah do dalšího vývoje lidstva. "
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-37",
+      "answer": "yes",
+      "comment": "Dobrovolnosti se meze nekladou. Samozřejmě s příslušnou kontrolou pojišťoven. "
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-38",
+      "answer": "yes",
+      "comment": "Personálně a technicky výborná zařízení by měla pracovat doslova ve dne v noci. Doprava pacientů na tato pracoviště je rozhodně méně nákladná než budování takových zařízení v každé nemocnici.  "
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-39",
+      "comment": "Zatím, alespoň co vím, nemáme nic jiného. I v našem městě jsme zkoušeli jiný způsob likvidace plevelu, bohužel bezvýsledně.  "
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-40",
+      "answer": "no",
+      "comment": "Bohužel provoz na silnicích neustále roste a odpovědnost řidičů bohužel ne. Pokud prevence nezabírá, musí nastoupit v tomto případě represe.   "
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-41",
+      "answer": "yes",
+      "comment": "To už je velký zásah do naší svobody."
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-42",
+      "comment": "Nechám na odbornících. Vstup je podmiňován vstupními podmínkami a v případě EU se nejedná o uzavřenou společnost.  "
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-43",
+      "answer": "no",
+      "comment": "V současné době rozhodně ne. Až další vývoj ukáže, co je reálné a co jsou jen sny. "
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-44",
+      "answer": "yes",
+      "comment": "Pokud to přispěje k částečnému řešení problémů s cenou energií.  "
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-45"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-47",
+      "answer": "no",
+      "comment": "Je řada jiných pěkných míst."
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-48",
+      "answer": "yes",
+      "comment": "Problém se musí řešit i bez směrnice EU, ale pokud by řešení pomohla, proč ne. Ten problém je stejný bez ohledu na zemi. "
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-49",
+      "answer": "no",
+      "comment": "Bavit se při současné situaci o jakémkoli ukončování nevidím reálné. Pokud aktuální energetická krize přispěje k rychlejšímu využívání obnovitelných zdrojů při odpovídající,  ekonomice, potom bychom se měli k uvedenému problému vrátit.      "
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-50",
+      "comment": "Evropa nemůže zůstat v této snaze sama. Stačí se podívat na zeměkouli, jak je velká Evropa a jak ostatní světadíly. Pokud v tom zůstane Evropa sama, tak se ekonomicky zničí. "
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-52",
+      "answer": "no",
+      "comment": "Jsme příliš malý stát. "
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-53",
+      "answer": "yes",
+      "comment": "Pokud splňují podmínky a povede to k naší větší bezpečnosti, potom ano."
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-54",
+      "comment": "Je třeba najít ten správný poměr rozdělování dotací mezi velké a malé farmáře s cílem zajistit kvalitní, pokud možno levné, tuzemské potraviny.  "
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-55",
+      "answer": "no",
+      "comment": "Trochu to zlehčím, ještě bych zakotvil povinnost poskytovat kartáčky na zuby."
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-56",
+      "comment": "Zase další centrální orgán, který by rozhodoval o pronajmutí bytu v malé obci, to asi ne."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-57",
+      "answer": "no",
+      "comment": "Již v minulosti se někomu ustupovalo a všichni víme, tak to dopadlo. "
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-13-c-338969",
+      "question_id": "senatni-2022-13-q-58",
+      "answer": "yes",
+      "comment": "Bezvýsledná práce přece nemá smysl."
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-10",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-25",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-35"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-13-c-203124",
+      "question_id": "senatni-2022-13-q-58",
+      "answer": "yes"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/16.json
+++ b/data/kalkulacka/senatni-2022/16.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-16",
-  "name": "16",
-  "description": "16 - DESCRIPTION",
+  "name": "Beroun",
+  "description": "Beroun",
   "district_code": "16",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-16-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-16-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-16-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-16-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-16-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-16-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-16-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-16-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-16-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-16-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-16-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-16-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-16-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-16-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-16-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-16-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-16-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-16-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-16-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-16-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-16-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-16-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-16-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-16-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-16-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-16-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-16-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-16-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-16-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-16-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-16-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-16-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-16-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-16-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-16-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-16-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-16-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-16-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-16-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-16-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-16-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-16-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-16-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-16-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-16-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-16-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-16-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-16-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-16-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-16-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-16-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-16-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-16-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-16-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-16-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-16-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-16-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-16-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-16-candidate-875643",
+      "id": "senatni-2022-16-c-875643",
       "name": "Michal Auředník",
-      "type": "party",
+      "type": "person",
       "description": "Michal Auředník - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -487,7 +489,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-16-875643-party",
+          "id": "senatni-2022-16-c-875643-p",
           "name": "Michal Auředník",
           "description": "Michal Auředník - DESCRIPTION",
           "contacts": {
@@ -499,9 +501,9 @@
       ]
     },
     {
-      "id": "senatni-2022-16-candidate-219251",
+      "id": "senatni-2022-16-c-219251",
       "name": "Janis Sidovský",
-      "type": "party",
+      "type": "person",
       "description": "Janis Sidovský - DESCRIPTION",
       "contacts": {
         "web": [
@@ -524,7 +526,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-16-219251-party",
+          "id": "senatni-2022-16-c-219251-p",
           "name": "Janis Sidovský",
           "description": "Janis Sidovský - DESCRIPTION",
           "contacts": {
@@ -551,9 +553,9 @@
       ]
     },
     {
-      "id": "senatni-2022-16-candidate-728249",
+      "id": "senatni-2022-16-c-728249",
       "name": "Jiří Oberfalzer",
-      "type": "party",
+      "type": "person",
       "description": "Jiří Oberfalzer - DESCRIPTION",
       "contacts": {
         "web": [
@@ -567,7 +569,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-16-728249-party",
+          "id": "senatni-2022-16-c-728249-p",
           "name": "Jiří Oberfalzer",
           "description": "Jiří Oberfalzer - DESCRIPTION",
           "contacts": {
@@ -585,9 +587,9 @@
       ]
     },
     {
-      "id": "senatni-2022-16-candidate-244153",
+      "id": "senatni-2022-16-c-244153",
       "name": "Martin Karim",
-      "type": "party",
+      "type": "person",
       "description": "Martin Karim - DESCRIPTION",
       "contacts": {
         "web": [
@@ -614,7 +616,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-16-244153-party",
+          "id": "senatni-2022-16-c-244153-p",
           "name": "Martin Karim",
           "description": "Martin Karim - DESCRIPTION",
           "contacts": {
@@ -645,5 +647,1116 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-1",
+      "answer": "yes",
+      "comment": "Rád bych nějak motivoval vlastníky bytů k jejich použití pro bydlení."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-2",
+      "answer": "yes",
+      "comment": "Bydlení musí zůstat pro lidi dostupné."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-3",
+      "answer": "no",
+      "comment": "Stávající úprava je dostatečná, Parlament v případě potřeby může referendum vyhlásit. "
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-5",
+      "answer": "no",
+      "comment": "Důchodový věk není možné neustále zvyšovat. "
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-8",
+      "answer": "no",
+      "comment": "Určitá míra progresivního zdanění již funguje dnes. Zdroje musí stát hledat jinde, například v omezení daňových úniků. Zdanění práce je v ČR vysoké."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-9",
+      "answer": "yes",
+      "comment": "Uškodilo by to jen zločincům, kterým by klesly jejich nelegální příjmy."
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-10",
+      "answer": "yes",
+      "comment": "Jedná se o zločin proti lidské důstojnosti, který je bohužel v mnoha případech buď neřešen nebo nedostatečně potrestán."
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-21",
+      "comment": "Bylo by hezké veřejnoprávní instituce rozmístit po celém území republiky, je to ale značná investice a je třeba dbát, aby to nemělo vliv na efektivitu státní správy."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-23",
+      "answer": "yes",
+      "comment": "Dnes je mnoha lidem upřeno nebo ztíženo jejich volební právo a to je nepřijatelné."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-25",
+      "comment": "Dvě z mých dětí prošly z různých důvodů osmiletými gymnázii. Byl bych rád, kdyby bylo možné stejně jako ve Finsku děti vzdělávat co nejdéle společně. Doufám, že až povyrostou mé dvě mladší děti, bude základní školství na tuto změnu již připraveno."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-33",
+      "answer": "no",
+      "comment": "Současná platná česká právní úprava je dostatečná.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-37",
+      "comment": "Jsem pro možnost volby nadstandartů ze strany pojištěnců, ale obávám se, aby nedošlo k omezení standartní základní péče. Pokud bude zaručeno, aby funkční základní péče byla zachována, nemám s připojištěním problém.  "
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-40",
+      "answer": "no",
+      "comment": "Tyto systémy některé řidiče vedou k tomu, že v obci zvolní."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-45",
+      "answer": "no",
+      "comment": "Současný ochránce práv řadu let neoprávněně užíval titul JUDr. a není pro výkon funkce kompetentní.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-49",
+      "answer": "no",
+      "comment": "Současná situace s drahými energiemi to neumožňuje."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-56",
+      "answer": "yes",
+      "comment": "Považuji to za dobrý nápad a také bych byl rád, aby nějaký veřejnoprávní bytový fond byl zapojen jako zdroj a investice do důchodové reformy."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-16-c-244153",
+      "question_id": "senatni-2022-16-q-58",
+      "answer": "yes",
+      "comment": "Dluhy sice mají být placeny, když jsou dlouhodobě nevymahatelné není efektivní je bezvýsledně dlouhodobě vymáhat."
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-2",
+      "answer": "no",
+      "comment": "Pokud ano, strop nájemného by měl být odstupňován dle lokalit. "
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-5",
+      "answer": "no",
+      "comment": "Potřebujeme systémovou reformu udržitelných důchodů, ne neustálé zvyšování věkové hranice."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-6",
+      "answer": "no",
+      "comment": "Jsou ekologičtější a efektivnější metody zadržování vody v krajině."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-8",
+      "answer": "no",
+      "comment": "Ne, ale mělo by se ulehčit daňové zatížení pracující střední třídy. Plus mám za to, že by vysokopříjmové osoby měly mít povinnost přispívat na sociální programy. "
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-9",
+      "answer": "yes",
+      "comment": "Jsou škodlivější návykové látky a přesto jsou legální. "
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-12",
+      "answer": "yes",
+      "comment": "Ano, v případě nejzávaznějších narušení veřejného pořádku."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-19",
+      "answer": "yes",
+      "comment": "V drahých lokalitách by měli mít nárok například i učitelé, hasiči, zdravotní sestry a podobně."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-20",
+      "answer": "no",
+      "comment": "Ale je třeba zlepšit informování veřejnosti v této otázce. "
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-23",
+      "answer": "no",
+      "comment": "Jsem pro možnost korespondenční hlasování. Stát aktuálně není schopen zajistit funkčnost a bezpečnost online hlasování. "
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-24",
+      "answer": "no",
+      "comment": "Jinak nepřestaneme být montovnou Evropy. Tyto profese jsou zároveň nejvíce ohroženy robotizací."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-26",
+      "answer": "yes",
+      "comment": "Ale je potřeba zlepšit financování a personální zajištění."
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-28",
+      "answer": "yes",
+      "comment": "Vlastní měna při našem navázání na Německo je více zranitelná, jak ukazuje současná inflace. "
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-31",
+      "answer": "yes",
+      "comment": "Ne ve smyslu rozdávání financí, ano ve smyslu podpory institucionálních změn. "
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-33"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-35",
+      "answer": "yes",
+      "comment": "2% HDP, jak jsme se zavázali NATO"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-41",
+      "answer": "yes",
+      "comment": "Jedná se o významný zásah do soukromí. Dovedu si představit využívání jen v trestním řízení s dohledem soudu. "
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-42",
+      "answer": "yes",
+      "comment": "Za předpokladu splnění všech podmínek, včetně ekonomických ukazatelů a stavu demokratických institucí a za předpokladu odbourání systémové korupce, která na Ukrajině bují. "
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-52",
+      "answer": "no",
+      "comment": "Při společném vyjednávání s ostatními státy EU jsme silnější"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-54",
+      "answer": "yes",
+      "comment": "Jsem pro zachování rovnosti, rozhodně ne zvýhodňovat velké farmy."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-55",
+      "answer": "yes",
+      "comment": "Především jsem zajištění těchto hygienických potřeb ve vzdělávacích zařízeních. "
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-56",
+      "answer": "yes",
+      "comment": "Především pro sociální bydlení. "
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-16-c-219251",
+      "question_id": "senatni-2022-16-q-58",
+      "comment": "Ano, ale ne v případě, kdy dlužníci vyvedou majetek jinam a užívají jej nadále. Časové hledisko by mělo začínat na hranici 10 let. "
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-1",
+      "answer": "no",
+      "comment": "Jedná se o soukromý majetek a tyto \"dodatečné\" zdanění, která mají naplnit státní kasu, jsou krokem zpět. Co zdaníme dál? Auto, kterým nejezdíte nebo panenku, se kterou si nehrajete? Běžný občan půl roku vydělává na stát. Co takhle daleko efektivnější hospodaření státu, než další daně? "
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-2",
+      "answer": "no",
+      "comment": "ČR by spíše měla regulovat ceny pohonných hmot, od kterých se pak odvíjí následné další zdražování. "
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-3",
+      "answer": "yes",
+      "comment": "Ano. O důležitých věcech by měli lidé mít možnost hlasovat. Třeba o setrvání v EU. "
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-4",
+      "comment": "Záleží na regionu. Konkrétně v Berouně & Praha západ by výstavba mohla velmi pomoci a ulehčit tak D5 a dopravě ve městě. "
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-6",
+      "answer": "yes",
+      "comment": " "
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-7",
+      "comment": "Nebyl bych asi proti. Nicméně, navýšil bych kapacitu kontejnerů na třídění odpadu. Často jsou přeplněné a pak se nepořádek válí všude kolem nebo odpad končí na nelegálních skládkách. "
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-8",
+      "answer": "no",
+      "comment": "Nesouhlasím s trestáním lidí, kteří dají práci více než ostatní. Je to z mého pohledu spíše daň za úspěch. Tito lidé vytváří pracovní pozice, zaměstnávají lidi a často se podílí i rozvoji samotného regionu.  "
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-9",
+      "answer": "yes",
+      "comment": "Konopí je od pradávna známé jako bylina, které dokáže zázraky (především na klouby). Problém konopí je, že z něj na rozdíl od alkoholu, stát nemá příjmy. Alkohol je tvrdá droga, kterou si lze legálně koupit a která Vám může doslova zničit život. "
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-10",
+      "answer": "yes",
+      "comment": "100%   A nejen za znásilnění! Již samotný případný postih musí být takový, aby nebyl výsměchem, ale byl skutečným trestem. Výše trestu sám o sobě by měl být prevencí. Pokud násilník může zničit život někomu jinému, musí počítat s tím, že trest bude odpovídat. "
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-11",
+      "answer": "yes",
+      "comment": "Nevidím jediný důvod, proč nemají odvádět daně, pokud podnikají na území ČR. "
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-12",
+      "answer": "no",
+      "comment": "Pokud se nejedná o vyloženě zakázaný obsah (např. pornografie), pak za obsah má být zodpovědný ten, kdo jej sdílí. Sociální sítě se často stávají cenzorem, který rozhoduje o tom, co je povolené a co zakázané. I sociální síť má svého majitele, kterému slouží a mají tak možnost ovlivnit názor ve společnosti. Přesně to se teď i nyní děje. "
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-13",
+      "answer": "no",
+      "comment": "Otázkou je, co je \"fake news\"? Z minulosti víme, že byly mazané zprávy a lidé blokovaní, pokud napsali zprávu, která se o pár týdnů nebo měsíců ukázala, jako pravdivá. Především doba covidová zde přinesla spoustu takových případů. Žijeme v moderním světě, kdy si lidé snadno mohou ověřit, pokud je informace opravdu zajímá, co je na ní pravdy. Nelze vše cenzurovat a mazat. Zůstane pak jen vládní propaganda a povolený názor. "
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-14",
+      "answer": "yes",
+      "comment": "Jsem pro okamžité zrušení poplatků. Některá veřejnoprávní média opravdu nepůsobí jako nestranná. "
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-15"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-16",
+      "answer": "no",
+      "comment": "Manželství je svazek muže a ženy. "
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-17"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-19",
+      "answer": "no",
+      "comment": "Myslím, že existují jiná, lepší řešení. "
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-20",
+      "answer": "no",
+      "comment": "Stát se má především starat, aby těch lidí bylo co nejméně a ne je cíleně \"vyrábět\". "
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-21",
+      "comment": "Spíše ano. Asi by to nemělo být přímo pravidlo, ale postupné zlepšení lepší dostupnosti by určitě ušetřilo čas a náklady. "
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-22",
+      "answer": "no",
+      "comment": "Máme spoustu problémů zde v České republice. Až budou všechny vyřešeny, můžeme kolonizovat Mars.  "
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-23",
+      "answer": "no",
+      "comment": "Jen v případě, že daný volič prokazatelně nemůže (např. kvůli zdraví) se osobně dostavit. Doplnění: Osobně bych podpořil zamítnutí korespondenční volby ze zahraničí. Nevidím jediný důvod, proč by o lidé, kteří dlouhodobě žijí v cizině, měli rozhodovat a lidech žijících v ČR. "
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-24",
+      "comment": "Spíše ano. "
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-25",
+      "answer": "no",
+      "comment": "Pokud má dítě talent na určitou věc, měl by se rozvíjet co nejdříve. Proč mučit někoho matikou, když je od přírody talent na zpěv nebo housle? "
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-26",
+      "answer": "no",
+      "comment": "Bohužel, realita má spíše opačný efekt. Slabší žáci brzdí nebo mohou negativně ovlivnit nadané. "
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-27",
+      "answer": "yes",
+      "comment": "Včera bylo pozdě. Více o mém názoru na webu senatormichal.cz"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-28",
+      "answer": "no",
+      "comment": "Doufám, že nikdy. Po euro bude následovat CBDS (digitální měna) a dílo zkázy bude dokonáno. Opět je to složitější téma, ale pokud se podíváte, jak např. Piráti již dnes tlačí na digitalizaci, začne to vše do sebe velmi nebezpečně zapadat. "
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-29",
+      "answer": "yes",
+      "comment": "Jsem proti cizím vojenským základnám a pobytu cizích vojsk na území ČR. "
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-30",
+      "comment": "Ano, jsme v srdci Evropy, to ale neznamená, že musíme být v jádru Evropské Unie. "
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-31",
+      "answer": "no",
+      "comment": "ČR by měla PŘEDEVŠÍM podporovat vlastní obyvatele na prvním místě. "
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-32",
+      "answer": "no",
+      "comment": "Kdo prosím bere ohledy na zájmy ČR? "
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-33",
+      "answer": "no",
+      "comment": "Právě naopak. ČR by si měla pečlivě vybírat, koho si pouští na své území. "
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-34",
+      "answer": "no",
+      "comment": "Není to tak dávno, co nás Němci odmítali pustit za hranice (lidi, kteří dojíždí za prací do Německa). Na hranicích se museli prokazovat PCR testy, aby vůbec mohli za prací. Příště si můžou vymyslet jiné důvody a pak smysl volného prostoru zcela ztrácí na svém významu.  Já bych byl pro obnovení kontroly na hranicích. Těch 5 minut nikoho nezabije a přesně budeme vědět, koho si pouštíme do země. To platí teď dvojnásob. Míří k nám ekonomických migrantů a pokud bude v Africe nouze o vodu, Evropa se má na co těšit. Měli bychom vědět, koho si pouštíme na své území. "
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-35",
+      "answer": "no",
+      "comment": "Armáda má své opodstatnění, ale pokud u nás budou žít lidé, kteří zde pracovali a platili celý život daně na hranici chudoby, pak by se měl stát především postarat o ně. A to je jen jeden z mnoha příkladů. Jsem pro podporu vybavení, které může pomáhat např. při hašení požárů nebo při povodních, ale odmítám vyhazování desítek miliard za stíhačky a jiné válečné zbraně. "
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-36",
+      "answer": "no",
+      "comment": "Myslím, že to je zcela proti přírodě. Co si budou moci vybrat dále? Zda bude mít modrý oči, blond vlasy? "
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-37"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-38",
+      "comment": "Je to na diskuzi. Pokud by to pomohlo rychlejšímu termínu výkonu a lepší péci, byl bych určitě pro. "
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-39",
+      "comment": "Nechal bych si poradit o odborníků. Z mého pohledu ANO, ale neznám názor druhé strany. Je to na diskuzi a zvážení pro vs. proti. "
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-40",
+      "answer": "no",
+      "comment": "Systémy měření jsou určitě dobrým nástrojem u škol, školek a míst se zvýšenou koncentrací chodců. Silnice se často mění v závodní dráhu a v případě, že pravidla dodržujete, pak o radarech ani nevíte. Nicméně, pokud jsou ale záměrně umístěny např. přímo na hranici obce, kde každý už trochu přidá nohu na plyn, není to šťastné řešení. "
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-41",
+      "answer": "yes",
+      "comment": "Zavádění podobných systémů je příprava na systém sociálního kreditu a cesta do otroctví. Opět složité a zásadní téma. "
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-42"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-43"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-44",
+      "answer": "no",
+      "comment": "Pokud nechceme ztratit poslední možnost dodávky plynu na přímo z Ruska a zcela zničit ČR, pak určitě ne! "
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-46",
+      "comment": "Celé téma je velmi složité a nelze odpovědět ANO/NE. "
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-47",
+      "answer": "yes",
+      "comment": "Jedině tak se můžeme posunout blíže k míru. Místo posílání zbraní se pokusit diplomaticky vyjednávat jménem České republiky. "
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-48",
+      "answer": "yes",
+      "comment": "Česká republika by s tím měla poradit sama a nečekat, co pošle Brusel. Máme spoustu velmi kvalitních právníků, kteří by si s problematikou dobře poradili. "
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-49",
+      "comment": "Česká republiky musí pružně reagovat na situaci a tomu se přizpůsobit. Vše musí činit tak, aby rozhodnutí byla v nejlepším zájmu obyvatel, firem a institucí v ČR. V žádném případě na sebe nenechat tlačit z EU. "
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-50",
+      "answer": "no",
+      "comment": "Já doufám, že do té doby už dávno v EU nebudeme a ČR si opět bude o všem rozhodovat sama."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-51",
+      "comment": "Opět složité téma, na které se nedá říci ANO-NE."
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-52",
+      "answer": "yes",
+      "comment": "Nevidím jediný důvod, proč ne. Důležitá je pro nás cena a plynulost dodávek. Proč máme kupovat ruský plyn z Německa za násobky ceny, nebo \"ekologicky\" předražený od našich milovaných spojenců z USA? Prvním krokem k úspěšné diplomacii je demise vlády současných prozápadních politiků. "
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-53",
+      "answer": "no",
+      "comment": "Za současné situace je to přilévání oleje do ohně a eskalovat konflikt s Ruskem znamená zkázu pro Evropu. "
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-54",
+      "comment": "Osobně jsem celkově proti dotacím, které často ničí přirozenou hospodářskou soutěž. V první řadě si musíme dostatečně ochránit vlastní trh a podporovat naše farmy a zemědělce. Jsou to oni, kdo by měl určovat ceny a ne se nechat vydírat supermarkety, kteří na úkor nich profitují. "
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-55",
+      "answer": "no",
+      "comment": "Co je tohle za otázku? To jako přijdu na úřad a budu po někom požadovat vložky? To jako vážně? Co dál? Mýdlo a zubní pastu? "
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-56",
+      "answer": "yes",
+      "comment": "Jsem pro podporu bydlení a pokud by toto řešení pomohlo, pak jsem určitě pro. "
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-57",
+      "comment": "Složité téma, nelze odpovědět ANO-NE. "
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-16-c-875643",
+      "question_id": "senatni-2022-16-q-58",
+      "answer": "yes",
+      "comment": "Pokud jsou opravdu dlouhodobě bezvýsledné, pak nemá smysl do nich nadále investovat čas a energii. "
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/19.json
+++ b/data/kalkulacka/senatni-2022/19.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-19",
-  "name": "19",
-  "description": "19 - DESCRIPTION",
+  "name": "Praha 11",
+  "description": "Praha 11",
   "district_code": "19",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-19-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-19-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-19-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-19-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-19-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-19-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-19-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-19-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-19-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-19-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-19-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-19-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-19-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-19-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-19-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-19-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-19-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-19-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-19-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-19-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-19-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-19-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-19-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-19-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-19-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-19-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-19-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-19-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-19-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-19-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-19-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-19-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-19-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-19-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-19-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-19-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-19-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-19-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-19-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-19-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-19-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-19-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-19-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-19-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-19-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-19-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-19-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-19-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-19-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-19-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-19-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-19-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-19-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-19-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-19-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-19-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-19-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-19-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-19-candidate-420727",
+      "id": "senatni-2022-19-c-420727",
       "name": "David Bohbot",
-      "type": "party",
+      "type": "person",
       "description": "David Bohbot - DESCRIPTION",
       "contacts": {
         "web": [
@@ -497,7 +499,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-19-420727-party",
+          "id": "senatni-2022-19-c-420727-p",
           "name": "David Bohbot",
           "description": "David Bohbot - DESCRIPTION",
           "contacts": {
@@ -519,9 +521,9 @@
       ]
     },
     {
-      "id": "senatni-2022-19-candidate-746291",
+      "id": "senatni-2022-19-c-746291",
       "name": "Milan Urban",
-      "type": "party",
+      "type": "person",
       "description": "Milan Urban - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -529,7 +531,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-19-746291-party",
+          "id": "senatni-2022-19-c-746291-p",
           "name": "Milan Urban",
           "description": "Milan Urban - DESCRIPTION",
           "contacts": {
@@ -541,9 +543,9 @@
       ]
     },
     {
-      "id": "senatni-2022-19-candidate-999606",
+      "id": "senatni-2022-19-c-999606",
       "name": "Šárka Oharková",
-      "type": "party",
+      "type": "person",
       "description": "Šárka Oharková - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -551,7 +553,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-19-999606-party",
+          "id": "senatni-2022-19-c-999606-p",
           "name": "Šárka Oharková",
           "description": "Šárka Oharková - DESCRIPTION",
           "contacts": {
@@ -563,9 +565,9 @@
       ]
     },
     {
-      "id": "senatni-2022-19-candidate-325120",
+      "id": "senatni-2022-19-c-325120",
       "name": "Vladimír Špidla",
-      "type": "party",
+      "type": "person",
       "description": "Vladimír Špidla - DESCRIPTION",
       "contacts": {
         "web": [
@@ -579,7 +581,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-19-325120-party",
+          "id": "senatni-2022-19-c-325120-p",
           "name": "Vladimír Špidla",
           "description": "Vladimír Špidla - DESCRIPTION",
           "contacts": {
@@ -597,9 +599,9 @@
       ]
     },
     {
-      "id": "senatni-2022-19-candidate-107153",
+      "id": "senatni-2022-19-c-107153",
       "name": "Ladislav Kos",
-      "type": "party",
+      "type": "person",
       "description": "Ladislav Kos - DESCRIPTION",
       "contacts": {
         "web": [
@@ -612,7 +614,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-19-107153-party",
+          "id": "senatni-2022-19-c-107153-p",
           "name": "Ladislav Kos",
           "description": "Ladislav Kos - DESCRIPTION",
           "contacts": {
@@ -629,9 +631,9 @@
       ]
     },
     {
-      "id": "senatni-2022-19-candidate-517013",
+      "id": "senatni-2022-19-c-517013",
       "name": "Robert Vašíček",
-      "type": "party",
+      "type": "person",
       "description": "Robert Vašíček - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -640,7 +642,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-19-517013-party",
+          "id": "senatni-2022-19-c-517013-p",
           "name": "Robert Vašíček",
           "description": "Robert Vašíček - DESCRIPTION",
           "contacts": {
@@ -653,9 +655,9 @@
       ]
     },
     {
-      "id": "senatni-2022-19-candidate-358095",
+      "id": "senatni-2022-19-c-358095",
       "name": "Tomáš Hudeček",
-      "type": "party",
+      "type": "person",
       "description": "Tomáš Hudeček - DESCRIPTION",
       "contacts": {
         "web": [
@@ -678,7 +680,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-19-358095-party",
+          "id": "senatni-2022-19-c-358095-p",
           "name": "Tomáš Hudeček",
           "description": "Tomáš Hudeček - DESCRIPTION",
           "contacts": {
@@ -705,9 +707,9 @@
       ]
     },
     {
-      "id": "senatni-2022-19-candidate-388017",
+      "id": "senatni-2022-19-c-388017",
       "name": "Hana Kordová Marvanová",
-      "type": "party",
+      "type": "person",
       "description": "Hana Kordová Marvanová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -722,7 +724,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-19-388017-party",
+          "id": "senatni-2022-19-c-388017-p",
           "name": "Hana Kordová Marvanová",
           "description": "Hana Kordová Marvanová - DESCRIPTION",
           "contacts": {
@@ -741,5 +743,1116 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-1",
+      "answer": "no",
+      "comment": "Vlastnictví nelze v právním státě trestat. Už vůbec samotná daň z nemovitostí je hanebná, protože penalizuje vlastnictví. Pokusy zdanit prázdné byty jsou reakcí na spekulativní trh s nemovitostmi. Já navrhuji vystavět na zelené louce nová sídliště napříč republikou a tyto státní byty už nikdy nikomu neprodat. Tím vyřešíme bytovou krizi. "
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-2",
+      "answer": "no",
+      "comment": "Na prvním místě jsou lidé, takže si dovedu představit 5letou lhůtu na výstavbu státních sídlišť a během výstavby si dovedu představit dočasnou regulaci, aby lidé po dobu těch 5 let měli kde bydlet. Jakmile zde vznikne alespoň 100 000 nových státních bytů napříč republikou, totiž zcela nová sídliště v katastru všech krajských měst, dále v dalších velkých sídlech v rámci republiky, tak odstranit jakoukoli regulaci. Protože buď se nabídka potká s poptávkou, nebo předražené byty zůstanou prázdné a lidé v nouzi půjdou bydlet do levných státních bytů. "
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-3",
+      "answer": "yes",
+      "comment": "Samozřejmě ano. Petice a celostátní referendum je projev vůle občanů a jakmile se vůler občanů rozchází se zvolenými politiky, je na řadě korektiv v podobě celostátního referenda. Kdo se toho bojí, nepřeje lidem skutečnou demokracii. "
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-4",
+      "answer": "no",
+      "comment": "Odpověděl jsem NE, protože kandiduji v Praze a hájím zájmy svých voličů a ti rychlovlak v Praze nepotřebují. Potřebujeme lepší silnice, obchvaty, okruhy a nová parkovací místa. Takže stavím na stejnou úroveň výstavbu silnic a dálnic a rovněž výstavbu koridorů pro rychlovlaky. Je to skvělá představa, že jako dědeček jednou pojhedu na chalupu na Vysočině 30 minut. "
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-5",
+      "answer": "no",
+      "comment": "Odmítám okrádání důchodců, snižování reálné hodnoty důchodů a zvyšování věku pro odchod do důchodu. Nabízím lepší řešení. Jako bývalý poradce ministra práce a sociálních věcí jsem detailně studoval důchodový systém v České republice. Na uživení jednoho důchodce potřebujeme alespoň dva daňové poplatníky v produktivním věku. Takže je třeba okamžitě začít všemi způsoby podporovat porodnost. Ať je nás klidně 20 milionů. Ptáte se, kam pak s těmi lidmi v naší maličké zemi? Národy kolem nás vymírají, budou vznikat česká osídlení v zahraničí, jako se to kdysi povedlo Volyňským Čechům. "
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-6",
+      "answer": "no",
+      "comment": "Z ekologického hlediska jsou vodní přehrady katastrofa, protože přerušují říční migraci. Tam, kde hrozily povodně, tam už dávno přehrady stojí a nové bych rozhodně nestavěl. Pokud jde o vodu, je třeba ji vrátit do krajiny formou hladiny spodních vod, nikoli formou přehradních bazénů. "
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-7",
+      "answer": "no",
+      "comment": "Určitě ne, protože by to prodražilo v nich prodávané nápoje. Navíc narozdíl od skla je nelze recyklovat, aniž by prošly náročným tříděním a opětovným roztavením. "
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-8",
+      "answer": "no",
+      "comment": "Vyšší sazba daně pro vyšší příjmy je nespravedlivá. Skutečně bohatí lidé, milionáři a miliardáři si totiž platy nevyplácejí a své příjmy vyvádějí přes dividendy, akcie a zahraniční trusty mimo daňový systém České republiky. Dokud nedokážeme zdanit superbohaté lidi, proč bychom trestali ty méně bohaté? "
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-9",
+      "answer": "yes",
+      "comment": "Marihuana ještě nikoho nezabila a naopak lidem s Alzheimerem nebo Parkinsonovou chorobou pomáhá od jejich nemoci. Kriminalizace se navíc děje jen proto, aby farmaceutické kartely mohly v lékárnách prodávat vlastní předraženou marihuanu, na kterou důchodce skutečně nemá. Takže okamžitě dekriminalizovat. "
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-10",
+      "answer": "yes",
+      "comment": "Nejvyšší hodnotou svobody člověka je neporušitelná duševní, tělesná a právní integrita. Nikdo nemá právo vzít si násilím tělo druhého člověka. Jsem ochoten připustit, že jsou lidé, kteří se neovládají. Pak ale ať žijí v ústavech, protože jejich volný pohyb ohrožuje ostatní."
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-11",
+      "answer": "yes",
+      "comment": "Pokud platí české e-shopy nebo inzertní portály, není žádný důvod, aby byla výjimka pro zahraniční společnosti. Ještě více je třeba řešit otázku dodržování Ústavy Čr a platných zákonů z hlediska svobody projevu, která je častokrát pošlapána na sociálních sítích. Zejména TikTok a Facebook bych přinutil dodržovat české zákony a svobodu slova. Obráceně každá urážka by byla ihned řešitelná právní cestou. V současnosti vás skupiny dezolátů napadají za váš názor brutálním a zastrašujícím způsobem. "
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-12",
+      "answer": "yes",
+      "comment": "Sociální sítě dnes v našich životech hrají stejně důležitou roli, jako naše projevy na veřejnosti a mají rovnocenný dosah na vaši pověst. "
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-13",
+      "answer": "yes",
+      "comment": "Neschvaluji současné mazání příspěvků neziskovkami, které nikdo z nás nezmocnil k vyrábění té jediné skutečné pravdy. Pokud se tedy vyskytne závadný výrok, měli byste mít možnost jej žalovat ke speciálnímu soudu, kde závadný výrok bude hájit jeho dohledatelný autor ze sociálních sítí a na druhé straně bude žalobce. Ten, kdo výrok zveřejní, by měl prokázat jeho pravdivost důkazy v jednodenním stání a obráceně ten, kdo výrok žaluje, by měl přinést důkazy jeho nepravdivosti. Výrok by měl padnout ten samý den zasedání a bude proti němu samozřejmě odvolání do 30 dnů od rozsudku a poté by měl být v případě potvrzujícího rozsudku závadný výrok okamžitě odstraněn. "
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-14",
+      "answer": "no",
+      "comment": "Česká televize a Český rozhlas plní veřejnoprávní roli, jsou ale bohužel nástrojem v rukou politiků. Navrhnu změnu zákona tak, abyste mohli učinit daňovou asignaci ve prospěch veřejnoprávních médií. Protože je jasné, že většina lidí by asignovala směrem k televizi, bude asignace pevně rozdělena v poměru 75:25 ve prospěch ČT před ČRo. Daňové asignace budou daňově odečitatelná položka, takže si tím snížíte základ daně. A tento systém nahradí povinné výpalné od všech občanů s přijímačem. Na jedné straně ubude počet předplatitelů, na druhé straně budete moci upsat daleko vyšší částku a především veřejnoprávní televize a rozhlas nebude vůbec závislé na politicích, ale jen na svých předplatitelích a tak je to v pořádku. Bude daleko nezávislejší žurnalistika. "
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-15",
+      "answer": "no",
+      "comment": "Pracovní agentury jsou často poslední šance získat práci pro lidi, kteří nemají pracovní návyky a v běžném pracovním poměru by se neudrželi. Proto nevidím důvod, proč je omezovat. "
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-16",
+      "answer": "yes",
+      "comment": "Jsem pro rovná práva i pro stejnopohlavní páry, odmítám ale používat výraz manželství. Ten vychází ze staročeského mal žen a dva gayové prostě nemají ženu. Podobně nenazýváme tygra králíkem a hada slepicí. Každopádně je neudržitelné, aby registrované partnerství bylo jen lepším přátelstvím, ale mělo by dostat rovnocenná práva s manželstvím, ve smyslu práv partnerů, nebo dědictví, vdovského důchodu a podobně. "
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-17",
+      "answer": "no",
+      "comment": "Především bych přistřihl křídla exekučnímu businessu. Zločinné spolčení justiční mafie s lichváři zneužívá půjčky bez ručitele, aby okradly lidi o všechno. Nově nebude možné vzít si půjčku bez ručitele. Zabráníme tím lichvě a exekucím."
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-18",
+      "answer": "no",
+      "comment": "Především bych přistřihl křídla exekučnímu businessu. Zločinné spolčení justiční mafie s lichváři zneužívá půjčky bez ručitele, aby okradly lidi o všechno. Nově nebude možné vzít si půjčku bez ručitele. Zabráníme tím lichvě a exekucím."
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-19",
+      "answer": "no",
+      "comment": "My na Praze 11, Praze 15, v Dolních Měcholupech, Praze 22 nebo Kolovratech víme, že developer se cpe pod různými záminkami do již uzavřeného městského prostředí a obsazuje při tom trávníky, parkoviště nebo původní objekt zboří a postaví tam něco megalomanského, aby na tom vydělal. To nechceme, nechte naše sídliště a naši zeleň být. Takže developer ať si staví tam, kde ho nechají místní a ať si s tím dělá, co chce. Naopak podporuji výstavbu státních bytů v nových lokalitách za městem tak, abychom za pět let postavili 100 000 nových bytů a ulevili tam lidem na trhu s nájemním bydlením a dali jim skutečnosu jistotu. "
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-20",
+      "answer": "no",
+      "comment": "Sociální dávky nevyřeší bytovou, ani pracovní situaci lidí. Lidem je třeba zajistit nová pracovní místa s takovým platem, aby žádné sociální dávky nepotřebovali. "
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-21",
+      "answer": "no",
+      "comment": "Někdy si jako Pražan říkám, co bych dal za to, kdyby se úřady přesunuly do Brna nebo Olomouce, měli bychom tu větší klid. Je to ale strašně drahé a v době hospodářské krize si toto neumím představit. "
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-22",
+      "answer": "yes",
+      "comment": "Už moji prarodiče sledovali, jak pes Lajka a kosmonaut Gagarin obletěli Zemi. Je divné, že se za dalších 60 let nic nového neudálo. Česká republika nemůže na vědeckém programu prodělat. Naopak se může stát dodavatelem důležitých komponent pro let do Vesmíru. Takže podporuji. "
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-23",
+      "answer": "no",
+      "comment": "V situaci, kdy bude volba veřejná, pak na způsobu volby nezáleží, protože každý si svůj hlas dohledá. V případě tajné volby, což je ústavním zvykem, není možné, aby jakákoli aplikace kontrolovala hlasy milionů voličů. Nevěřím aplikacím, věřím lidem. Takže jsem pro dosavadní způsob lidských volebních komisí. "
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-24",
+      "answer": "yes",
+      "comment": "To je přece jasná, sociologie ještě nic nevyrobila, řemeslo a technické znalosti ano. "
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-25",
+      "answer": "yes",
+      "comment": "Každé dítě je jiné a přesto nelze dítě na základě ADHD, dyslexie, nebo dysgrafie ihned vyřadit z lidské společnosti. "
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-26",
+      "answer": "yes",
+      "comment": "České školství si musí rozmyslet, jestli půjde západoevropskou cestou vychovávání debilů, kteří na mapě nedokážou najít jednotlivé kontinenty a pletou si Českou republiku s Čečenskem, nebo si ponecháme vysoký standard školství, ke kterému prostě biflování patří, a taky odborná pomoc problémovým žákům. "
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-27",
+      "comment": "Ano, pokud to pro nás bude výhodné. Velká Británie je ostrov a není nijak závislá na evropském tranzitu. Kdokoli vykřikuje, jak hned teď odejdeme z Evropské unie, chci po něm všechny asociační dohody, nahrazující dosavadní členské výhody. Jsem ochoten se pustit do dobrodružství v podobě zajištění těchto dohod, ale to bude trvat nejméně 20 let. To jen pro ty, kdo hýkají blahem nad okamžitým odchodem z EU. A to píšu jako velký kritik Evropské unie. U mě jsou na prvním místě lidé a EU je pro mě souhrn mezinárodních záruk i negativ členství. A na na druhé straně, pokud se EU vzdá přílišné byrokracie, mohla by pro nás být vlastně výhodná. Každopádně rozhodnutí by mělo být vždy v rukou občanů v celostátním referendu, nikoli politiků, kteří podobným způsobem za našimi zády rozdělili Československo. "
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-28",
+      "answer": "no",
+      "comment": "Euro je pro nás nevýhodné, protože se staneme provincií bez vlastní monetární politiky. Česká Koruna je stabilní a žádaná měna. "
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-29",
+      "answer": "yes",
+      "comment": "NATO  prokázalo na Ukrajině svou slabost. Koncepce společné obrany u nás za 20 let vytvořilo loutkovou armádu bez tanků a letadel. Upřednostňuji švýcarský model obrany území a agresivní styl obrany, kdy přeneseme vlastními akcemi boj na území protivníka. Navíc pokud zůstaneme nadále obklopeni členskými zeměmi NATO, nemáme se přece čeho bát. Nebo že by nás NATO jako neutrální zemi napadlo?"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-30",
+      "answer": "no",
+      "comment": "Proklamace o tvrdém jádru EU mně připomínají Radu vzájemné hospodářské pomoci za komunismu. Dokud není sídlo EU v Praze a nemáme stejný výtlak jako Francie a Německo, jako malý stát stejně musíme poslouchat Brusel, tak alespoň bez hlasitého tleskání. "
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-31",
+      "answer": "no",
+      "comment": "Ptám se, kdo pomůže nám? Myslím, že bychom konečně měli začít dělat obchodní zahraniční politiku, takže každá naše investice by se měla vrátit v podobě zisku pro české občany. Dosud je tomu tak, že když někam pošleme pomoc, většinou ještě přijdeme o další obchodní partnery a zisky z mezinárodní spolupráce. "
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-32",
+      "answer": "yes",
+      "comment": "Samozřejmě, že bychom měli brát ohled na rozvojové země, protože po nás představují potenciální trhy a nasytí naše peněženky. "
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-33",
+      "answer": "no",
+      "comment": "Už Římská říše nahrazovala nedostatečnou porodnost římského obyvatelstva dovozem federátů, což se jí posléze vymstilo. Nemám vůbec problém s tím, že cizinec se zamiluje do Češky a rozhodne se splnit zákonné možnosti a žít tady. Nemám problém přijmout Páskistánského gaye, protože doma by ho ukamenovali. Ale opravdu odmítám usnadnit sem cestu ekonomickým migrantům. To jsou lidé, co se sem jdou najíst za naše, poberou výhody, ale nic nám nepřinesou. "
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-34",
+      "answer": "yes",
+      "comment": "Jednoznačně ano a to je jeden z důvodů, proč se nám stále EU vyplatí. "
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-35",
+      "answer": "yes",
+      "comment": "Česká armáda díky napojeným mafií spotřebuje dost peněz. To, co skutečně potřebujeme, je domácí výroba levných a primitivních zbraní, kvantitu před složitými technologiemi, objem před předraženými zahraničními krámy, jako je Pandur nebo Gripen. Chci česká BVPéčka, české tanky domácí konstrukce, česká letadla a Českou armádu. "
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-36",
+      "answer": "yes",
+      "comment": "Pokud to jde, neexistuje jediný důvod, proč jim to neumožnit. "
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-37",
+      "answer": "no",
+      "comment": "Systém povinného zdravotního pojištění by se měl opět vrátit do rukou státu, protože soukromé subjekty z něj pouze čerpají peníze pro své akcionáře. "
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-38",
+      "answer": "no",
+      "comment": "Chcete snad trestat lidi, že nebydlí v Praze? "
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-39",
+      "answer": "yes",
+      "comment": "Působení na lidskou DNA je zhoubné, navíc chemická rezidua zůstávají v půdě a dostávají se do člověka. "
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-40",
+      "answer": "yes",
+      "comment": "Vždyť je to jedna velká zlodějna. Například nepoužívaný železniční přejezd na Mělníce vydělal radnici a spřáteleným firmám desítky milionů korun na porušení rychlosti, ačkoli tam vlak neviděli 30 let. "
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-41",
+      "answer": "yes",
+      "comment": "Velmi těžká otázka, protože můžeme hledat ztracené dítě nebo dezorientovaného seniora. Ovšem zneužívání databáze ze strany státní orgánů ke sledování obyvatelstva je dostatečný důvod ke zrušení. "
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-42",
+      "answer": "no",
+      "comment": "Otázka je nesmyslná. Problém Ukrajiny je obyvatelstvo, které si nechá rozkrádat zemi mafiemi a tento systém je ve společnosti zakořeněn po staletí. Proto na Ukrajině nevznikla skutečná demokracie ani po osamostatnění od Sovětského Svazu. Nedostatek kontrolních mechanismů znemožňuje vybudování občanské společnosti a udržení bohatství v zemi. Tudíž by to byl poslední hřebíček do rakve Evropské unie. "
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-43",
+      "answer": "no",
+      "comment": "Otázka je nesmyslná. Právě přístupové hovory do NATO zahájily současnou válku na Ukrajině. Mnohem výhodnější pro nás je, aby se Ukrajina stala neutrálním státem a nárazníkovým státem mezi Ruskou federací a státy Evropské unie. "
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-44",
+      "answer": "no",
+      "comment": "Evropská unie udělá nejlépe, když nechá své členské země potichu si vyjednat lepší podmínky na ruský plyna vybudovat nové plynovody z Polska nebo Itálie."
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-45",
+      "answer": "no",
+      "comment": "Nejsem spokojen, protože se věnuje genderovým bojům před ochranou občanů před chudobou a ekonomickými mafiemi. "
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-46",
+      "answer": "no",
+      "comment": "Můžete trestat, pokud na to máte sílu a prostředky. Každá sankce se nám zatím vrátila jako bumerang. Nevšiml jsem si, že bychom si od zavedení sankcí polepšili. Právě naopak. "
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-47",
+      "answer": "no",
+      "comment": "Krym není samostatná země, tudíž mohou probíhat maximálně zdvořilostní návštěvy a projevy. "
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-48",
+      "answer": "no",
+      "comment": "Potírání domácího násilí dostatečně řeší platné české zákony. "
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-49",
+      "answer": "no",
+      "comment": "Celé je to nesmysl. Zakážeme uhlí, až papaláši přestanou létat letadly a používat služební limuzíny s osmiválci, které žerou jako ruský zájezd. "
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-50",
+      "answer": "no",
+      "comment": "Je to samozřejmě nesmysl. Výroba a provoz elektromobilu násobně překračuje emise moderního spalovacího motoru. Proto klimatická neutralita je nebetyčná lež a podvod tisíciletí. "
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-51",
+      "answer": "no",
+      "comment": "Česká republika by se neměla plést do války velmocí. My tak maximálně můžeme uznávat domovníky na Žižkově. Velká politika škodí našim obchodním zájmům ve Světě. "
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-52",
+      "answer": "yes",
+      "comment": "Jednoznačně ano. Zatímco Brusel dál pojede rétoriku boje za Ukrajinu, kam dosud neposlal ani jednoho vojáka, my můžeme potichu dojednat výhodné ceny zemního plynu. Píšu to jako uživatel automobilu na slačený zemní plyn, kterému za dva roky trojnásobně zdražil provoz. "
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-53",
+      "answer": "yes",
+      "comment": "Finsko a Švédsko jsou nezávislé země a mně nepřísluší rozhodovat o nich, když nejsem občanem těchto států. "
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-54",
+      "answer": "no",
+      "comment": "Zemědělství je za 30 let Sametu v katastrofálním stavu. Odmítám řešit velikost farem. Rád bych, aby vedle sebe existovaly malé i velké zemědělské podniky s rovnocenným přístupem k dotacím. "
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-55",
+      "answer": "no",
+      "comment": "To je takový nesmysl, jako bezplatné zubní kartáčky. Psal jsem to jinde: zajistěte lidem stálou práci s takovým platem, aby nepotřebovali žádné sociální dávky. "
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-56",
+      "answer": "yes",
+      "comment": "Určitě ano, ale namísto nákupu předražených bytů od spekulantů by měl sám stavět nová státní sídliště na zelené louce a postavit byt dvakrát levněji, než by ho koupil na spekulativním trhu s nemovitostmi. "
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-57",
+      "comment": "To přece není starost občana České republiky, ale plně to přísluší Ukrajincům. Nejsem Ukrajinec a proto odmítám radit, co mají udělat. "
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-19-c-517013",
+      "question_id": "senatni-2022-19-q-58",
+      "answer": "yes",
+      "comment": "Samozřejmě, co jiného s nimi? Zároveň by měl být takový dlužník zanesen do stálého seznamu, který mu znemožní čerpat veškeré státní dotace, požitky, nebo si vzít nový úvěr. "
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-1",
+      "answer": "no",
+      "comment": "Vlastnictví znamená mimo jiné neomezené panství nad věcí, tady právo i danou věc neužívat. Jestliže vlastník bytu dodržuje veškeré právní předpisy týkající se vlastnictví nemovitosti, zejména nemovitost udržuje, neobtěžuje okolí apod., pak není důvod zatěžovat majitele dalšími zvýšenými náklady v podobě zvýšených daní. Stát v posledních 30 letech zcela selhal v bytové politice a nyní se toto snaží vyřešit přenesením své povinnosti na soukromý sektor ať už v podobě regulovaného nájemného nebo v podobě povinného obsazení bytu. "
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-2",
+      "answer": "no",
+      "comment": "Stát v současnosti už reguluje velké množství aktivit lidí a podnikatelů. Navíc regulace nájemného u bytů byla zrušena celkem nedávno a důvodem pro její zrušení bylo mimo jiné, že se toto ukázalo jako neefektivní a diskriminační vůči majitelům bytů."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-6"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-8",
+      "answer": "no",
+      "comment": "Stát se ukázal a stále ukazuje jako špatný hospodář. Není problém ten, že by se vybíralo málo na daních, problémem je výdajová politika státu. Rozhodně jsem pro zachování stejné rovné daně pro všechny fyzické osoby."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-9",
+      "answer": "yes",
+      "comment": "Vědecké výzkumy ukázaly nespornou výhodu lečbou konopí u některých nemocí, proto by tato možnost neměla být lidem odpírána."
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-11",
+      "answer": "no",
+      "comment": "Jakékoliv zvýšení daňového zatížení se drříve či později vždy promítne do ceny pro konečného spotřebitele. Zvýšení daně těmto subjektům by mohlo přinést zpoplatnění dosud bezplatných služeb a navýšení již zpoplatněných služeb. Googlu ani Facebooku nelze upřít zásadní roli v komunikaci lidí ve vyhledávání informací nebo v inzerci. "
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-12"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-13",
+      "answer": "no",
+      "comment": "Kdo určí, co je \"fake news\"?"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-14",
+      "answer": "yes",
+      "comment": "Veřejnoprávní vysílání by mělo být hrazeno přímo ze státního rozpočtu, nikoliv koncesionářskými poplatky. Výše příjmu veřejnoprávnícho vysílání absolutně neodpovídá kvalitě poskytovaných informací."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-15",
+      "answer": "no",
+      "comment": "Pracovní agentury tvoří nezanebatelnou část naší ekonomiky a jsou alternativou ke zkostnatělému zákoníku práce, jehož zvýšená ochrana zaměstnanců je mnohdy kontraproduktivní."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-17",
+      "answer": "no",
+      "comment": "Věřitel musí mít možnost volby exekutora, jelikož se jedná o jeho peníze, které mu má exekutor vymoci. Je to podobné, jako kdyby stát nařizoval, v jaké bance mají mít lidé peníze."
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-18",
+      "answer": "no",
+      "comment": "Toto pravidlo by znamenalo omezení věřitele zvolit si exekutora k úspěšnému vymáhání dluhu, což by dostalo věřitele do horšího postavení než je dlužník a takto si právní stát nepředstavuji."
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-22",
+      "answer": "no",
+      "comment": "ČR má teď opravdu mnoho jiných starostí a důležitějších věcí na vyřešení."
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-23",
+      "answer": "no",
+      "comment": "Možnost volit osobně a tajně je základní součástí volebního práva, které nesmí být nikdy v této podobě odňato, a to ani formou alternativy, resp. možnosti vybrat si, zda volit osobně, nebo online. Při online volbě nikdy nelze 100% zajistit, že volbu provede skutečně dotyčný volič."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-25",
+      "answer": "no",
+      "comment": "Naopak. Každý člověk je unikátní a vzdělávací systém by se měl snažit odhalit v dětech, co nejdříve jejich nadání a talent, a ten dále rozvíjet.  Není nutné technicky zaměřeného člověka od základní školy trápit 2 cizími jazyky, pokud má problém už s jedním, ale spíše ho podpořit v tom, co ho zajímá, a tak prohloubit jeho znalosti. "
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-29",
+      "answer": "yes",
+      "comment": "Namísto účasti v NATO by ČR měla více spolupracovat s okolními zeměmi, nejen na společné obraně, ale i v ekonomických a hospodářských záležitostech."
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-32",
+      "answer": "no",
+      "comment": "Zákony by měly být v první řadě v zájmu občanů ČR, případně v zájmu samotné ČR, aby se všem v naší republice žilo co nejlépe, abychom zde mohli pracovat, podnikat a vychovávat děti. Nevidím jediný důvod, proč by se u nás měl při schvalování zákonů brát ohled na rozvojové zěmě, když v nejlidnatějších zemí světa (Čína, Indie) se toto neděje. Vliv českých zákonů na rozvojové země není žádný, avšak je zásadní pro lidi žijící v ČR."
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-35"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-44",
+      "answer": "no",
+      "comment": "EU by měla co nejdříve zrušit sankce vůči Rusku a začít s Ruskem vyjádnávat o dodávkách a cenách plynu. Toto by bylo v zájmu občanů členských států EU."
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-46",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-50"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-53",
+      "answer": "no",
+      "comment": "Rozšiřování NATO dále na východ je v rozporu se závazkem z 90. let, který NATO dalo Rusku. "
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-55",
+      "answer": "no",
+      "comment": "Toto bych ponechala na rozhodnutí daného úřadu, rozhodně bych to nedávala do zákona."
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-56",
+      "answer": "no",
+      "comment": "Další státní úřad znamená další výdaje státu. Navíc stát se už několikrát ukázal a stále ukazuje jako špatný hospodář. Víme jistě, že nový úřad by znamenal nemalé státní výdaje, ale nevíme, zda by jeho přínos tyto výdaje vyvážil."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-57"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-19-c-999606",
+      "question_id": "senatni-2022-19-q-58",
+      "answer": "no",
+      "comment": "Znamenalo by to jasný signál, že nepracovat a mít dluhy v této zemi je lepší, než pracovat a řádně splácet své závazky."
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-1"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-19"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-25",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-26"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-28",
+      "answer": "no",
+      "comment": "Zatím ne"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-31"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-44"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-54",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-19-c-107153",
+      "question_id": "senatni-2022-19-q-58"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/22.json
+++ b/data/kalkulacka/senatni-2022/22.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-22",
-  "name": "22",
-  "description": "22 - DESCRIPTION",
+  "name": "Praha 10",
+  "description": "Praha 10",
   "district_code": "22",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-22-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-22-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-22-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-22-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-22-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-22-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-22-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-22-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-22-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-22-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-22-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-22-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-22-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-22-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-22-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-22-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-22-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-22-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-22-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-22-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-22-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-22-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-22-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-22-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-22-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-22-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-22-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-22-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-22-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-22-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-22-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-22-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-22-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-22-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-22-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-22-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-22-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-22-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-22-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-22-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-22-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-22-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-22-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-22-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-22-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-22-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-22-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-22-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-22-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-22-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-22-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-22-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-22-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-22-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-22-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-22-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-22-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-22-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-22-candidate-972050",
+      "id": "senatni-2022-22-c-972050",
       "name": "Bohumil Zoufalík",
-      "type": "party",
+      "type": "person",
       "description": "Bohumil Zoufalík - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -487,7 +489,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-22-972050-party",
+          "id": "senatni-2022-22-c-972050-p",
           "name": "Bohumil Zoufalík",
           "description": "Bohumil Zoufalík - DESCRIPTION",
           "contacts": {
@@ -499,9 +501,9 @@
       ]
     },
     {
-      "id": "senatni-2022-22-candidate-371682",
+      "id": "senatni-2022-22-c-371682",
       "name": "Renata Chmelová",
-      "type": "party",
+      "type": "person",
       "description": "Renata Chmelová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -524,7 +526,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-22-371682-party",
+          "id": "senatni-2022-22-c-371682-p",
           "name": "Renata Chmelová",
           "description": "Renata Chmelová - DESCRIPTION",
           "contacts": {
@@ -551,9 +553,9 @@
       ]
     },
     {
-      "id": "senatni-2022-22-candidate-549994",
+      "id": "senatni-2022-22-c-549994",
       "name": "Jan Pirk",
-      "type": "party",
+      "type": "person",
       "description": "Jan Pirk - DESCRIPTION",
       "contacts": {
         "web": [
@@ -574,7 +576,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-22-549994-party",
+          "id": "senatni-2022-22-c-549994-p",
           "name": "Jan Pirk",
           "description": "Jan Pirk - DESCRIPTION",
           "contacts": {
@@ -599,16 +601,16 @@
       ]
     },
     {
-      "id": "senatni-2022-22-candidate-878037",
+      "id": "senatni-2022-22-c-878037",
       "name": "Helena Leisztner",
-      "type": "party",
+      "type": "person",
       "description": "Helena Leisztner - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-22-878037-party",
+          "id": "senatni-2022-22-c-878037-p",
           "name": "Helena Leisztner",
           "description": "Helena Leisztner - DESCRIPTION",
           "contacts": {
@@ -619,9 +621,9 @@
       ]
     },
     {
-      "id": "senatni-2022-22-candidate-762354",
+      "id": "senatni-2022-22-c-762354",
       "name": "Štěpán Kavur",
-      "type": "party",
+      "type": "person",
       "description": "Štěpán Kavur - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -629,7 +631,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-22-762354-party",
+          "id": "senatni-2022-22-c-762354-p",
           "name": "Štěpán Kavur",
           "description": "Štěpán Kavur - DESCRIPTION",
           "contacts": {
@@ -641,16 +643,16 @@
       ]
     },
     {
-      "id": "senatni-2022-22-candidate-357855",
+      "id": "senatni-2022-22-c-357855",
       "name": "Jiří Kobza",
-      "type": "party",
+      "type": "person",
       "description": "Jiří Kobza - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-22-357855-party",
+          "id": "senatni-2022-22-c-357855-p",
           "name": "Jiří Kobza",
           "description": "Jiří Kobza - DESCRIPTION",
           "contacts": {
@@ -661,5 +663,720 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-22-c-371682",
+      "question_id": "senatni-2022-22-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-1",
+      "answer": "yes",
+      "comment": "Jednalo by se o další zdroj financování výstavby obecních bytů."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-2",
+      "answer": "yes",
+      "comment": "Jsem pro zavedení podobně jako v jiných evropských vyspělých zemích (např. v Rakousku)."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-3",
+      "answer": "yes",
+      "comment": "Je třeba, aby veřejnost měla možnost rozhodovat o důležitých otázkách."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-4",
+      "answer": "no",
+      "comment": "Všechny druhy dopravy by měly mít podporu."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-5",
+      "answer": "no",
+      "comment": "Vzhledem ke zdravotnímu stavu populace nepřijatelné."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-6",
+      "answer": "no",
+      "comment": "Nové přehrady už není kde stavět."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-8",
+      "answer": "yes",
+      "comment": "Základní prvek solidarity."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-9",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-10"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-11",
+      "answer": "yes",
+      "comment": "Vydělávají u nás, proto je spravedlivé je zdanit."
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-14",
+      "answer": "yes",
+      "comment": "Aby byla zaručena nezávislost, nelze je financovat z vládních peněz."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-15",
+      "answer": "yes",
+      "comment": "Je nutné, aby byly pod větší kontrolou."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-16",
+      "comment": "Ve svazku by páry měly mít stejná práva, ale nemohou se nazývat manželství."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-19",
+      "answer": "yes",
+      "comment": "Nutná podmínka pro řešení bydlení u nás."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-20",
+      "answer": "no",
+      "comment": "Je však nutno o dávkách srozumitelně komunikovat."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-21"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-22"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-23",
+      "answer": "yes",
+      "comment": "To by voličům usnadnilo život."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-24",
+      "answer": "no",
+      "comment": "Všem stejné podmínky, v případě potřeby mohou podporovat firmy/zaměstnavatelé."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-25",
+      "answer": "no",
+      "comment": "1. stupeň společně, od 2. stupně rozdělení podle dalšího studia."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-26",
+      "answer": "no",
+      "comment": "Pro inkluzi musí být vytvořeny podmínky, které zatím nejsou."
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-27",
+      "answer": "no",
+      "comment": "Pozitiva převažují nad negativy."
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-28",
+      "answer": "yes",
+      "comment": "Ano, ale až to bude výhodné."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-30"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-31",
+      "comment": "ČR podporuje v rámci svých možností."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-33",
+      "answer": "no",
+      "comment": "Stávající systém plní svoji funkci."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-35",
+      "comment": "Je však třeba dodržet pravidla NATO."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-36"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-40",
+      "comment": "Pouze a místech, nutných kvůli bezpečnosti."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-42",
+      "answer": "yes",
+      "comment": "Ano, ale musí projít stejným procesem přijetí."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-43",
+      "answer": "no",
+      "comment": "To by bylo velké riziko."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-47",
+      "answer": "yes",
+      "comment": "Jednat je třeba s každým."
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-49",
+      "answer": "no",
+      "comment": "Vzhledem k akutní energetické potřebě ne."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-52",
+      "comment": "Vyplyne to z naší potřeby nebo nutnosti."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-54",
+      "answer": "no",
+      "comment": "Měly by být pro všechny podle jednotných pravidel."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-55"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-56"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-57",
+      "comment": "To záleží na Ukrajině a jejím stanovisku i na výsledku vyjednávání."
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-22-c-762354",
+      "question_id": "senatni-2022-22-q-58",
+      "answer": "yes",
+      "comment": "Je však třeba tuto situaci řešit adekvátními nástroji (oddlužení, insolvence, osobní finanční plán)."
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/25.json
+++ b/data/kalkulacka/senatni-2022/25.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-25",
-  "name": "25",
-  "description": "25 - DESCRIPTION",
+  "name": "Praha 6",
+  "description": "Praha 6",
   "district_code": "25",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-25-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-25-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-25-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-25-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-25-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-25-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-25-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-25-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-25-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-25-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-25-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-25-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-25-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-25-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-25-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-25-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-25-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-25-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-25-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-25-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-25-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-25-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-25-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-25-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-25-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-25-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-25-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-25-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-25-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-25-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-25-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-25-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-25-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-25-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-25-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-25-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-25-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-25-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-25-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-25-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-25-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-25-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-25-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-25-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-25-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-25-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-25-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-25-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-25-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-25-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-25-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-25-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-25-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-25-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-25-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-25-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-25-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-25-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-25-candidate-842348",
+      "id": "senatni-2022-25-c-842348",
       "name": "Jaroslav Dvořák",
-      "type": "party",
+      "type": "person",
       "description": "Jaroslav Dvořák - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -487,7 +489,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-25-842348-party",
+          "id": "senatni-2022-25-c-842348-p",
           "name": "Jaroslav Dvořák",
           "description": "Jaroslav Dvořák - DESCRIPTION",
           "contacts": {
@@ -499,9 +501,9 @@
       ]
     },
     {
-      "id": "senatni-2022-25-candidate-377248",
+      "id": "senatni-2022-25-c-377248",
       "name": "Petr Pavlík",
-      "type": "party",
+      "type": "person",
       "description": "Petr Pavlík - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -511,7 +513,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-25-377248-party",
+          "id": "senatni-2022-25-c-377248-p",
           "name": "Petr Pavlík",
           "description": "Petr Pavlík - DESCRIPTION",
           "contacts": {
@@ -525,16 +527,16 @@
       ]
     },
     {
-      "id": "senatni-2022-25-candidate-678819",
+      "id": "senatni-2022-25-c-678819",
       "name": "Jiří Pavel Pešek",
-      "type": "party",
+      "type": "person",
       "description": "Jiří Pavel Pešek - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-25-678819-party",
+          "id": "senatni-2022-25-c-678819-p",
           "name": "Jiří Pavel Pešek",
           "description": "Jiří Pavel Pešek - DESCRIPTION",
           "contacts": {
@@ -545,9 +547,9 @@
       ]
     },
     {
-      "id": "senatni-2022-25-candidate-813666",
+      "id": "senatni-2022-25-c-813666",
       "name": "Jiří Růžička",
-      "type": "party",
+      "type": "person",
       "description": "Jiří Růžička - DESCRIPTION",
       "contacts": {
         "web": [
@@ -566,7 +568,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-25-813666-party",
+          "id": "senatni-2022-25-c-813666-p",
           "name": "Jiří Růžička",
           "description": "Jiří Růžička - DESCRIPTION",
           "contacts": {
@@ -589,16 +591,16 @@
       ]
     },
     {
-      "id": "senatni-2022-25-candidate-426167",
+      "id": "senatni-2022-25-c-426167",
       "name": "Petr Hannig",
-      "type": "party",
+      "type": "person",
       "description": "Petr Hannig - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-25-426167-party",
+          "id": "senatni-2022-25-c-426167-p",
           "name": "Petr Hannig",
           "description": "Petr Hannig - DESCRIPTION",
           "contacts": {
@@ -609,9 +611,9 @@
       ]
     },
     {
-      "id": "senatni-2022-25-candidate-630845",
+      "id": "senatni-2022-25-c-630845",
       "name": "Lenka Helena Koenigsmark",
-      "type": "party",
+      "type": "person",
       "description": "Lenka Helena Koenigsmark - DESCRIPTION",
       "contacts": {
         "web": [
@@ -634,7 +636,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-25-630845-party",
+          "id": "senatni-2022-25-c-630845-p",
           "name": "Lenka Helena Koenigsmark",
           "description": "Lenka Helena Koenigsmark - DESCRIPTION",
           "contacts": {
@@ -661,16 +663,16 @@
       ]
     },
     {
-      "id": "senatni-2022-25-candidate-188521",
+      "id": "senatni-2022-25-c-188521",
       "name": "Petr Vacek",
-      "type": "party",
+      "type": "person",
       "description": "Petr Vacek - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-25-188521-party",
+          "id": "senatni-2022-25-c-188521-p",
           "name": "Petr Vacek",
           "description": "Petr Vacek - DESCRIPTION",
           "contacts": {
@@ -681,9 +683,9 @@
       ]
     },
     {
-      "id": "senatni-2022-25-candidate-290001",
+      "id": "senatni-2022-25-c-290001",
       "name": "Dana Balcarová",
-      "type": "party",
+      "type": "person",
       "description": "Dana Balcarová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -702,7 +704,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-25-290001-party",
+          "id": "senatni-2022-25-c-290001-p",
           "name": "Dana Balcarová",
           "description": "Dana Balcarová - DESCRIPTION",
           "contacts": {
@@ -725,5 +727,2223 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-1",
+      "answer": "no",
+      "comment": "Spíše ne. Ale nutno také dodat, že vzhledem k rozšířenému skupování nemovitostí ze strany zahraničních investorů by bylo dobře otevřít otázku, zda nezavést zdanění jejich vlastnictví většího počtu nemovitostí, které omezuje dostupnost pro české občany. Další otázkou je pak fungování platforem typu AirBnB, které by bylo záhodno regulovat, protože nejen že vysávájí realitní trh, ale také to slouží k obcházení pravidel pro hotely a podobná zařízení krátkodobého ubytování a často je to v rozporu s kvalitou života místních."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-5",
+      "answer": "yes",
+      "comment": "Bohužel se tomuto nepopulárnímu kroku nevyhneme což je dáno především stárnoucí populací."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-6"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-9",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-15"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-33"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-36",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-25-c-630845",
+      "question_id": "senatni-2022-25-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-1",
+      "answer": "yes",
+      "comment": "Tyto dlouhodobě prázdné byty jsou mnohdy majetkem zahraničních vlastníků, které si je pořídili jako investici."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-2",
+      "comment": "Někteří majitelé domů jsou rozumní a vědí, když nastaví nájemné pro nájemce vysoké, tak příjdou o nájemníka a pokud je nájemník slušný, tak slušného nájemníka aby majitel domu pohledal."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-3",
+      "answer": "yes",
+      "comment": "Referendum o jakýchkoliv otázkách. Občané musí mít možnost rozhodnout o své budoucnosti. "
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-4",
+      "comment": "I dálnice jsou důležité."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-5",
+      "answer": "no",
+      "comment": "Senioři by měli mít možnost, prožít svůj důchodový věk aktivně."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-6",
+      "comment": "Spíše si myslím, že ano. Cenná surovina voda nám odtéká často nevyužita z ČR pryč. Je však třeba mít souhlas s obyvateli budoucích zaplavených oblastí."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-7",
+      "answer": "no",
+      "comment": "Jsem zásadně proti Green Dealu, který ničí Českou republiku a ostatně i celou  Evropskou unii. Oceány zamořené plovoucími ostrovy z plastů rozhodně nejsou u břehů Evropy, ale naopak Asie, Afriky a Jižní Ameriky. Pokud se tam nezmění vnímání v tomto směru, nemá cenu abychom my  v Evropě takové záležitosti zaváděli."
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-8",
+      "comment": "Dřív jsem byl rozhodně proti. Ovšem nyní je zcela jiná situace. Příjmy některých firem jsou vzhledem k inflaci nespravedlivě vysoké. Je třeba jiná speciální daň na tyto nezasloužené příjmy. Ale obecná progresivita spíše NE."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-9",
+      "comment": "Poskytneš prstíček a za chvíli to bude i pro tvrdší drogy."
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-10",
+      "answer": "no",
+      "comment": "Je to diskutabilní. V mnoha případech dochází k zneužívání tohoto institutu, neboť se dnes jako znásilnění považuje cokoliv, co dříve znásilněním nebylo. Například některé metody trenérů ve sportu, aby ze svých svěřenkyň dostali maximum pro jejich sportovní výkony. Dále se zneužívá tento institut v manželstvích, která se rozpadají. A bývá to zneužíváno různými zlatokopkami, kdy se za znásilnění považuje i bývalý dobrovolný sex. Nejsem si v tomto případě vědom, zda v případě znásilnění se vším, co se dnes pod tímto pojmem rozumí ( i bez koitu) nemá obviněný povinnost dokazovat nevinu, či je to jako v jiných trestních činech, že platí presumpce neviny."
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-11"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-12",
+      "answer": "no",
+      "comment": "Jsem proti jakékoliv cenzuře, to jest i na internetu."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-13",
+      "answer": "no",
+      "comment": "Kdo určí, co je falešná správa. Jak se říká, je třeba počkat půl roku a z fake news se stane relevantní, pravdivá zpráva. "
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-14",
+      "answer": "no",
+      "comment": "Ale rozhodně by mělo být pravdivé a ne stranící jakékoliv politické myšlence či vládní politice. Katastrofální je v tomto případě ČT a její pořady 168 hodin, Reportéři, Newsroom a Václav Moravec. Ten je ovšem také v současné době neskonale zastaralý a nudný v porovnání s CNN Prima News."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-15",
+      "answer": "yes",
+      "comment": "Vraťme věci do řádných kolejí."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-16",
+      "answer": "no",
+      "comment": "Registrované partnerství, to ano, ale svátost manželská je institut původně zamýšlený jako plození a výchovu dětí, budoucích generací pro republiku."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-17",
+      "answer": "yes",
+      "comment": "Exekuce nesmí být pro někoho kšeft a pro druhého životní katastrofa."
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-18",
+      "answer": "yes",
+      "comment": "Samozřejmě."
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-19",
+      "answer": "yes",
+      "comment": "Ale musí to být pro řádné občany, kteří se dostali do platebních neschopností vlivem nestoudných cen elektřiny, plynu a tepla a základních potravin. Např. vdovy, vdovci a pod."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-20",
+      "answer": "yes",
+      "comment": "Rozhodně ano. Slušní lidé, kteří se dostanou do potíží, se za svou neschopnost dostát všem platbám za elektřinu, plyn, nájemné, se za tento fakt stydí, protože celý život vše řádně a včas platili."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-21",
+      "answer": "no",
+      "comment": "Zvýší to náklady a teď je doba, kdy je potřeba nevynakládat zbytečné výdaje."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-22",
+      "answer": "no",
+      "comment": "Starejme se radši o to, abychom v zimě měli čím topit a nezabývat se takovými hloupostmi."
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-23",
+      "answer": "no",
+      "comment": "Zachovejme takovou volbu, která je svobodná a dostupná i pro starší spoluobčany, aniž by museli žádat o asistenci své potomky, kteří by je často nutili volit proti jejich vlastnímu přesvědčení. Viz akce \" přemluv bábu\"."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-24",
+      "answer": "yes",
+      "comment": "Těch genderových odborníků, politických geografů, politologů a dalších \"nezbytných\" profesí, které jsou houfně využívány ve veřejnoprávních médiích, aby vůbec měli tito absolventi jakoukoliv činnost a v podstatě ovlivňují názory lidí podle svých politických preferencí, je nadbytek. I nadbytek právníků je zbytečný. Právníci vyhledávají ne řešení, která by pomohla lidem, ale naopak jim jde o zdroje jejich i tak dost vysokých příjmů."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-25",
+      "answer": "no",
+      "comment": "Každé dítě je specifické svými vlohami pro rozdílnou životní dráhu."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-26",
+      "answer": "no",
+      "comment": "Inkluze ničí naše školství. Měli jsme a stále máme výborné speciální školy a vysokoškolsky vyškolené pedagogy pro tento obor. Naše speciální školství bylo vzorem pro jiné státy. Nepřejímejme ze západu všechno, když jsem v něčem lepší."
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-27",
+      "comment": "Velké státy EU nás nutí, abychom se vzdali posledních pravomocí  a práva veta. To by znamenalo konec samostatného státu a stali bychom se kolonií západních států. Na druhou stranu schengenský prostor je praktický pro obyčejné lidi ohledně cestování např. do letních destinací. EU musí opustit nesmyslný Green Deal. Dřív jsem byl spíše nakloněn zůstat v EU, nyní spíše odejít, protože se EU stává něčím, co už jsme zažili a nechceme to zažívat znovu. Evropská unie je nyní pro nás brzdou a nebezpečím. Lépe být jako Švýcarsko. Schengen ano, jinak samostatnost a svoboda."
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-28",
+      "answer": "no",
+      "comment": "Rozhodně NE. Samostatná měna znamená samostatnost pro stát."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-29",
+      "answer": "yes",
+      "comment": "Byli jsme nadšeni ze slov Václava Havla v roce 1990, že ČSR musí být neutrální. Neutralita je to nejlepší řešení. Podívejme se na prosperitu neutrálního Švýcarska, ale i Rakouska. Účast v NATO je hrozně drahá a ne, jak neustále vtloukají do hlavy, že by samostatnost by byla dražší.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-30",
+      "answer": "no",
+      "comment": "Místo ČR je ve středoevropských státech. Západ nás stále vnímá jako jakýsi přívěsek, který je tak jenom dobrý jako levná montovna a odbytiště nadbytečných potravin. Ideální byl Visegrád ( do té doby než začal válka na Ukrajině)"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-31",
+      "answer": "no",
+      "comment": "Vláda ČR by rozhodně měla více podporovat naše občany v této době katastrofální inflace a astronomických cen energií."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-32",
+      "answer": "yes",
+      "comment": "Asi ano. Protože ony ještě neztratily zdravý rozum a kašlou na nějakou ekologii, jde jim o prosperitu a ne o zelenou ideologii a Evropu ničící Green Deal."
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-33",
+      "answer": "no",
+      "comment": "A zároveň nějakým relevantním způsobem ukončit současnou politiku k imigrantům z Ukrajiny. Buďto jim zde umožnit pracovat a žít jako to fungovalo před válkou, to jest, jak to měli v ČR Ukrajinci před napadením Ukrajiny Ruskem, bez současných speciálních benefitů. Nebo, pokud zde nebudou mít práci a prostředky k žití, tak jen poslat zpět. Stejně je jich většina z válkou nezasažených oblastí. S ukrajinskými pracovníky a pracovnicemi jsme byli zde nadmíru spokojeni, pro jejich pracovitost a skromnost. Ten nadměrný nárůst imigrantů z UA a hlavně rozdílný přístup k těm, co tu pracovali a těm, co si přijeli pouze pro podporu, nadělal dost zlé krve v náhledu našich občanů k, do této doby, většinou sympatickým zde žijícím a pracujícím, či podnikajícím Ukrajincům."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-34",
+      "answer": "yes",
+      "comment": "Samozřejmě, to budu neustále prosazovat i kdybychom vystoupili z EU a NATO."
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-35",
+      "answer": "no",
+      "comment": "Nejbezpečnějším a nejstabilnějším státem Střední Ameriky je Kostarika, demokracie od roku 1902. Jediný vojenský puč byl v roce 1948, trval pouze dva měsíce a jeho následkem bylo zrušení armády a od roku 1949 v Ústavě Kostariky je zákaz mít armádu a od té doby nebyl žádný vojenský puč. Volby jsou povinné pro všechny občany.  Prezident může vykonávat funkci pouze jedno volební období, myslím že 4leté."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-36",
+      "answer": "no",
+      "comment": "Nějak příliš si hrajeme na Stvořitele. Pokud se umělé oplodnění podaří a dítě bude zdravé, tak by rodiče měli děkovat Bohu za ten zázrak a nevymýšlet si další zásahy do přirozeného průběhu těhotenství.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-37",
+      "comment": "Obávám se, že by to rozevřelo nůžky mezi občany."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-38",
+      "comment": "Neměnit fungující systémy."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-39",
+      "comment": "Je třeba zvážit rizika a přínos."
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-40",
+      "comment": "Toho sledování je někdy až příliš. Ovšem je třeba zase nějaká disciplína. Řidiči, zvláště ti mladí, bývají často bezohlední."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-41",
+      "answer": "yes",
+      "comment": "Nechci zde velkého bratra, tak jak je to v Číně."
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-42",
+      "answer": "no",
+      "comment": "proč by měla, když nesplňuje ani jedno z kritérií."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-43",
+      "answer": "no",
+      "comment": "Nechci třetí světovou válku."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-44",
+      "answer": "no",
+      "comment": "To by znamenalo vůbec žádný plyn z Ruska a katastrofu pro všechny aspekty našeho života. Nesouhlasím s válkou na Ukrajině a se vpádem RF ( i když je třeba brát v potaz i předchozí signály, které k tomu vpádu vedly) na Ukrajinské území. Ale veškeré sankce neničí Rusko, ale  EU a hlavně ČR, které je jako bývalá plynová velmoc Evropy na ruském plynu plně závislá."
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-45",
+      "answer": "yes",
+      "comment": "Oceňuji jeho nestrannost a v podstatě hrdinství odolávat neustálým útokům médií."
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-46",
+      "answer": "no",
+      "comment": "Ty následky neseme my. Rusko ne. Rubl stoupá. Inkaso za plyn a ropu je pro Rusko neustále vyšší a vyšší. Musíme si toto uvědomit. politický systém v Rusku je imunní proti jakýmkoliv občanským nepokojům. Můžeme změnit imperiální choutky RF spíše spoluprací s ním, než s neustálým zvyšováním sankcí, které dopadají hlavně jako bumerang zpět na EU a na občany RF, kteří v podstatě s V.V. Putinem nesouhlasí. Nemohou cestovat do EU. Ruská vládnoucí třída je tzv. za vodou a nějaké sankce se jich netýkají. Tak místo na francouzskou Riviéru, budou jezdit na tureckou Riviéru. či do Spojených arabských emirátů, Ománu atd. Chtělo by to špetku zdravého rozumu a výměnu na špici EU."
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-47",
+      "comment": "Proč by měli vyjednávat. Krym je nedůležitý. Je důležitý pouze pro ruskou černomořskou flotilu a z Krymu je pro Rusko nezbytný pouze Sevastopol (vojenství) a Jalta (rekreace). Jinak je Krym pro RF v podstatě asi jenom přítěží."
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-48",
+      "answer": "no",
+      "comment": "Je to zneužitelné. Máme dostatečné a účinné zákonodárství, nemusíme přejímat něco, co má zase v podstatě jiný cíl, než chránit ženy před domácím násilím."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-49",
+      "answer": "no",
+      "comment": "V současné situaci budeme ještě za uhlí velice rádi, abychom v zimě nezmrzli, nemocnice mohly fungovat, protože bez tepla nemohou atd. atd."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-50",
+      "answer": "no",
+      "comment": "Nepodporuji šílené nápady, když ostatní svět si pojede podle svých not. Na celosvětovém znečištění se EU podílí pouze 8%. A ta mantra klimatické neutrality EU je v tomto světle naprosto směšná."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-51",
+      "comment": "Co je nám do Krymu. To ať si vyřeší ti, co tam bydlí. a oni si to již vyřešili referendem."
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-52",
+      "answer": "yes",
+      "comment": "Dost ideologie Je potřeba jednat ve prospěch našich občanů, tak jak to dělá Viktor Orbán v Maďarsku."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-53",
+      "answer": "no",
+      "comment": "Švédsko ať si dělá co chce, pokud si chce zničit to, na čem vydělávalo po čas druhé světové války, kdy kšeftovalo jak s Hitlerovským Německem, tak se spojenci. Co se týká Finska, tam je to jiné. Myslím, že se Finsko zavázalo k neutralitě po druhé světové válce. Zde to opět zavání rozpoutáním třetí světové války. "
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-54",
+      "comment": "Pro malé i velké. Ale hlavně by měly jít do výroby a ne do vlastnictví."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-55",
+      "answer": "no",
+      "comment": "To už jsme zase v komunismu? Co to je za otázku? Je to vůbec u nás problém? Nebo se počítá s větším počtem mladých žen, které skončí jako bezdomovkyně?"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-56",
+      "answer": "yes",
+      "comment": "A zároveň tvrdá kontrola, aby se s tím nekšeftovalo a byty byly pronajímány těmi skutečně potřebnými. Vdovci či vdovy už nebudou moci utáhnout nájem a energie bytů, kde žili se svými dosavadními partnery. To je nejzranitelnější skupina, která by se mohla ocitnout na ulici. "
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-57",
+      "comment": "Je potřeba zainteresovat mezinárodní neutrální společenství a ukončit válku. Jak? To už nechám na jednání. Ústupky musí učinit obě strany."
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-25-c-426167",
+      "question_id": "senatni-2022-25-q-58",
+      "comment": "Dluhy se mají platit. Ovšem pokud takové exekuce jsou jalové a při tom drahé, tak by měl být nějaký státní orgán, nezávislý na stranách sporu, který by měl rozhodnout."
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-1",
+      "answer": "no",
+      "comment": "Proč Praha nestaví svoje byty ? Proč prodává pozemky ?  Žádné byty by nebyly prázdné nebo nehorázně předražené kdyby Praha uvolňovala na trh svoje byty pro své Pražany."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-2",
+      "answer": "no",
+      "comment": "Kdyby Praha stavěla své byty na svých pozemcích a ty pak uvolňovala na trh neměla by důvod regulovat nájemné."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-3"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-4",
+      "answer": "no",
+      "comment": "Praha potřebuje především dostavbu vnitřního (tunelového) a vnějšího okruhu"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-5"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-11",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-14",
+      "answer": "yes",
+      "comment": "Společnost ČT by měla být rozdělena na zpravodajství a ostatní tvorbu a tu zprivatizovat..."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-15",
+      "answer": "no",
+      "comment": "Měla by být zavedena silná regulace a povinností PA. Nemohou zneužívat své autority vůči svým klientům."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-16",
+      "answer": "no",
+      "comment": "Je mi to líto ale manželství je mezi ženou a mužem.... přesto láska nezná hranic..."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-17"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-19",
+      "answer": "yes",
+      "comment": "Na výstavbu \"svých\" bytů Praha Praha dávno rezignovala..... k velké radosti developerů..."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-20",
+      "answer": "yes",
+      "comment": "Zvláště v dnešní době... stát utratí 70 miliard - bez efektu - a na občany v nouzi nemá \"kapacitu ?\""
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-23",
+      "answer": "no",
+      "comment": "Téma korespondenčního či internetového hlasování je pro mne tématem o totalitární budoucnosti...."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-24",
+      "answer": "yes",
+      "comment": "Stát musí definovat svou \"generační strategickou politiku zaměstnanosti a rozvoje\" a aktuálně nepreferované obory dotovat pro budoucnost.... jsme jen ve vleku neexistující ruky trhu.... "
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-25",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-26",
+      "answer": "no",
+      "comment": "Stejně jako psychologie definuje své základní hranice formou, norma, širší norma, ..., je možné se takto dívat i na schopnosti a možnosti studentů....."
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-27",
+      "answer": "yes",
+      "comment": "ČR je v EU za \"Oslíčku otřes se \".... zahraniční firmy odvádějí své zisky z ČR, nereinvestují je zde. Nemají o to zájem. Proto u nás nepodnikají, aby zde reinvestovali zisky (..jako například distributoři energií nebo banky). Podíl peněz \"zcizených z ČR\" je stonásobně vyšší než \"almužna\" ve formě dotací z EU.... "
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-28",
+      "answer": "no",
+      "comment": "To by byla konečná pro českou státnost a konec světla na konci tunelu... "
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-29",
+      "answer": "yes",
+      "comment": "V současném a zdá se že i budoucím světě má ČR budoucnost jako neutrální země (jako Rakousko) a jako součást neutrálního pásu oddělující zájmy RU/CHI vs Evropa-USA"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-30",
+      "answer": "no",
+      "comment": "ČR má místo v \"Pásy Svobody neutrálních států\" - Část Německa (NDR)+ČESKO+RAKOUSKO+SLOVINSKO ... mimo EU mimo NATO mimo RUSKO"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-32"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-35",
+      "answer": "no",
+      "comment": "Žádnou armádu, která by mohla nabídnout svým občanům aspoň nějaký pocit bezpečí NEMÁME. Máme jen spousty úředníků na pořádání výběrových (neveřejných - dle průzkumu a zadání) řízení...."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-37",
+      "answer": "yes",
+      "comment": "tato možnost zachrání státní a krajské nemocnice. Jinak \"bohatí\" pacienti odejdou do soukromých klinik a my budeme muset opět více dotovat naše zdravotnictví..."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-39",
+      "answer": "yes",
+      "comment": "Je ostuda že již zakázáno nebylo.... podobné jako s tabákovými výrobky.... jak dlouho výrobce ví o pochybnostech svých produktů ?"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-41",
+      "answer": "yes",
+      "comment": "1984"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-42",
+      "answer": "no",
+      "comment": " Z EU, z hospodářské a politické solidarity se stal nástroj ekonomického kolonialismu a rozpínavosti států EHS jenž se cítí a jednají jako jediní možní...my jsme jen \"Oslíčku otřes se\". EU ví všechno nejlépe"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-43",
+      "answer": "no",
+      "comment": "Vstupem Ukrajiny do EU a NATO zahájíme 3. Světovou válku, která se samozřejmě odehraje v Evropě. Nikoliv v USA, Rusku, Číně.... "
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-44",
+      "answer": "no",
+      "comment": "EU by měla být rozpuštěna. Už jsem se stejně zadlužili jako oni, už nic nevlastníme a nemáme...jen dluhy"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-46",
+      "answer": "no",
+      "comment": "Jaké nesly USA \"následky za vylhanou válku\" v Iráku a válku v Afghanistánu ?. Proč se o tom nemluví ? Kdo Iráckým matkám nahradí jejich syny, kdo nese následky za ten omyl ?"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-47",
+      "answer": "yes",
+      "comment": "Proč ne ? "
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-48",
+      "answer": "no",
+      "comment": "To musí řešit český zákonodárce, Proč opět EU ?"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-49",
+      "answer": "no",
+      "comment": "Čím je to pro nás výhodné ? "
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-50",
+      "answer": "no",
+      "comment": "Podporuji, aby EU byla rozpuštěna do konce roku 2023. To je jediné světlo na konci tunelu.."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-52",
+      "answer": "yes",
+      "comment": "Jiná cesta není a o jiné nemá smysl jednat... bez levných vstupů energií nemáme šanci uspět v novém světě..."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-53",
+      "comment": "Považuji to za nerozumné a \"populistické\""
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-54",
+      "answer": "yes",
+      "comment": "Zemědělství je po armádě druhým sektorem zdecimovaným EU a EHS"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-55",
+      "answer": "no",
+      "comment": "Tato možnost by měla být součástí sociálních dávek"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-56",
+      "answer": "no",
+      "comment": "Obce, kraje musí být garanty a nositeli bytové politiky. Stát má tyto politiky samosprávných celků a obcí podporovat "
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-57",
+      "answer": "yes",
+      "comment": "Má jinou šanci ? Má to jít vybojovat naše armáda ? podobně jako Irák a Afganistán ?"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-25-c-842348",
+      "question_id": "senatni-2022-25-q-58",
+      "answer": "no",
+      "comment": "Ale mají být přezkoumány a znovu posouzeny, především s ohledem na postup exeturského úřadu - exekutora"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-4",
+      "answer": "yes",
+      "comment": "Vlaková doprava je ekologičtější než automobilová, což platí i pro přepravu nákladů."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-5",
+      "answer": "no",
+      "comment": "Dokud nebude připravena smysluplná důchodová reforma nevidím důvod budoucím důchodcům nastavovat jiné podmínky, než mají ti současní."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-8",
+      "answer": "yes",
+      "comment": "Současný systém je výhodný pro bohaté a nevýhodný pro lidi práce a nízkopříjmové skupiny obyvatelstva. Je výmluvné, že v každé civilizované zemi na západ od našich hranic je progresivní zdanění."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-10",
+      "answer": "yes",
+      "comment": "Současné tresty za sexuální násilí jsou ostudně nízké a soudy navíc zpravidla ukládají nižší trestné sazby z možného rozpětí či dokonce jen podmíněné tresty. "
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-11",
+      "answer": "no",
+      "comment": "Nevidím důvod proč selektivně danit jen tyto dvě společnosti."
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-12",
+      "answer": "yes",
+      "comment": "Je to ale otázka míry. Nemohou být zodpovědné za vše, ale nemělo by jim také být tolerováno šíření nenávistných, rasistických atd. obsahů."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-14",
+      "answer": "no",
+      "comment": "Naopak by měly být televizní a rozhlasové poplatky zvýšeny a měl by být zákonný mechanismus pro jejich zvyšování s inflací. Jsou zásadní pro demokracii a neměly by být rukojmími poslanců. "
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-15",
+      "answer": "yes",
+      "comment": "Omezena a výrazně regulována."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-16",
+      "answer": "yes",
+      "comment": "Podle Ústavy máme mít všichni stejná práva a stejné povinnosti. Pokud někomu upíráme nějaké právo jen na základě sexuální orientace, porušujeme Ústavu a Listinu základních práv a svobod. Je to stejné, jako kdybychom upírali někomu právo uzavřít manželství na základě rasy, etnicity či náboženského vyznání."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-19",
+      "answer": "yes",
+      "comment": "Když to jde v Německu, v Rakousku či v Dánsku, proč by to nemělo jít u nás?"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-21",
+      "answer": "no",
+      "comment": "Je to velmi nepraktické a v tak malé zemi zbytečné."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-22"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-23",
+      "answer": "yes",
+      "comment": "Žijeme ve 21. století a v řadě zemí je to standard. Mnoha lidem by to pomohlo a takové opatření má potenciál zvýšit účast u voleb. "
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-25",
+      "answer": "yes",
+      "comment": "Brzká selekce dětí vede ke zvýhodňování těch, které měly štěstí a narodily se do lepšího sociálního prostředí. Celkově na tom ale tratíme všichni."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-26",
+      "answer": "yes",
+      "comment": "Je v našem zájmu, aby každý mohl maximálně rozvinout svůj potenciál a své talenty. "
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-27",
+      "answer": "no",
+      "comment": "Vystoupení z Evropské unie by mělo fatální následky ekonomické, společenské i kulturní."
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-28",
+      "answer": "yes",
+      "comment": "Včera bylo pozdě. Dnes v době krizí se ukazuje, jaký problém bylo lpění na koruně."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-29",
+      "answer": "no",
+      "comment": "V žádném případě nesmíme oslabit naši mezinárodní ochranu a musíme být součástí demokratického světa včetně jeho společné obrany."
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-31",
+      "answer": "yes",
+      "comment": "Ač si to mnozí nemyslí, jsme v rámci světa jednou z těch bohatších zemí a bohatství zavazuje. "
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-33",
+      "answer": "yes",
+      "comment": "Dnešní azylové řízení je nekonečné martýrium a ministerstvo vnitra s v podstatě snaží všem žadatelům o azyl situaci co nejvíce ztížit. "
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-34",
+      "answer": "yes",
+      "comment": "Musíme zůstat pevnou součástí Evropské unie a Schengenu. Přináší nám to obrovské výhody a usnadňuje to život a cestování, což ví každý, kdo někdy cestoval do Chorvatska."
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-35",
+      "answer": "no",
+      "comment": "Armáda by měla nejprve prokázat, že miliardy, které se na ní vydávají, jsou vynakládány účelně. Zatím spíše prokazuje opak."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-36",
+      "answer": "no",
+      "comment": "Lidé si nemají hrát na Boha. Je úžasné, že existuje možnost umělého oplodnění pro páry, které by jinak děti mít nemohly, ale vše má své hranice. "
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-37",
+      "answer": "no",
+      "comment": "Možnost soukromého připojištění předpokládá existenci dvojího standardu ve zdravotnictví, což je nepřijatelné. Každý má mít právo na to nejlepší možné ošetření, nehledě na to, kolik má peněz."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-38",
+      "comment": "Nejsem odborník na zdravotnictví a toto je vysoce odborná otázka. "
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-39",
+      "answer": "yes",
+      "comment": "Jako včelař vím, jaké škody takové přípravky dokáží napáchat na včelstvech, a nedělám si proto iluze o jejich dopadech na životní prostředí."
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-40",
+      "answer": "no",
+      "comment": "Měl by se ale změnit systém vybírání pokut, aby nebyl motivační pro vybírání pokud za každou cenu a účelovému umisťování těchto systémů do míst, kde jde jen o vybírání pokut."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-41",
+      "answer": "yes",
+      "comment": "Možnosti dohledu se s novými technologiemi dramaticky rozšiřují a s tím se zároveň zmenšuje naše svoboda. Takové technologie jsou snadno zneužitelné, jak můžeme vidět v Číně, která je vyžívá k tyranizování ujgurské menšiny. To by pro nás mělo být varování. "
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-42",
+      "answer": "yes",
+      "comment": "Ale teprve až k tomu bude po všech stránkách připravena, což ještě dlouho nebude."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-43",
+      "answer": "yes",
+      "comment": "Ale teprve až k tomu bude po všech stránkách připravena, což ještě dlouho nebude."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-44",
+      "comment": "To je velmi odborná otázka a nejsem expert na dopady takového kroku. "
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-45",
+      "answer": "no",
+      "comment": "Současný veřejný ochránce práv jedná podle mne v rozporu se svými povinnostmi a poškozuje obraz této instituce, který budovali takové nezpochybnitelné morální autority jako pan Motejl či paní Šabatová."
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-46",
+      "answer": "yes",
+      "comment": "Vojenské napadení suverénního státu nemá ve 21. století místo a pachatel by měl nést veškeré následky takového konání."
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-48",
+      "answer": "yes",
+      "comment": "Násilí vůči ženám a domácí násilí je palčivý problém a kauzy jako ta Feriho, Trávníčka či Cimického jsou jen špičkou ledovce. Je třeba dělat mnohem více v jeho potírání, navíc v zemi, jejíž Parlament neschválil Istambulskou úmluvu."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-49",
+      "comment": "Vše bude záležet na tom, jak se bude vyvíjet energetická krize. Jakýkoliv kategorický soud je v této chvíli předčasný, protože nikdo z nás nemá křišťálovou kouli."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-51",
+      "answer": "no",
+      "comment": "Násilná anexe území svrchovaného státu nesmí být schvalována. Je naivní si myslet, že by Putin skončil u Krymu."
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-52",
+      "answer": "no",
+      "comment": "Jsme součástí Evropské unie a nesmíme podkopávat její jednotu, jako to dělá Viktor Orbán."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-56",
+      "comment": "To je technická otázka. Ďábel je vždy v detailech a musel bych vidět konkrétní návrh takového fondu."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-57",
+      "answer": "no",
+      "comment": "Násilná agrese proti suverénnímu státu je hrubým porušením mezinárodního práva a nesmí vést k tomu, že by byl na Ukrajinu vyvíjen tlak, aby se vzdala svých okupovaných území. Putin by to stejně bral jako schvalování agrese a pokračoval by dále třeba až do Prahy."
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-25-c-377248",
+      "question_id": "senatni-2022-25-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-2",
+      "answer": "no",
+      "comment": "Vláda by měla podporovat obce a města, která by obecní byty stavěla."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-4",
+      "answer": "yes",
+      "comment": "Pokud by měla Evropa dokončenou síť pro rychlovlaky, mohla by výrazně omezit neekologické létání a zlepšit standart dopravy pro cestující."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-5",
+      "comment": "Je třeba vzít v úvahu udržitelnost systému, případně ho upravit např. vlastním spořením, důchodovou reformou atd."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-8",
+      "answer": "no",
+      "comment": "Tento princip už je uplatňován vyšším zdaněním příjmů nad milion Kč ročně."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-12",
+      "answer": "yes",
+      "comment": "Stejně jako jakákoliv jiná média."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-17",
+      "answer": "yes",
+      "comment": "Výsledkem si ovšem nemůžeme být jisti..."
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-20",
+      "answer": "no",
+      "comment": "Lidé mají být vedeni k zodpovědnosti za své jednání."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-21",
+      "answer": "yes",
+      "comment": "Je to mimo jiné důležité i pro život a normální fugování menších měst i dopravu."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-23",
+      "answer": "yes",
+      "comment": "Ale jen pro volby parlamentní, prezidentské a do Evropského parlamentu."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-25",
+      "answer": "no",
+      "comment": "Vzdělávání by mělo být formou i obsahem co nejvíce individualizováno."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-29",
+      "answer": "no",
+      "comment": "V současnosti se ukazuje, jak je naše členství v NATO důležité pro naši obranu."
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-31",
+      "answer": "yes",
+      "comment": "Postupovat společně s ostatními vyspělými zeměmi."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-33"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-37",
+      "answer": "yes",
+      "comment": "Lidé by se měli o své zdraví starat a měli by k tomu být motivováni i tímto způsobem."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-38",
+      "answer": "yes",
+      "comment": "Jedná se o finanční udržitelnost, vybavení i odbornou připravenost personálu."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-43",
+      "answer": "yes",
+      "comment": "Spíše ano, pokud bude sama chtít."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-49",
+      "answer": "no",
+      "comment": "Dlouho jsme přešlapovali na místě s budováním alternativních zdrojů..."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-53",
+      "answer": "yes",
+      "comment": "Už jsem podpořil svým hlasováním v Senátu"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-54",
+      "answer": "yes",
+      "comment": "Současný systém je velmi nespravedlivý vůči malým a středním firmám či jednotlivcům"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-55"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-57",
+      "answer": "no",
+      "comment": "To by byl konec zásad a principů mezinárodního práva a popření suverenity a svobody v  těsné blízkosti naší země"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-25-c-813666",
+      "question_id": "senatni-2022-25-q-58",
+      "answer": "yes",
+      "comment": "Už se tak děje v případě Milostivého léta"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-3",
+      "answer": "no",
+      "comment": "Riziko zneužití, právě v době je ko je tato, např. k vyvolaní referenda o vystoupení z EU a podobně"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-4",
+      "answer": "no",
+      "comment": "Přesto vysokorychlostní tratě pokládám za velmi důležité, zejména kvůli propojení s Evropou a vytváření alternativy proti letecké dopravě. "
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-6",
+      "answer": "no",
+      "comment": "Podporuji přehrady pouze v případě, kdy slouží jako zdroj pro zásobování pitnou vodou."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-8",
+      "comment": "Daně nesmí mít podobu trestu za schopnost."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-12",
+      "answer": "yes",
+      "comment": "Odpovědnost ano, ale absolutní kontrola je nebezpečná. Nechceme dopadnout jako v Číně"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-13",
+      "answer": "yes",
+      "comment": "Po upozornění je nutné toto důsledně prověřit a případně zprávy vymazat."
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-15",
+      "comment": "Požaduji větší kontrolu pracovních agentur ohledně dodržování zákoníku práce."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-21",
+      "answer": "yes",
+      "comment": "Platí pro krajská města a města s dobrou dopravní dostupností."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-22",
+      "comment": "V tomto bychom měli postupovat společně v rámci EU."
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-25",
+      "answer": "no",
+      "comment": "Víceletá gymnázia mají smysl pokud přijímají skutečně talentované děti."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-26",
+      "answer": "yes",
+      "comment": "Je třeba podporovat i speciální školy, protože ne pro každé dítě je běžný způsob výuky vhodný."
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-33"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-38",
+      "answer": "yes",
+      "comment": "Je třeba zajistit lepší dopravní obslužnost v regionech."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-42",
+      "comment": "Nové země musí prokázat, že budou platnými členy a budouctít hodnoty na kterých je EU postavena"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-43",
+      "comment": "Nové země musí prokázat, že budou platnými členy a budou ctít hodnoty na kterých je NATO založeno."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-44",
+      "answer": "no",
+      "comment": "Je třeba oddělit cenu elektřiny od ceny plynu, tedy dotovat cenu plynu pro výrobu elektřiny v plynových elektrárnách. A jak navrhuje Evropská komise, cílem je zbavit se závislosti na ruském plynu do roku 2030."
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-55"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-56",
+      "answer": "no",
+      "comment": "Toto by mělo být v kompetenci obcí, případně krajů."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-25-c-290001",
+      "question_id": "senatni-2022-25-q-58",
+      "answer": "no",
+      "comment": "Dobrým řešením je akce typu Milostivé léto."
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/28.json
+++ b/data/kalkulacka/senatni-2022/28.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-28",
-  "name": "28",
-  "description": "28 - DESCRIPTION",
+  "name": "Mělník",
+  "description": "Mělník",
   "district_code": "28",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-28-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-28-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-28-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-28-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-28-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-28-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-28-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-28-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-28-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-28-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-28-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-28-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-28-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-28-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-28-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-28-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-28-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-28-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-28-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-28-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-28-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-28-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-28-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-28-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-28-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-28-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-28-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-28-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-28-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-28-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-28-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-28-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-28-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-28-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-28-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-28-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-28-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-28-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-28-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-28-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-28-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-28-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-28-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-28-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-28-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-28-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-28-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-28-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-28-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-28-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-28-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-28-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-28-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-28-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-28-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-28-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-28-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-28-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-28-candidate-454822",
+      "id": "senatni-2022-28-c-454822",
       "name": "Zdeněk Šarapatka",
-      "type": "party",
+      "type": "person",
       "description": "Zdeněk Šarapatka - DESCRIPTION",
       "contacts": {
         "web": [
@@ -501,7 +503,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-28-454822-party",
+          "id": "senatni-2022-28-c-454822-p",
           "name": "Zdeněk Šarapatka",
           "description": "Zdeněk Šarapatka - DESCRIPTION",
           "contacts": {
@@ -527,9 +529,9 @@
       ]
     },
     {
-      "id": "senatni-2022-28-candidate-553512",
+      "id": "senatni-2022-28-c-553512",
       "name": "Andrea Brzobohatá",
-      "type": "party",
+      "type": "person",
       "description": "Andrea Brzobohatá - DESCRIPTION",
       "contacts": {
         "web": [
@@ -544,7 +546,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-28-553512-party",
+          "id": "senatni-2022-28-c-553512-p",
           "name": "Andrea Brzobohatá",
           "description": "Andrea Brzobohatá - DESCRIPTION",
           "contacts": {
@@ -563,16 +565,16 @@
       ]
     },
     {
-      "id": "senatni-2022-28-candidate-720036",
+      "id": "senatni-2022-28-c-720036",
       "name": "Milan Němec",
-      "type": "party",
+      "type": "person",
       "description": "Milan Němec - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-28-720036-party",
+          "id": "senatni-2022-28-c-720036-p",
           "name": "Milan Němec",
           "description": "Milan Němec - DESCRIPTION",
           "contacts": {
@@ -583,9 +585,9 @@
       ]
     },
     {
-      "id": "senatni-2022-28-candidate-289041",
+      "id": "senatni-2022-28-c-289041",
       "name": "Petr Holeček",
-      "type": "party",
+      "type": "person",
       "description": "Petr Holeček - DESCRIPTION",
       "contacts": {
         "web": [
@@ -608,7 +610,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-28-289041-party",
+          "id": "senatni-2022-28-c-289041-p",
           "name": "Petr Holeček",
           "description": "Petr Holeček - DESCRIPTION",
           "contacts": {
@@ -635,9 +637,9 @@
       ]
     },
     {
-      "id": "senatni-2022-28-candidate-704700",
+      "id": "senatni-2022-28-c-704700",
       "name": "Jarmila Smotlachová",
-      "type": "party",
+      "type": "person",
       "description": "Jarmila Smotlachová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -651,7 +653,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-28-704700-party",
+          "id": "senatni-2022-28-c-704700-p",
           "name": "Jarmila Smotlachová",
           "description": "Jarmila Smotlachová - DESCRIPTION",
           "contacts": {
@@ -669,9 +671,9 @@
       ]
     },
     {
-      "id": "senatni-2022-28-candidate-972909",
+      "id": "senatni-2022-28-c-972909",
       "name": "Karen Pumrová",
-      "type": "party",
+      "type": "person",
       "description": "Karen Pumrová - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -679,7 +681,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-28-972909-party",
+          "id": "senatni-2022-28-c-972909-p",
           "name": "Karen Pumrová",
           "description": "Karen Pumrová - DESCRIPTION",
           "contacts": {
@@ -691,9 +693,9 @@
       ]
     },
     {
-      "id": "senatni-2022-28-candidate-205170",
+      "id": "senatni-2022-28-c-205170",
       "name": "Ivan Noveský",
-      "type": "party",
+      "type": "person",
       "description": "Ivan Noveský - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -702,7 +704,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-28-205170-party",
+          "id": "senatni-2022-28-c-205170-p",
           "name": "Ivan Noveský",
           "description": "Ivan Noveský - DESCRIPTION",
           "contacts": {
@@ -715,5 +717,695 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-6"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-9",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-36"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-28-c-454822",
+      "question_id": "senatni-2022-28-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-4"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-11",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-16"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-17",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-18",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-32"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-39",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-50"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-28-c-704700",
+      "question_id": "senatni-2022-28-q-58",
+      "answer": "no"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/31.json
+++ b/data/kalkulacka/senatni-2022/31.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-31",
-  "name": "31",
-  "description": "31 - DESCRIPTION",
+  "name": "Ústí nad Labem",
+  "description": "Ústí nad Labem",
   "district_code": "31",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-31-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-31-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-31-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-31-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-31-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-31-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-31-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-31-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-31-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-31-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-31-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-31-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-31-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-31-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-31-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-31-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-31-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-31-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-31-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-31-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-31-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-31-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-31-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-31-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-31-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-31-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-31-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-31-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-31-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-31-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-31-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-31-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-31-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-31-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-31-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-31-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-31-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-31-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-31-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-31-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-31-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-31-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-31-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-31-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-31-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-31-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-31-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-31-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-31-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-31-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-31-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-31-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-31-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-31-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-31-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-31-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-31-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-31-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-31-candidate-665893",
+      "id": "senatni-2022-31-c-665893",
       "name": "Věra Nechybová",
-      "type": "party",
+      "type": "person",
       "description": "Věra Nechybová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -502,7 +504,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-31-665893-party",
+          "id": "senatni-2022-31-c-665893-p",
           "name": "Věra Nechybová",
           "description": "Věra Nechybová - DESCRIPTION",
           "contacts": {
@@ -529,9 +531,9 @@
       ]
     },
     {
-      "id": "senatni-2022-31-candidate-165219",
+      "id": "senatni-2022-31-c-165219",
       "name": "Martin Krsek",
-      "type": "party",
+      "type": "person",
       "description": "Martin Krsek - DESCRIPTION",
       "contacts": {
         "web": [
@@ -549,7 +551,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-31-165219-party",
+          "id": "senatni-2022-31-c-165219-p",
           "name": "Martin Krsek",
           "description": "Martin Krsek - DESCRIPTION",
           "contacts": {
@@ -571,9 +573,9 @@
       ]
     },
     {
-      "id": "senatni-2022-31-candidate-619365",
+      "id": "senatni-2022-31-c-619365",
       "name": "Alfréd Dytrt",
-      "type": "party",
+      "type": "person",
       "description": "Alfréd Dytrt - DESCRIPTION",
       "contacts": {
         "web": [
@@ -587,7 +589,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-31-619365-party",
+          "id": "senatni-2022-31-c-619365-p",
           "name": "Alfréd Dytrt",
           "description": "Alfréd Dytrt - DESCRIPTION",
           "contacts": {
@@ -605,9 +607,9 @@
       ]
     },
     {
-      "id": "senatni-2022-31-candidate-246453",
+      "id": "senatni-2022-31-c-246453",
       "name": "Jan Beer",
-      "type": "party",
+      "type": "person",
       "description": "Jan Beer - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -615,7 +617,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-31-246453-party",
+          "id": "senatni-2022-31-c-246453-p",
           "name": "Jan Beer",
           "description": "Jan Beer - DESCRIPTION",
           "contacts": {
@@ -627,9 +629,9 @@
       ]
     },
     {
-      "id": "senatni-2022-31-candidate-699892",
+      "id": "senatni-2022-31-c-699892",
       "name": "Martin Balej",
-      "type": "party",
+      "type": "person",
       "description": "Martin Balej - DESCRIPTION",
       "contacts": {
         "web": [
@@ -648,7 +650,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-31-699892-party",
+          "id": "senatni-2022-31-c-699892-p",
           "name": "Martin Balej",
           "description": "Martin Balej - DESCRIPTION",
           "contacts": {
@@ -671,9 +673,9 @@
       ]
     },
     {
-      "id": "senatni-2022-31-candidate-800949",
+      "id": "senatni-2022-31-c-800949",
       "name": "Jaroslav Telecký",
-      "type": "party",
+      "type": "person",
       "description": "Jaroslav Telecký - DESCRIPTION",
       "contacts": {
         "web": [
@@ -691,7 +693,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-31-800949-party",
+          "id": "senatni-2022-31-c-800949-p",
           "name": "Jaroslav Telecký",
           "description": "Jaroslav Telecký - DESCRIPTION",
           "contacts": {
@@ -713,9 +715,9 @@
       ]
     },
     {
-      "id": "senatni-2022-31-candidate-163515",
+      "id": "senatni-2022-31-c-163515",
       "name": "René Hladík",
-      "type": "party",
+      "type": "person",
       "description": "René Hladík - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -723,7 +725,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-31-163515-party",
+          "id": "senatni-2022-31-c-163515-p",
           "name": "René Hladík",
           "description": "René Hladík - DESCRIPTION",
           "contacts": {
@@ -735,9 +737,9 @@
       ]
     },
     {
-      "id": "senatni-2022-31-candidate-570575",
+      "id": "senatni-2022-31-c-570575",
       "name": "Miloslav Buldra",
-      "type": "party",
+      "type": "person",
       "description": "Miloslav Buldra - DESCRIPTION",
       "contacts": {
         "web": [
@@ -749,7 +751,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-31-570575-party",
+          "id": "senatni-2022-31-c-570575-p",
           "name": "Miloslav Buldra",
           "description": "Miloslav Buldra - DESCRIPTION",
           "contacts": {
@@ -765,16 +767,16 @@
       ]
     },
     {
-      "id": "senatni-2022-31-candidate-392644",
+      "id": "senatni-2022-31-c-392644",
       "name": "Petr Nedvědický",
-      "type": "party",
+      "type": "person",
       "description": "Petr Nedvědický - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-31-392644-party",
+          "id": "senatni-2022-31-c-392644-p",
           "name": "Petr Nedvědický",
           "description": "Petr Nedvědický - DESCRIPTION",
           "contacts": {
@@ -785,5 +787,1131 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-1",
+      "answer": "yes",
+      "comment": "Vlastnictví prostoru k bydlení zavazuje k poskytnutí práva na bydlení. "
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-2",
+      "answer": "no",
+      "comment": "Volný trh klepne hamižné přes prsty sám."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-3",
+      "answer": "yes",
+      "comment": "Šlechtické tituly jsou v ČR zakázané od roku 1918, od té doby vládne demokracie, což by se mělo respektovat."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-4",
+      "answer": "no",
+      "comment": "Prozatím není vůbec jasné, jakou energii budeme využívat doma, natož jakou bude využívat rychlovlak. Svět je příliš nestabilní k podpoře kolejí."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-5",
+      "answer": "no",
+      "comment": "Solidarita je vlastní člověku."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-6",
+      "answer": "no",
+      "comment": "Příroda je mocná čarodějka. Poradí si zcela jistě i bez zásahů člověka."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-7",
+      "answer": "yes",
+      "comment": "Jakékoliv drancování přináší více škody než užitku."
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-8",
+      "answer": "yes",
+      "comment": "Lidé mají souměřitelné žaludky."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-9",
+      "answer": "yes",
+      "comment": "Nikdy jsem neslyšel o regulaci rajčat nebo okurek, proč tedy nenechat na zahrádkářích, čím si chtějí osadit zahrádku?"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-10",
+      "comment": "Systém by měl především pachatele napravit!"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-11",
+      "answer": "no",
+      "comment": "Nevidím rozdíl mezi Googlem, Facebookem nebo velkohokynářskými obchody typu Albert či Makro. Proč by jedni měli mít daň speciální a jiní ne? Každému stejně!"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-12",
+      "answer": "no",
+      "comment": "Zodpovědnost musí mít jedinec, pokud není zbaven svéprávnosti."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-13",
+      "answer": "no",
+      "comment": "Neznám žádný věrohodný orgán, který by mohl zodpovědně říci, co je nebo není fake news."
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-14",
+      "answer": "no",
+      "comment": "Pokud nelze u veřejnoprávních médií inkasovat peníze z reklam a přesto musí plnit svoji roli, není na místě prostor k ukusování z koláče."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-15",
+      "answer": "yes",
+      "comment": "Provize považuji za běžné u přeprodeje zboží, tady jde o lidskou sílu, práci a otrokářskou společnost jsme přece již dávno opustili."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-17",
+      "answer": "yes",
+      "comment": "Jen supi pořádají hostiny na cizích!"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-18",
+      "answer": "yes",
+      "comment": "Jeden správní orgán k projednání věci také stačí."
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-19",
+      "answer": "yes",
+      "comment": "Každá společnost na světě má nějaké procento těch, kteří si neumí pomoci sami a jejich situace by měla být řešitelná."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-20",
+      "answer": "yes",
+      "comment": "Pokud by tomu tak nebylo, na holičkách by zůstalo mnoho nesvéprávných jedinců."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-21",
+      "answer": "yes",
+      "comment": "Praha není a nemůže být hlavou chobotnice."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-22",
+      "answer": "no",
+      "comment": "Prozatím bych nechal politiky řídit ČR a až když se to naučí, mohou dostat řidičský průkaz pro jiná území."
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-23",
+      "answer": "no",
+      "comment": "Algoritmy jsou zrádné."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-24",
+      "answer": "yes",
+      "comment": "Absolventi nepotřebných oborů pak nebudou přivádět do rozpaků úředníky na Úřadu práce."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-25",
+      "answer": "no",
+      "comment": "Talent neumlčíš."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-26",
+      "answer": "yes",
+      "comment": "Kde není podpora, je ohroženo sebevědomí."
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-27",
+      "answer": "no",
+      "comment": "Melouny na zahradě nerostou, ty nám musí dovézt ze Španělska."
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-28",
+      "answer": "no",
+      "comment": "Prozatím vedlo zavedení Eura kdykoliv ke zvýšení cen u všeho zboží a služeb."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-29",
+      "answer": "no",
+      "comment": "Nedovedu si představit nikoho, kdo by mohl ČR bránit, když se jdu podívat třeba jen na hodinu tělocviku ve škole, kde učím. Kdo uběhne alespoň 2 kilometry bez zadýchání?"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-30",
+      "answer": "yes",
+      "comment": "Já pán, ty pán = musíme si být všichni rovni. Německo jako Češi!"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-31",
+      "answer": "yes",
+      "comment": "Pokud na to budeme mít a nepůjde o vyhazování peněz oknem, proč ne."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-32",
+      "answer": "yes",
+      "comment": "Všechno nás jednou může dohnat. Nyní jde o zvyšování teploty, proto jsem pro."
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-33",
+      "answer": "no",
+      "comment": "Pokud již nyní odpovídá standardům demokratického světa, není třeba pravidla rozvolňovat."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-34",
+      "answer": "yes",
+      "comment": "S tím, že zavedení vnitřních kontrol na území ČR nic nebrání."
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-35",
+      "answer": "yes",
+      "comment": "Ovšem ze začátku klidně více peněz na brannou výchovu do škol."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-36",
+      "answer": "no",
+      "comment": "Stačí, že si v krámě mohou vybrat růžovou nebo modrou dupačku."
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-37",
+      "answer": "yes",
+      "comment": "Kdo chce být na pokoji sám nebo k obědu si i v nemocnici zadebužírovat minutkou, proč ne."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-38",
+      "answer": "no",
+      "comment": "Šlo by totiž jen o vznik zdravotnické turistiky."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-39",
+      "comment": "Je možné omezovat vědu v zájmu lidstva?"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-40",
+      "answer": "yes",
+      "comment": "Bojím se, že jednoho dne automatický výběr sáhne i do mého účtu, mojí peněženky."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-41",
+      "answer": "no",
+      "comment": "Pokud je kdokoliv schopen garantovat jeho nezneužití."
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-42",
+      "answer": "no",
+      "comment": "Ukrajina by si měla vyřešit problémy uvnitř svého území tak, aby v ní nevládl klientelismus a korupce, která nemá v EU prostor + začít přibližovat svůj právní systém Evropě, pak mohou přicházet úvahy o jejím vstupu kamkoliv."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-43",
+      "answer": "no",
+      "comment": "Je k tomu nějaký zvláštní důvod?"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-44",
+      "answer": "yes",
+      "comment": "Jedině strop může přinutit prodejce k zodpovědnější formě prodeje."
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-45",
+      "answer": "yes",
+      "comment": "Agenda běží dál, pokud se nemýlím. Úřad zaměstnává několik desítek právníků, personální nouzí netrpí. "
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-46",
+      "comment": "Mezinárodní tribunály mají v oblasti válečných zločinů procesními předpisy upraveno, kdo je nebo není válečný zločinec. Nechme jim jejich autonomii a nikam je netlačme, plně jim důvěřuji."
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-47",
+      "comment": "Pokud je součástí mandátu jednat za ČR v zájmu lidu a není jiné cesty, než komunikovat s ruskou administrativou na Krymu, ať jednají a pokud nejsou s Krymem životu nutná témata, ať nejednají."
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-48",
+      "answer": "yes",
+      "comment": "Pokud se nebude překrývat s tuzemskými právními předpisy."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-49",
+      "answer": "no",
+      "comment": "Vznik nových ložisek bude trvat tisíce let, takže rok nebo dva v procesu spalování uhlí nehrají žádnou roli."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-50",
+      "answer": "no",
+      "comment": "Obávám se, že i nyní jde o výkřik do tmy aktivistů Green Dealu."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-51",
+      "comment": "Právo na sebeurčení je nutné respektovat. I když jak víme z nedávné minulosti, Čechů ani Slováků se nikdo na nic neptal."
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-52",
+      "answer": "yes",
+      "comment": "Oni se snad Maďaři nebo Bulhaři nechávají někým zastupovat? Když chci koupit rohlík, také jdu do pekárny sám."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-53",
+      "answer": "yes",
+      "comment": "Díky jejich připravenosti v oblasti obrany v odpovědi na tuto otázku nevidím žádný problém."
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-54",
+      "answer": "no",
+      "comment": "Každému podle velikosti obdělávané plochy. Pokud dám více menšímu, nevyprodukuje víc."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-55",
+      "answer": "no",
+      "comment": "Jen těm, kdo jsou v tísni."
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-56",
+      "answer": "yes",
+      "comment": "Stále jde o lepší řešení, než bylo zvoleno v Teplicích, kde bylo rozprodáno do mrtě úplně vše a pokud má nyní město občana ve stavu tísně nebo jiného handicapu, nemůže mu nabídnout vůbec nic!"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-57",
+      "comment": "Nejsem expert, nerad mluvím do cizích věcí. Co dělají sousedé u mě v baráku je mně také do jisté míry jedno."
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-31-c-246453",
+      "question_id": "senatni-2022-31-q-58",
+      "answer": "yes",
+      "comment": "Kde nic není, ani smrt nebere."
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-3",
+      "answer": "yes",
+      "comment": "Jak se ukazuje při současné energetické krizi by tento požadavek byl velmi důležitý."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-4",
+      "answer": "no",
+      "comment": "I za cenu \"lehkého\" zdržení by výstavba měla jít ruku v ruce s výstavbou další dopravní infrastruktury."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-6",
+      "comment": "Tohle je spíše otázka pro odborníky. Nemám takové informace, abych mohl vědět, jestli v ČR existují vhodná místa pro takovou výstavbu. Pokud ano, nejsem proti."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-9",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-11"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-12",
+      "answer": "no",
+      "comment": "Výjimkou by měl být obsah rasistický,nacistický a fašistický."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-13",
+      "answer": "no",
+      "comment": "Jsem proti jakékoli názorové cenzuře."
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-14",
+      "answer": "yes",
+      "comment": "Vzhledem k tomu co plodí veřejno-právní \"sdělovadla\" by neměly dostávat peníze žádné."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-16",
+      "comment": "Kdo s kým žije je soukromá záležitost a nemyslím si, že by se to mělo na veřejnosti příliš ventilovat."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-18",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-20",
+      "comment": "Pravdou je, že řada našich spoluobčanů nemá ani potuchy o tom, že nárok na nějakou \"dávku\" vůbec mají."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-21"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-23",
+      "answer": "no",
+      "comment": "Zde vidím slabé místo pro regulérnost voleb."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-24",
+      "comment": "Jsem pro podporu technického vzdělání, ale i tady je potřeba rozlišovat neboť ne každý člověk má tzv. technické buňky."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-25",
+      "answer": "no",
+      "comment": "Inkluzi v základním vzdělání nepovažuji za cestu správným směrem."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-26",
+      "answer": "no",
+      "comment": "Zde si myslím, že je to přesně naopak, a sice, že \"pomalejší\" jedinci zpomalují výuku pro ostatní."
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-27",
+      "answer": "yes",
+      "comment": "Již v referendu o vstupu do EU jsem byl proti!"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-28",
+      "answer": "no",
+      "comment": "Rozhodně jsem proti!"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-29",
+      "answer": "yes",
+      "comment": "Jako člověk vyznávající mírovou spolupráci mezi národy a převědčením \"pacifista\" odmítám jakékoli použití zbraní, snad a výjimkou policie, sportovců a v myslivosti!"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-30",
+      "answer": "no",
+      "comment": "Jsem pro neutralitu."
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-31",
+      "comment": "Protiotázka: Víme kde taková pomoc vždy končí?"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-32",
+      "answer": "no",
+      "comment": "Změna klimatu? Nesmysl, zkoncovat s greendealem!"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-33",
+      "answer": "yes",
+      "comment": "Ano, ale jen v nutných případech a řádně prověřených."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-34",
+      "answer": "yes",
+      "comment": "Vzhledem k tomu, že jak jsem již výše uvedl jsem pro vystoupení z EU, by samozřejmě záleželo na tom jaké bychom si vyjednali podmínky v jednotlivých oblastech, včetně cestování."
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-36"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-37",
+      "comment": "Zde jsem spíše pro pojištění státní a snížení počtu ZP."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-39",
+      "comment": "Rozhodně si myslím, že by používání těchto látek mělo být omezeno na nenutnější mez."
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-41"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-42",
+      "answer": "no",
+      "comment": "To je obcházení vstupních regulí, které si EU sama nastavila! Podpora nacizmu v těchto podmínkách není."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-43",
+      "answer": "no",
+      "comment": "Nevidím jediný důvod, proč by se mělo NATO \"roztahovat\" východním či jakýmkoli jiným směrem. Ostatně jsem pro zrušení NATO, tak jak bylo \"hlášeno\" již v roce 1989."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-44",
+      "answer": "no",
+      "comment": "Jestli chceme skutečně přijít o možnost dostat do ČR vůbec nějaký zemní plyn, tak to udělejme ale, pak ať si to státní moc \"vysvětlí\" občanům i firmám!"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-45",
+      "comment": "Vždy je možné, aby to bylo lepší."
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-46",
+      "answer": "no",
+      "comment": "Otázka je špatně formulována. Za prvé by měl být uzavřen mír. Za druhé NATO se musí stáhnout a nedráždit RF. Západ by se měl spolupodílet na denacifikaci Ukrajiny, když už nedokázal Ukrajinu donutit dodržovat \"Minské dohody\"."
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-47",
+      "answer": "yes",
+      "comment": "Každá mírová jednání včetně obchodních jsou lepší než válčit."
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-48",
+      "answer": "yes",
+      "comment": "Samozřejmě, pokud z toho nevznikne paskvil jako v 90% všeho co EU přijímá."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-49",
+      "comment": "I zde je otázkou jak se bude situace vyvíjet v jiných energetických oblastech."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-50",
+      "comment": "V té době věřím, že již v EU nebudeme, případně již EU nebude v dnešní formě a podobě existovat."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-52",
+      "answer": "yes",
+      "comment": "Vyjednávání o energetické soběstačnosti bych rozhodně nenechával na nikom jiném než na našich odbornících např. ing. Vlad. Štěpán, ing. Ivan Noveský, Alena Vitásková, Fr, Janeček, ad."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-53",
+      "answer": "no",
+      "comment": "NATO by se mělo ropustit!"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-54",
+      "comment": "Nemyslím, že by se mělo příliš rozlišovat. Pro mě je nejdůležitější podpora samostatného českého zemědělství tak, aby jsme v plodinách, kterým se daří v našem podnebním pásmu mohli býti soběstační, taktéž v chovu \"masné\" zvěře."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-55",
+      "answer": "no",
+      "comment": "Populismus."
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-56",
+      "answer": "yes",
+      "comment": "Určitě za přesně specifikovaných podmínek dobrá myšlenka."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-57",
+      "answer": "yes",
+      "comment": "Já ten konflikt nadále vidím jako vyprovokovaný tzv. kolektivním západem prostřednictvím Ukrajiny a tím zabíjení se slovanů navzájem, což vyhovuje hlavně USA a západu."
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-31-c-570575",
+      "question_id": "senatni-2022-31-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-2",
+      "answer": "yes",
+      "comment": "Dalo by se tím předejít nehorázně vysokým nájmům, které požadují takzvaní obchodníci s chudobou, tedy vlastníci zchátralých nemovitostí, v nichž ubytovávají zejména nepřizpůsobivé občany. Je to jedno z dílčích opatření, které by řešilo problém sociálně vyloučených lokalit. "
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-6"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-8",
+      "answer": "no",
+      "comment": "Stávající solidární daň v tuto chvíli považuji za dostatečnou. "
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-9",
+      "answer": "yes",
+      "comment": "Pro léčebné účely. "
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-10",
+      "answer": "yes",
+      "comment": "Sexuální zločiny patří k jedním z nejzávažnějších. "
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-15",
+      "answer": "yes",
+      "comment": "Měla by být omezena. "
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-19",
+      "answer": "yes",
+      "comment": "Ano, zejména obecní a státní výstavba. "
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-20",
+      "answer": "no",
+      "comment": "Ale jsou ohrožené skupiny, jako třeba senioři a samoživitelé, které nemají povědomí o tom, jak by jim stát mohl v nouzi pomoci. Stát musí o možnostech podpory pro ohrožené skupiny více informovat. "
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-22"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-28",
+      "answer": "no",
+      "comment": "V tuto chvíli na to není správná doba. "
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-31",
+      "answer": "yes",
+      "comment": "Ano, pomáhat a současně zabránit ekonomickému a sociálnímu rozpadu vlastní země."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-32",
+      "comment": "Částečně ano, ale jasně daných podmínek. "
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-35",
+      "answer": "yes",
+      "comment": "Měla by plnit svůj závazek vůči Severoatlantické alianci."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-36",
+      "comment": "Důležité pro tyto rodiče je, aby vůbec dítě měli a zdravé. "
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-42",
+      "comment": "Jsem příznivcem rozšiřování EU. Ovšem země, které by se měly stát její součástí, by měly projít celým kandidátským procesem a současně by mělo jí o stabilní demokratické země. "
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-43",
+      "comment": "Podobně jako při vstupu do EU ba měla kandidátská stana projít celým vstupním procesem a mělo by jít o stabilní demokratickou zemi, což Ukrajina v tuto chvíli není. "
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-50",
+      "comment": "V tuto chvíli , kdy ceny energií letí raketově vzhůru, EU musí přehodnotit Green Deal. "
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-52",
+      "comment": "Česká republika v době radikálního zvyšování ceny plynu musí vyjednat dodávky za rozumnou cenu. "
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-31-c-665893",
+      "question_id": "senatni-2022-31-q-58",
+      "answer": "yes"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/34.json
+++ b/data/kalkulacka/senatni-2022/34.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-34",
-  "name": "34",
-  "description": "34 - DESCRIPTION",
+  "name": "Liberec",
+  "description": "Liberec",
   "district_code": "34",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-34-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-34-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-34-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-34-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-34-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-34-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-34-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-34-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-34-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-34-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-34-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-34-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-34-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-34-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-34-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-34-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-34-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-34-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-34-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-34-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-34-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-34-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-34-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-34-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-34-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-34-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-34-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-34-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-34-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-34-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-34-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-34-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-34-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-34-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-34-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-34-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-34-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-34-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-34-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-34-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-34-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-34-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-34-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-34-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-34-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-34-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-34-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-34-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-34-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-34-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-34-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-34-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-34-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-34-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-34-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-34-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-34-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-34-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-34-candidate-879839",
+      "id": "senatni-2022-34-c-879839",
       "name": "Svatopluk Holata",
-      "type": "party",
+      "type": "person",
       "description": "Svatopluk Holata - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -487,7 +489,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-34-879839-party",
+          "id": "senatni-2022-34-c-879839-p",
           "name": "Svatopluk Holata",
           "description": "Svatopluk Holata - DESCRIPTION",
           "contacts": {
@@ -499,9 +501,9 @@
       ]
     },
     {
-      "id": "senatni-2022-34-candidate-936940",
+      "id": "senatni-2022-34-c-936940",
       "name": "Martina Motshagen",
-      "type": "party",
+      "type": "person",
       "description": "Martina Motshagen - DESCRIPTION",
       "contacts": {
         "web": [
@@ -520,7 +522,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-34-936940-party",
+          "id": "senatni-2022-34-c-936940-p",
           "name": "Martina Motshagen",
           "description": "Martina Motshagen - DESCRIPTION",
           "contacts": {
@@ -543,9 +545,9 @@
       ]
     },
     {
-      "id": "senatni-2022-34-candidate-474514",
+      "id": "senatni-2022-34-c-474514",
       "name": "Michael Canov",
-      "type": "party",
+      "type": "person",
       "description": "Michael Canov - DESCRIPTION",
       "contacts": {
         "web": [
@@ -568,7 +570,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-34-474514-party",
+          "id": "senatni-2022-34-c-474514-p",
           "name": "Michael Canov",
           "description": "Michael Canov - DESCRIPTION",
           "contacts": {
@@ -595,9 +597,9 @@
       ]
     },
     {
-      "id": "senatni-2022-34-candidate-990991",
+      "id": "senatni-2022-34-c-990991",
       "name": "Radka Loučková Kotasová",
-      "type": "party",
+      "type": "person",
       "description": "Radka Loučková Kotasová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -615,7 +617,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-34-990991-party",
+          "id": "senatni-2022-34-c-990991-p",
           "name": "Radka Loučková Kotasová",
           "description": "Radka Loučková Kotasová - DESCRIPTION",
           "contacts": {
@@ -637,5 +639,350 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-3"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-10"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-12"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-15"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-16",
+      "answer": "no",
+      "comment": "Stejnopohlavní páry by měly mít právo uzavírat sňatek na stejné úrovni, ale s odpovídajícím názvem (nikoli takovým, který implikuje muže a ženu). Muži manmelství (manmel a manmel), ženy ženželství (ženželka a ženželka).  "
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-21"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-23",
+      "answer": "no",
+      "comment": "Dosud by byla příliš velká možnost zneužití tohoto způsobu volby (hackeři apod.)  "
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-26",
+      "answer": "no",
+      "comment": "Inkluze vede naopak k tomu, že slabší žáky motivuje méně, protože jsou v kolektivu outsidery. Při speciální výuce (zvláštní třídy) naopak mohou vyniknout.  "
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-30"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-31"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-45"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-48",
+      "answer": "no",
+      "comment": "V ČR je toto ošetřeno dostatečně. "
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-50",
+      "answer": "no",
+      "comment": "Mnohem důležitější je, aby směrem k větší ekologii šel cely svět (Indie, Čína atd.). Ostrov uhlíkový neutrality (EU) ve světě, kde by tomu jinde ve světě vůbec nebylo,  by byl svojí efektivitou bezvýznamný a naopak by EU zničil konkureschopnost.    "
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-52",
+      "comment": "Měla by v případě, že to nedokáže EU jako celek. "
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-34-c-474514",
+      "question_id": "senatni-2022-34-q-58",
+      "answer": "yes"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/37.json
+++ b/data/kalkulacka/senatni-2022/37.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-37",
-  "name": "37",
-  "description": "37 - DESCRIPTION",
+  "name": "Jičín",
+  "description": "Jičín",
   "district_code": "37",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-37-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-37-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-37-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-37-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-37-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-37-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-37-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-37-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-37-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-37-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-37-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-37-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-37-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-37-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-37-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-37-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-37-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-37-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-37-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-37-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-37-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-37-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-37-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-37-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-37-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-37-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-37-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-37-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-37-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-37-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-37-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-37-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-37-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-37-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-37-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-37-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-37-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-37-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-37-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-37-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-37-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-37-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-37-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-37-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-37-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-37-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-37-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-37-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-37-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-37-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-37-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-37-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-37-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-37-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-37-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-37-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-37-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-37-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-37-candidate-828456",
+      "id": "senatni-2022-37-c-828456",
       "name": "Tomáš Czernin",
-      "type": "party",
+      "type": "person",
       "description": "Tomáš Czernin - DESCRIPTION",
       "contacts": {
         "web": [
@@ -494,7 +496,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-37-828456-party",
+          "id": "senatni-2022-37-c-828456-p",
           "name": "Tomáš Czernin",
           "description": "Tomáš Czernin - DESCRIPTION",
           "contacts": {
@@ -513,9 +515,9 @@
       ]
     },
     {
-      "id": "senatni-2022-37-candidate-844780",
+      "id": "senatni-2022-37-c-844780",
       "name": "René Franěk",
-      "type": "party",
+      "type": "person",
       "description": "René Franěk - DESCRIPTION",
       "contacts": {
         "web": [
@@ -534,7 +536,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-37-844780-party",
+          "id": "senatni-2022-37-c-844780-p",
           "name": "René Franěk",
           "description": "René Franěk - DESCRIPTION",
           "contacts": {
@@ -557,9 +559,9 @@
       ]
     },
     {
-      "id": "senatni-2022-37-candidate-383315",
+      "id": "senatni-2022-37-c-383315",
       "name": "Václav Ort",
-      "type": "party",
+      "type": "person",
       "description": "Václav Ort - DESCRIPTION",
       "contacts": {
         "web": [
@@ -572,7 +574,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-37-383315-party",
+          "id": "senatni-2022-37-c-383315-p",
           "name": "Václav Ort",
           "description": "Václav Ort - DESCRIPTION",
           "contacts": {
@@ -589,9 +591,9 @@
       ]
     },
     {
-      "id": "senatni-2022-37-candidate-664833",
+      "id": "senatni-2022-37-c-664833",
       "name": "Marta Martinová",
-      "type": "party",
+      "type": "person",
       "description": "Marta Martinová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -614,7 +616,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-37-664833-party",
+          "id": "senatni-2022-37-c-664833-p",
           "name": "Marta Martinová",
           "description": "Marta Martinová - DESCRIPTION",
           "contacts": {
@@ -641,9 +643,9 @@
       ]
     },
     {
-      "id": "senatni-2022-37-candidate-957667",
+      "id": "senatni-2022-37-c-957667",
       "name": "Jaromír Dědeček",
-      "type": "party",
+      "type": "person",
       "description": "Jaromír Dědeček - DESCRIPTION",
       "contacts": {
         "web": [
@@ -656,7 +658,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-37-957667-party",
+          "id": "senatni-2022-37-c-957667-p",
           "name": "Jaromír Dědeček",
           "description": "Jaromír Dědeček - DESCRIPTION",
           "contacts": {
@@ -673,9 +675,9 @@
       ]
     },
     {
-      "id": "senatni-2022-37-candidate-593846",
+      "id": "senatni-2022-37-c-593846",
       "name": "Eva Kotyzová",
-      "type": "party",
+      "type": "person",
       "description": "Eva Kotyzová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -689,7 +691,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-37-593846-party",
+          "id": "senatni-2022-37-c-593846-p",
           "name": "Eva Kotyzová",
           "description": "Eva Kotyzová - DESCRIPTION",
           "contacts": {
@@ -707,9 +709,9 @@
       ]
     },
     {
-      "id": "senatni-2022-37-candidate-116316",
+      "id": "senatni-2022-37-c-116316",
       "name": "Dana Kracíková",
-      "type": "party",
+      "type": "person",
       "description": "Dana Kracíková - DESCRIPTION",
       "contacts": {
         "web": [
@@ -728,7 +730,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-37-116316-party",
+          "id": "senatni-2022-37-c-116316-p",
           "name": "Dana Kracíková",
           "description": "Dana Kracíková - DESCRIPTION",
           "contacts": {
@@ -751,5 +753,1087 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-4",
+      "answer": "no",
+      "comment": "Infrastruktura pro rychlovlaky vyžaduje vysoké pořizovací náklady. Provoz bude náročný na elektrickou energii."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-16",
+      "comment": "Nepovažuji za úplně důležité, jak se partnerství dvou lidí nazývá. Stejnopohlavní páry by měly mít stejná práva, zejména v otázkách společného jmění, práva na bydlení, partner by měl být každopádně považován za osobu blízkou v otázkách zdravotního stavu, dědictví či rodičovství."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-33",
+      "comment": "Současný způsob udělování azylu nevyžaduje změnu."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-39",
+      "answer": "no",
+      "comment": "Souhlasím se současnou normou, která zakazuje použití na plodiny pro potravinářské využití. Jsem pro šetrné použití v mezních případech. Při likvidaci vytrvalých plevelů při posklizňové aplikaci zatím glyfosát nemá náhradu. "
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-55",
+      "comment": "Považoval bych to za logické ve veřejných budovách"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-57",
+      "answer": "no",
+      "comment": "Dějiny se nesmí opakovat! V této otázce je jasná paralera s Mnichovskou dohodou. "
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-37-c-828456",
+      "question_id": "senatni-2022-37-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-1",
+      "answer": "yes",
+      "comment": "Výstavba investičních bytů, ve kterých reálně nikdo nebydlí, zvyšuje nájemní bydlení všem."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-2",
+      "answer": "no",
+      "comment": "Obce by ale měly být výrazně podpořeny v budování vlastních nájemních bytů."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-3",
+      "answer": "yes",
+      "comment": "Ano, petiční právo obecně by mělo být posíleno."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-4",
+      "comment": "Především si zaslouží modernizaci naše stávající síť – je dlouhodobě zanedbávaná a není tak konkurenceschopná vůči automobilové dopravě. Hlavní tratě nemají aktuálně ani kapacitu na další nákladní vlaky.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-5",
+      "answer": "no",
+      "comment": "Je potřeba adekvátně odměňovat ty, kteří chtějí pracovat i v důchodu: je to výhodné pro stát i seniory. "
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-6",
+      "answer": "no",
+      "comment": "Přehrady nám se suchem     nepomohou – je třeba zaměřit se na systém vodozádržných a přírodě blízkých opatření v krajině. Prázdné přehrady všude po světě ukazují, že technická řešení nepřinášejí v aktuálním podnebí kýžený výsledek.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-7",
+      "comment": "Mnohem důležitější je, aby se zvýšilo množství odpadu, který se po vytřídění skutečně recykluje v nové materiály a výrobky. "
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-8",
+      "comment": "Mělo by dojít ke snížení zdanění nízkopříjmových obyvatel.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-10",
+      "answer": "yes",
+      "comment": "Problém je ale hlavně v tom, že jsou nyní v trestním řízení udělovány nízké tresty. Je potřeba napravit definici znásilnění tak, aby zahrnovala i situace, kdy oběť nedokáže projevit odpor. "
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-11",
+      "answer": "yes",
+      "comment": "Podporuji zavedení globální minimální daně.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-12",
+      "answer": "no",
+      "comment": "Právní odpovědnost provozovatelů sociálních sítí za obsah jejich uživatelů by vedla k omezování svobody slova."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-13",
+      "answer": "no",
+      "comment": " Boj s fake news je třeba založit na mediální výchově ve školách.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-14",
+      "answer": "no",
+      "comment": "Ne, rady veřejnoprávních médií by se však měly stát politicky nezávislými a skládat se především ze skutečných mediálních odborníků a odbornic.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-15",
+      "answer": "yes",
+      "comment": "Agenturní zaměstnávání trvale devalvuje pracovní podmínky a pokřivuje trh práce."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-16",
+      "answer": "yes",
+      "comment": "Jsem přesvědčená o tom, že všichni lidé by měli mít stejná práva i povinnosti. A dlouhodobé     průzkumy veřejného mínění potvrzují, že manželství pro všechny chce i většina české společnosti. "
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-17",
+      "answer": "yes",
+      "comment": "Zavedením místní příslušnosti se zvýší přezkoumatelnost činnosti exekutorů."
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-18",
+      "answer": "yes",
+      "comment": "Jde o efektivní nástroj proti dluhovým pastem.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-19",
+      "comment": "Sociální bydlení by ale být navázáno potřebu v konkrétní lokalitě (tedy nesouhlasím s „musí“ a „vždy“). Obce by měly být motivovány k rozvoji bytového fondu, jehož součástí je sociální bydlení.   "
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-20",
+      "answer": "yes",
+      "comment": "V současné době v informování veřejnosti hrají zásadní roli neziskové organizace – stát by měl ale dělat víc v informování občanů o nároku na dávky.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-21",
+      "comment": "U vybraných úřadů si to umím představit."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-22",
+      "comment": "Výzkum spojený s kolonizací přináší technologie využitelné pro řešení aktuálních problémů. Praktickou realizaci kolonizace Marsu ale považuji ve chvíli, kdy čelíme několika globálním krizím, za skutečně vedlejší."
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-23",
+      "answer": "yes",
+      "comment": "Ano, za podmínky, že budou naplněny všechny ústavněprávní požadavky a IT infrastruktura ve stavu, který spolehlivě zajistí bezpečný průběh.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-24",
+      "answer": "no",
+      "comment": "Vzhledem k rychlému rozvoji technologií a proměnám pracovního trhu už není udržitelný scénář, že se člověk vyučí v oboru, v němž celý život pracuje. Naučit by se tedy měl především všeobecnému přehledu, kritickému myšlení a samotné schopnosti se učit."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-25",
+      "answer": "no",
+      "comment": "Měla by být možnost zvolit si různé možnosti způsobů vzdělávání, jako je individuální vzdělávání. Vzdělávání by mělo být stále povinné, školní docházka by ale měla být jen jednou z možností jak povinnost splnit."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-26",
+      "answer": "yes",
+      "comment": "26 V oblasti inkluze se musíme zaměřit především na dobře cílenou podporu přímo školám, dlouhodobé a fungující financování, podporu a profesní rozvoj učitelů.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-28",
+      "answer": "yes",
+      "comment": "Ano, ale nejprve je třeba stabilizovat korunu vůči euru."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-33",
+      "answer": "yes",
+      "comment": "Žádost o azyl musí být především zefektivněna. Azylové řízení by samozřejmě nadále mělo splňovat požadavky na bezpečnostní kontrolu příchozích."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-35"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-37",
+      "answer": "no",
+      "comment": "V konečném důsledku by možnost soukromého připojištění vedla ke zhoršení standardní péče, a rozevírání nůžek v dostupnosti potřebné péče mezi bohatými a chudými."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-38",
+      "comment": "S centralizací vysoce specializované péče souhlasím, s tímto krokem ale nesmí dojít k zhoršení dostupnosti běžnější péče."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-39",
+      "answer": "yes",
+      "comment": "U této látky bylo prokázáno, že je zdraví vysoce nebezpečná. Zároveň je ale třeba vyvíjet a testovat přípravky, kterými ho budeme moci efektivně nahradit.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-41",
+      "answer": "yes",
+      "comment": "Fungování biometrického sledování lze jen obtížně veřejně kontrolovat."
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-42",
+      "answer": "yes",
+      "comment": "Ano, pokud splní podmínky vstupu (Kodaňská kritéria)."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-43",
+      "comment": "Ukrajina aktuálně o vstup neusiluje, nicméně o vstupu či nevstupu jakéhokoli státu do NATO by neměla rozhodovat žádná autoritářská země mimo NATO, byť jde o jadernou velmoc."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-44",
+      "answer": "yes",
+      "comment": "Ano, současná krize vyžaduje jednotný postup evropského trhu.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-45",
+      "answer": "no",
+      "comment": "Stanislav Křeček se nechová jako nestranný a nezávislý ombudsman, který má hájit práva všech občanů. "
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-46",
+      "answer": "yes",
+      "comment": "Ano, pokud tato otázka znamená odpovědnost za válečné zločiny a platby poválečných reparací. "
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-47",
+      "answer": "no",
+      "comment": "O čem? Podmínky ústupu Ruska z Ukrajiny by měla vyjednat ukrajinská administrativa."
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-48",
+      "answer": "yes",
+      "comment": "Ano, bagatelizace domácího násilí musí skončit."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-49",
+      "answer": "yes",
+      "comment": "Ano, mělo by skončit co nejdříve, je třeba urychleně podpořit rozvoj obnovitelných zdrojů energie, což ČR dlouhodobě a naprosto zanedbávala (přičemž 2/3 roční spotřeby uhlí ČR dováží).     \n"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-50",
+      "answer": "yes",
+      "comment": "Současná energetická krize není dopadem politik směřujících k uhlíkové neutralitě, ale naopak odrazem naší trvající závislosti na fosilních palivech. Občanky a občany je třeba podpořit v tom, aby své energetické potřeby dokázali naplňovat sami nebo s pomocí obcí a to nejlépe umožňují OZE v kombinaci s efektivními úsporami spotřeby."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-52",
+      "answer": "no",
+      "comment": "Ne, fakticky by to znamenalo vazalství vůči autoritářskému režimu, které by se dlouhodobě vymstilo. Je třeba hledat celoevropské řešení krize s plynem."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-54",
+      "comment": "Otázka špatně položena. Menší zemědělci byli v dotačním systému dlouhodobě diskriminování, to je určitě třeba narovnat. Platby, které zemědělci od společnosti dostávají, by ale hlavně měly kompenzovat úsilí přínosné pro celou společnost, např. opatření na zádrž vody v krajině bránící suchu i povodním. "
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-56",
+      "comment": "Budovat bytový fond by mělo být v kompetenci obcí. Stát by měl zajistit legislativní rámec, metodickou podporu a pomoc efektivnímu fungování trhu s bydlením.     \n"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-37-c-664833",
+      "question_id": "senatni-2022-37-q-58",
+      "answer": "yes",
+      "comment": "Vleklé vymáhání pohledávek, ve kterých jde často už jen o uměle navyšované náklady za vedení exekucí, neúměrně zatěžují nejen úřady, ale hlavně zaměstnavatele. Dlužníci se pak skrývají v šedé ekonomice nebo jsou zbytečně na dávkách. Tím mrháme nejen penězi, ale i     potřebnou pracovní silou."
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-2",
+      "answer": "no",
+      "comment": "Regulované nájemné je možné uplatnit u výstavby sociálních bytů obcemi za pomoci dotace, ale obecně regulovat ceny nájemného by pokřivilo tržní prostředí."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-37-c-116316",
+      "question_id": "senatni-2022-37-q-58",
+      "answer": "yes"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/4.json
+++ b/data/kalkulacka/senatni-2022/4.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-4",
-  "name": "4",
-  "description": "4 - DESCRIPTION",
+  "name": "Most",
+  "description": "Most",
   "district_code": "4",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-4-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-4-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-4-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-4-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-4-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-4-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-4-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-4-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-4-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-4-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-4-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-4-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-4-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-4-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-4-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-4-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-4-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-4-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-4-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-4-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-4-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-4-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-4-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-4-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-4-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-4-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-4-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-4-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-4-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-4-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-4-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-4-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-4-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-4-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-4-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-4-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-4-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-4-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-4-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-4-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-4-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-4-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-4-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-4-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-4-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-4-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-4-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-4-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-4-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-4-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-4-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-4-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-4-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-4-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-4-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-4-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-4-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-4-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-4-candidate-871435",
+      "id": "senatni-2022-4-c-871435",
       "name": "Alena Dernerová",
-      "type": "party",
+      "type": "person",
       "description": "Alena Dernerová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -493,7 +495,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-4-871435-party",
+          "id": "senatni-2022-4-c-871435-p",
           "name": "Alena Dernerová",
           "description": "Alena Dernerová - DESCRIPTION",
           "contacts": {
@@ -511,9 +513,9 @@
       ]
     },
     {
-      "id": "senatni-2022-4-candidate-737193",
+      "id": "senatni-2022-4-c-737193",
       "name": "Hana Aulická Jírovcová",
-      "type": "party",
+      "type": "person",
       "description": "Hana Aulická Jírovcová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -528,7 +530,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-4-737193-party",
+          "id": "senatni-2022-4-c-737193-p",
           "name": "Hana Aulická Jírovcová",
           "description": "Hana Aulická Jírovcová - DESCRIPTION",
           "contacts": {
@@ -547,9 +549,9 @@
       ]
     },
     {
-      "id": "senatni-2022-4-candidate-248303",
+      "id": "senatni-2022-4-c-248303",
       "name": "Ivana Turková",
-      "type": "party",
+      "type": "person",
       "description": "Ivana Turková - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -557,7 +559,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-4-248303-party",
+          "id": "senatni-2022-4-c-248303-p",
           "name": "Ivana Turková",
           "description": "Ivana Turková - DESCRIPTION",
           "contacts": {
@@ -569,9 +571,9 @@
       ]
     },
     {
-      "id": "senatni-2022-4-candidate-729274",
+      "id": "senatni-2022-4-c-729274",
       "name": "Michal Moravec",
-      "type": "party",
+      "type": "person",
       "description": "Michal Moravec - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -579,7 +581,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-4-729274-party",
+          "id": "senatni-2022-4-c-729274-p",
           "name": "Michal Moravec",
           "description": "Michal Moravec - DESCRIPTION",
           "contacts": {
@@ -591,9 +593,9 @@
       ]
     },
     {
-      "id": "senatni-2022-4-candidate-425473",
+      "id": "senatni-2022-4-c-425473",
       "name": "Jan Paparega",
-      "type": "party",
+      "type": "person",
       "description": "Jan Paparega - DESCRIPTION",
       "contacts": {
         "web": [
@@ -606,7 +608,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-4-425473-party",
+          "id": "senatni-2022-4-c-425473-p",
           "name": "Jan Paparega",
           "description": "Jan Paparega - DESCRIPTION",
           "contacts": {
@@ -623,5 +625,393 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-1",
+      "answer": "no",
+      "comment": "Nelze někomu určovat, jak má zacházet se svým majetkem. Tohle už tu jednou bylo a nepřineslo to nic dobrého. Dodnes se s tím jako stát potýkáme."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-2",
+      "answer": "no",
+      "comment": "Pokud se jedná o soukromý bytový fond, tak stát nesmí zasahovat do rozhodnutí majitele. Stát může regulovat jenom to, co skutečně vlastní z více než 50%. "
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-3",
+      "answer": "yes",
+      "comment": "Referendum je nejvyšší formou demokracie a pokud se k těmto principům chceme hlásit, je referendum nedílnou součástí veřejné politiky."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-4",
+      "answer": "no",
+      "comment": "Infrastrukturu je třeba řešit komplexně s přihlédnutím k možnostem a potřebám každého regionu. Není možné, aby někde jezdil rychlovlak a jinde nejede ani školní autobus a tím pádem dochází k vylidňování malých obcí."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-5",
+      "answer": "no",
+      "comment": "Stárnutí populace sice k těmto úvahám přispívá, ale každý nemá to \"štěstí\", aby měl pevné zdraví potřebné k výkonu práce i po 65 - pátém roku života. Nechal bych to na individuálním posouzení každého jednotlivce. Pokud by tak chtěl udělat stát, tak je nutné k tomu přistoupit velice zodpovědně a třeba zákonem o zdravotním přezkumu každého jednotlivce každých 6 měsíců pro posouzení zdravotního stavu. Samozřejmě by náklady na tyto vyšetření v plné ceně hradil stát!"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-6",
+      "comment": "Tohle téma je vysoce odborné a mají ho řešit odborníci, kteří se touto problematikou zabývají."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-7",
+      "answer": "yes",
+      "comment": "Je to nejjednodušší způsob, jak snížit dopad na životní prostředí a recyklaci těchto odpadů."
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-8",
+      "answer": "no",
+      "comment": "Pokud je někdo šikovný, tak zájem státu by měl být ten, aby byl i spokojený. Stát by měl být ten, kdo občany k vyšším výdělkům a tím i k větší pracovitosti motivuje a ne, že je bude trestat za úspěch. Daň 15% je nastavená dobře a každý, kdo vychodil ZŠ ví, že z výdělku 10 000,- Kč je daň 1 500,- Kč a ze 100 000,- Kč je daň 15 000,- Kč, takže ten úspěšnější už vyšší daň odvede a nemusím ho trestat za úspěch a pracovitost. "
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-9",
+      "answer": "no",
+      "comment": "Léčebné účinky už asi nikdo nezpochybňuje, ale rozhodnou úlohu musí mít stát. U alkoholu a tabáku jsou také nastavena pravidla s vůdčí úlohou státu."
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-10",
+      "answer": "yes",
+      "comment": "Je ovšem potřeba, aby se změnila právní legislativa. Nelze jenom někoho nařknout a po prokázání účelového obvinění nechat za sebou zlikvidovaného člověka a dělat, že je to OK. Stejný trest by měl být uložen tomu, kdo druhého obviní a obvinění není prokázáno."
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-11",
+      "answer": "yes",
+      "comment": "Ano, jsou to globální firmy, které určují trh a oni rozhodují o tom jaký obsah povolí, nebo ne. Za tuto svou téměř monopolní pozici je nutné zaplatit exklusivitu na trhu kdekoliv na světě."
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-12",
+      "answer": "no",
+      "comment": "Jelikož se jedná o firmy , které mají monopol v komunikaci a médiích, měli by zveřejňovat všechen obsah a jeho závadnost, či nezávadnost musí posoudit stát, ve kterém je obsah zveřejněn. Jenom stát, má právo podle platné právní legislativy posoudit, jaký obsah a kdo sdílel, nebo zveřejnil. Nelze udělat z majitelů sociálních sítí tzv. nosiče pravdy a toho jediného správného názoru. Proto by měli platit daň ve všech zemích, kde působí a daný stát určí, jaký obsah je v pořádku, nebo už je v trestněprávní rovině tzv. za hranou."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-13",
+      "answer": "no",
+      "comment": "Jelikož se jedná o firmy , které mají monopol v komunikaci a médiích, měli by zveřejňovat všechen obsah a jeho závadnost, či nezávadnost musí posoudit stát, ve kterém je obsah zveřejněn. Jenom stát, má právo podle platné právní legislativy posoudit, jaký obsah a kdo sdílel, nebo zveřejnil. Nelze udělat z majitelů sociálních sítí tzv. nosiče pravdy a toho jediného správného názoru. Proto by měli platit daň ve všech zemích, kde působí a daný stát určí, jaký obsah je v pořádku, nebo už je v trestněprávní rovině tzv. za hranou."
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-14"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-15",
+      "answer": "no",
+      "comment": "Na pracovní agentury je navázána spousta lidí, kteří z nějakého důvodu nemohou vykonávat klasický pracovní úvazek a tím by přišli o možnost výdělku. Dalo by se možná zpřísnit v tom, že bez toho jaký úvazek brigádník vykonává, by se odváděli odvody na soc. pojištění a zdr. pojištění v minimální výši."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-16",
+      "answer": "no",
+      "comment": "Manželství je odvozeno od svazku muže a ženy - manžel a manželka, což u stejnopohlavních párů je poměrně složité určit a rozdělit. Instituce k této alternativě už existují, jenom by se měly doladit nějaké právní detaily. Nicméně ani církev nepovoluje sňatek stejnopohlavních párů v kostele a to je také jedna z \"podmínek\" běžného manželství - možnost uzavřít církevní sňatek."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-17",
+      "answer": "yes",
+      "comment": "Určitě by se tím zlepšila vazba dlužník - exekutor a nemohly by být účtovány nesmyslné platby za \"služební cesty\" exekutora, které je velmi obtížné prokázat a další nesmyslné \"náklady\" na exekuci. Těch věcí je spousta, které by to zlepšilo, ale v pár větách se to nedá shrnout."
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-18",
+      "answer": "yes",
+      "comment": "Ušetření peněz dlužníkům, kteří tím, že jsou v exekuci už mají takové problémy, že se do ní dostali."
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-19",
+      "answer": "yes",
+      "comment": "Určitě. Jenom u soukromé bych to nevyžadoval na 100%, ale spíš nějakou investiční pobídkou. U státní a obecní výstavby bych to uzákonil procenty, nebo počtem bytových jednotek, podle typu výstavby."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-20",
+      "answer": "no",
+      "comment": "Lidé jsou natolik rozumní, kdy si umí zhodnotit situaci v níž se nachází a sami potom aktivně hledají řešení. Ano, jsou případy imobilních a sociálně vyloučených občanů, ale to se dá zvládnout ve spolupráci s ošetřujícími( obvodními) lékaři a sousedy. Pro lidi bez domova jsou zde neziskové organizace, které za tímto účelem založené a ty potom přistupují k té aktivní formě vyhledávání."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-21",
+      "answer": "yes",
+      "comment": "V první řadě by to zvýšilo atraktivitu a důležitost regionů a nové pracovní příležitosti pro vysoce kvalifikované odborníky, kteří tím zajistí i snížení odlivu lidí z \"venkova\"."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-22"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-23",
+      "answer": "no",
+      "comment": "Zatím pro tuto formu volby nenastal čas. To je otázka pro rok 2035 a výše, jelikož je zde pořád vysoké procento lidí počítačově méně zdatných. Navíc poslední výsledky voleb v zahraničí, kde je zavedena \"jenom\" korespondenční volba, zanechaly zvláštní pachuť regulérnosti voleb."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-24",
+      "answer": "yes",
+      "comment": "Nelze to brát ovšem jako mantru. Je potřeba rozvíjet VŠ komplexně. Určitě bych ale snížil o nějaké procento obory humanitních studií a směrů."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-25",
+      "answer": "no",
+      "comment": "Nejdéle do konce prvního stupně, se rozpozná schopnost dětí pro učení a to je asi í moment, kdy by měli mít individuální studijní program, který bude respektovat jejich schopnosti a možnosti. Jakékoliv zbytečné další nároky je frustrují a brzdí v činnostech, které by jim mohli pomoci k lepšímu rozvoji. To je bohužel v \"běžné\" škole, vzhledem k povaze základního školství, nemožné."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-26",
+      "answer": "yes",
+      "comment": "Ano. Má být motivační, ale jak jsem odpovídal o otázku výše. Od druhého stupně to zatím, vzhledem k povaze našeho školství, považuji spíše za škodu pro všechny zúčastněné."
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-27",
+      "answer": "yes",
+      "comment": "Ano. Tak jek se EU prezentuje v posledních 5 letech, je členství v této instituci pro naše občany neperspektivní."
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-28",
+      "answer": "no",
+      "comment": "Jak je patrné, tak státy, které se vzdaly své národní měny, schudly a s nimi i jejich občané."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-29",
+      "answer": "yes",
+      "comment": "NATO neplní už dávno úlohu obranného paktu. A teď se to ukazuje znovu."
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-30",
+      "answer": "no",
+      "comment": "Místo ČR je  v srdci Evropy. Určitě ne v \"jádru\" EU."
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-31",
+      "answer": "no",
+      "comment": "Ne, dokud nebude mít vyřešeny své domácí problémy."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-32",
+      "answer": "yes",
+      "comment": "Ano u zákonů o klimatu ano, ale jinak by měla brát ohled hlavně na své občany."
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-33",
+      "answer": "no",
+      "comment": "Naopak zpřísnit. Už kvůli bezpečnostní situaci v Evropě."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-34",
+      "answer": "no",
+      "comment": "Volný pohyb osob lze vyjednat s každým státem zvlášť. Navíc Německo teď zrovna mluví o zavedení hraničních kontrol s ČR. Fajn udělejme je také. Zvýšíme tím společně s Němci Maďary, Poláky bezpečnost Evropy v otázce nelegální migrace."
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-35",
+      "answer": "yes",
+      "comment": "Ano. Bojeschopná armáda je potřeba. Hlavně v této době, když nás vlastní vláda a ministryně odzbrojili!"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-36",
+      "answer": "no",
+      "comment": "Je to smutné, když někdo musí podstoupit umělé oplodnění, ale při přirozeném oplodnění ta šance ovlivnění pohlaví také není. A je to dobře! Nehrajme si na \"bohy\" jenom proto, že to umíme!"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-38",
+      "comment": "Nemám úplně jasno. Někdo může brát centralizaci specializací jako zhoršení dostupnosti zdravotní péče a někdo jako posun dopředu, jako možnost mít nejmodernější vybavení, zvýšení kapacit těchto pracovišť, akorát by se musel pacient přepravit třeba na větší vzdálenost. To záleží na tom, kdo jak to uchopí."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-40",
+      "answer": "yes",
+      "comment": "Tato kompetence by měla patřit jen a pouze polici. Dnes jsou systémy, které i bez finančních sankcí dokáží zajistit dodržení nejvyšší povolené rychlosti. Buď jde o bezpečné silnice, nebo o kšeft."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-41"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-42",
+      "comment": "Ukrajina ať si dělá svou politiku. Mě zajímají občané ČR."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-43",
+      "comment": "Jak už jsem psal o otázku výše. Je to jejich rozhodnutí, se všemi plusy i minusy z toho vyplývající. Nejsem kompetentní k tomu, abych dělal Ukrajinskou zahraniční politiku."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-44",
+      "answer": "yes",
+      "comment": "Ano.  Zastropovat jí, ale musíme především my, jako ČR. "
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-47",
+      "comment": "Proč na Krymu? A o čem?"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-48",
+      "answer": "yes",
+      "comment": "Ano, ale ta směrnice není jenom o tomto problému."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-49",
+      "answer": "no",
+      "comment": "V současné situaci a chvíli je to sebevražda."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-50",
+      "answer": "no",
+      "comment": "V současné situaci a chvíli je to sebevražda."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-51",
+      "answer": "yes",
+      "comment": "Stejně jako ČR uznalo Kosovo jako suverénní stát bez souhlasu Srbska. Situace je i okolnosti jsou stejné a pokud si chceme hrát na morálně a korektně se chovající společenství, tak se tak mělo dávno stát."
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-52",
+      "answer": "yes",
+      "comment": "Pokud nemáme jinou alternativu, tak ano. Stejně jako to dělají i naši \"spojenci\" z EU."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-53",
+      "comment": "Je to věc obou těchto suverénních států."
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-54",
+      "comment": "Dotace by neměly být vůbec, ale trh v Evropě je tak pokřivený, že odpověď ANO,NE je velice zavádějící."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-55",
+      "answer": "no",
+      "comment": "Pak budeme rozdávat ještě boty, kalhoty, košile...... Proboha proberte se! Nejsme ve válce a kdo to tvrdí, tak je válečný štváč a dezinformátor! Premiéra a vládu ČR nevyjímaje."
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-56",
+      "comment": "Od toho jsou obce, města. Ty musí vytvořit bytový fond a dát tomu nějaký řád. Včetně sociálního bydlení. Je možné a i dokonce žádoucí přizvat i soukromou sféru."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-57",
+      "answer": "no",
+      "comment": "Na Ukrajině ale nezáleží. Rozhodne se jinde a každý to ví."
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-4-c-729274",
+      "question_id": "senatni-2022-4-q-58",
+      "answer": "yes",
+      "comment": "Kde nic není, ani smrt nebere! Známé pořekadlo."
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/40.json
+++ b/data/kalkulacka/senatni-2022/40.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-40",
-  "name": "40",
-  "description": "40 - DESCRIPTION",
+  "name": "Kutná Hora",
+  "description": "Kutná Hora",
   "district_code": "40",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-40-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-40-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-40-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-40-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-40-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-40-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-40-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-40-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-40-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-40-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-40-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-40-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-40-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-40-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-40-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-40-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-40-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-40-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-40-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-40-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-40-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-40-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-40-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-40-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-40-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-40-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-40-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-40-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-40-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-40-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-40-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-40-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-40-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-40-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-40-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-40-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-40-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-40-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-40-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-40-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-40-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-40-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-40-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-40-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-40-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-40-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-40-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-40-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-40-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-40-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-40-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-40-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-40-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-40-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-40-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-40-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-40-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-40-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-40-candidate-392078",
+      "id": "senatni-2022-40-c-392078",
       "name": "Bohuslav Procházka",
-      "type": "party",
+      "type": "person",
       "description": "Bohuslav Procházka - DESCRIPTION",
       "contacts": {
         "web": [
@@ -496,7 +498,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-40-392078-party",
+          "id": "senatni-2022-40-c-392078-p",
           "name": "Bohuslav Procházka",
           "description": "Bohuslav Procházka - DESCRIPTION",
           "contacts": {
@@ -517,9 +519,9 @@
       ]
     },
     {
-      "id": "senatni-2022-40-candidate-500322",
+      "id": "senatni-2022-40-c-500322",
       "name": "Jaromír Strnad",
-      "type": "party",
+      "type": "person",
       "description": "Jaromír Strnad - DESCRIPTION",
       "contacts": {
         "web": [
@@ -532,7 +534,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-40-500322-party",
+          "id": "senatni-2022-40-c-500322-p",
           "name": "Jaromír Strnad",
           "description": "Jaromír Strnad - DESCRIPTION",
           "contacts": {
@@ -549,9 +551,9 @@
       ]
     },
     {
-      "id": "senatni-2022-40-candidate-914940",
+      "id": "senatni-2022-40-c-914940",
       "name": "Kateřina Daczická",
-      "type": "party",
+      "type": "person",
       "description": "Kateřina Daczická - DESCRIPTION",
       "contacts": {
         "web": [
@@ -566,7 +568,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-40-914940-party",
+          "id": "senatni-2022-40-c-914940-p",
           "name": "Kateřina Daczická",
           "description": "Kateřina Daczická - DESCRIPTION",
           "contacts": {
@@ -585,9 +587,9 @@
       ]
     },
     {
-      "id": "senatni-2022-40-candidate-602069",
+      "id": "senatni-2022-40-c-602069",
       "name": "Jiří Reichel",
-      "type": "party",
+      "type": "person",
       "description": "Jiří Reichel - DESCRIPTION",
       "contacts": {
         "web": [
@@ -600,7 +602,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-40-602069-party",
+          "id": "senatni-2022-40-c-602069-p",
           "name": "Jiří Reichel",
           "description": "Jiří Reichel - DESCRIPTION",
           "contacts": {
@@ -617,9 +619,9 @@
       ]
     },
     {
-      "id": "senatni-2022-40-candidate-815996",
+      "id": "senatni-2022-40-c-815996",
       "name": "Luděk Jeništa",
-      "type": "party",
+      "type": "person",
       "description": "Luděk Jeništa - DESCRIPTION",
       "contacts": {
         "web": [
@@ -632,7 +634,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-40-815996-party",
+          "id": "senatni-2022-40-c-815996-p",
           "name": "Luděk Jeništa",
           "description": "Luděk Jeništa - DESCRIPTION",
           "contacts": {
@@ -649,16 +651,16 @@
       ]
     },
     {
-      "id": "senatni-2022-40-candidate-516282",
+      "id": "senatni-2022-40-c-516282",
       "name": "Antonín Dušek",
-      "type": "party",
+      "type": "person",
       "description": "Antonín Dušek - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-40-516282-party",
+          "id": "senatni-2022-40-c-516282-p",
           "name": "Antonín Dušek",
           "description": "Antonín Dušek - DESCRIPTION",
           "contacts": {
@@ -669,9 +671,9 @@
       ]
     },
     {
-      "id": "senatni-2022-40-candidate-353870",
+      "id": "senatni-2022-40-c-353870",
       "name": "Jiří Strachota",
-      "type": "party",
+      "type": "person",
       "description": "Jiří Strachota - DESCRIPTION",
       "contacts": {
         "web": [
@@ -690,7 +692,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-40-353870-party",
+          "id": "senatni-2022-40-c-353870-p",
           "name": "Jiří Strachota",
           "description": "Jiří Strachota - DESCRIPTION",
           "contacts": {
@@ -713,5 +715,1476 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-1",
+      "answer": "no",
+      "comment": "Každá daň musí mít objektivně měřitelný základ a jedinou sazbu. Zda je něco bytem, zda je to dlouhodobě prázdné není objektivně měřitelné."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-2",
+      "answer": "no",
+      "comment": "Státní regulace jakékoliv ceny deformuje trh, který právě cenou zajišťuje rovnováhu mezi nabídkou a poptávkou. "
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-3",
+      "answer": "yes",
+      "comment": "Mám na mysli POUZE LIDOVÉ VETO. To znamená na základě petice s podpisy stanovené části voličů ve stanovené lhůtě hlasovat v referendu o zamítnutí určitého rozhodnutí Poslanecké sněmovny. Jednalo by se o jednoduchý další krok schvalování zákonů (Parlament, president, lid - pokud silně nesouhlasí se svými zvolenými poslanci.) "
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-4",
+      "answer": "no",
+      "comment": "Chápu v otázce \"infrastrukturu pro rychlovlaky\" jako tzv. vysokorychlostní tratě (VRT) umožňující rychlosti nad 200 km/h. Ministerstvo dopravy v Programu rozvoje rychlých železničních spojení v ČR z roku 2016 uvádí dva dostatečné důvody, proč je ekonomicky žádoucí variantou modernizace našich konvenčních tratí na rychlost do 200 km/h: „nižší finanční nároky“ a „rychlejší realizovatelnost jednotlivých projektů ve srovnání s novostavbami vysokorychlostních tratí s výrazně větším stavebním rozsahem“. Finanční nároky byly v roce 2016 uvedeny jako poloviční a od té doby se řada projektů modernizace už uskutečnila.\n\nVRT s dvojnásobnou rychlostí proti konvenční trati vyžaduje osminásobný elektrický příkon a čtyřnásobek energie pro stejnou vzdálenost. Navržené VRT (použitelné pouze pro osobní dopravu) v ČR mají vytvořit ostrov mezi Německem a Rakouskem, které budou navazovat smíšenou dopravou do 200 km/h až do Litoměřic z Německa a do Břeclavi z Rakouska. Rozkrojíme zemi neskutečným způsobem, protože se projektuje s parametry francouzského TGV s minimálním poloměrem oblouku 7 km. Proto navržená trasa dokonce krájí obce. Do 200 km/h stačí poloměr 2 km jako v Japonsku, Číně, Itálii, ČR pro naklápěcí vlaky a dá se využívat pro nákladní dopravu včetně vojenských transportů. Při \"úspěchu\" v plánované třicetileté lhůtě pro novostavbu Praha - Brno  můžeme vybudovat další exponát národního skansenu, ve kterém už máme nikdy nepoužité pevnosti Terezín a Josefov. Není znám žádný investor kromě státu, který už dluží za celý loňský rozpočet a kus předloňského. Podle evropského auditorského dvora pouze malá část vysokorychlostních tratí není ztrátová."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-5",
+      "answer": "no",
+      "comment": "Věk odchodu do důchodu má být naším svobodným rozhodnutím, protože není možné srovnávat schopnost pracovat do vysokého věku např. ve vědě, kde je práce vášnivým koníčkem, a při dobývání nerostů v hlubinném dole. Státní určení důchodového věku je klasický příklad \"hraní na pánaboha\"."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-6"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-7",
+      "comment": "To je snad svobodné rozhodnutí výrobců a spotřebitelů?"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-8",
+      "answer": "no",
+      "comment": "Tzv. progresivní zdanění tzv. příjmů (spíš se jedná o \"zisk\") v zákonu o daních z příjmů je další \"krásný\" příklad hraní na pánaboha: jaká nelineární závislost daně na jejím základů má platit? Nejsme spíš v zajetí výroku \"větší příjem má znamenat větší daň\"? To dokonale splňuje daň s jedinou sazbou. Podotýkám, že největší daní z příjmu v ČR tvoří tzv. sociální a zdravotní pojistné, které není pojistným, protože se mu nelze vyhnout. To platí úzká vrstva zaměstnanců a OSVČ. Vůbec neplatí příjemci z kapitálu (60% HDP) ani lidé s velkou či malou mzdou... Bylo by lepší odstranit tuto \"100% degresi\" místo alchymie progrese."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-10"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-11",
+      "answer": "no",
+      "comment": "Bohatě by stačila DPH (která se však přes hranice EU nevybírá)."
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-12",
+      "answer": "no",
+      "comment": "Za obsah zodpovídá autor."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-13",
+      "answer": "no",
+      "comment": "Souhlasím s Vašimi uvozovkami."
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-14",
+      "comment": "\"Se mělo\" asi znamená zákonnou úpravu. Ať si veřejnost platí podle své potřeby, už existuje velká zkušenost s vysíláním mnoha stanic a technologie dnes umožňují dříve nevídané možnosti volby obsahu i ceny za službu."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-15",
+      "answer": "no",
+      "comment": "Proč? Co je státu do nich? Máme trestní zákoník."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-16",
+      "answer": "no",
+      "comment": "Odlišná podmínka je, že spolu nemohou zplodit dítě."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-17",
+      "answer": "no",
+      "comment": "Konkurence je dobrá věc, jen náklady exekuce by měl nést věřitel, aby obezřetněji resp. poctivěji půjčoval."
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-18"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-19",
+      "answer": "no",
+      "comment": "Musí se jen umřít. (Zatím.)"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-20",
+      "answer": "no",
+      "comment": "Místo sociálních dávek má stát z VYROVNANÉHO ROZPOČTU každému občanovi poskytovat základní příjem zdaněný jedinou sazbou jako všechny ostatní příjmy. Tím státu odpadá problém motivace k práci i mezigenerační solidarity. Protože jedinou funkcí státního sociálního zabezpečení se stane administrace násobku základního příjmu pro občany s fyzickým nebo duševním postižením a náhradní péče o děti, které jsou pro rodiče především zdrojem příjmu, získáme ze správy sociálního zabezpečení ohromné množství kvalifikovaných lidí pro náš napjatý pracovní trh."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-21",
+      "answer": "no",
+      "comment": "Proč? Jak změřit rovnoměrnost?"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-22"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-23",
+      "answer": "no",
+      "comment": "Už myšlenka korespondenční volby je nepřijatelné riziko pro tajnost volby a  vyloučení podvodů. Važme si důvěry občanů ve stávající systém. Pokud je někdo líný zvednout zadek nebo si naplánovat své cestování tak, aby méně než jednou ročně mohl volit, tak o to zřejmě nestojí. Kromě toho je nevhodné, aby rozhodovali o našem státu lidé, kteří ho nefinancují a nenesou důsledky zvolení svých zástupců."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-24",
+      "answer": "no",
+      "comment": "Státem by neměly být podporovány žádné směry středoškolského a vysokoškolského vzdělání více než jiné, leda s výjimkou vojenských a policejních škol. V úvahu by mohly připadnout i právnické školy, pokud by tam poklesla příliš poptávka nebo (nepochopitelně) vzrostly náklady. "
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-27",
+      "comment": "Stačí se chovat jako suverénní stát. Institut vyloučení z Unie evropské právo nezná :) "
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-28",
+      "answer": "no",
+      "comment": "Vlastní měnová politika je podstatná pro suverenitu státu."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-29",
+      "answer": "no",
+      "comment": "Proč ano? S naší současnou obranyschopností? Nebo až budeme jedničky?"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-30",
+      "comment": "Nevím, co je jádro EU."
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-31",
+      "comment": "Co je rozvojová spolupráce?"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-32",
+      "answer": "no",
+      "comment": "Vztahy s jinými státy řeší mezinárodní smlouvy. Zákony ČR jsou pravidla hry na našem území."
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-33"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-34"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-35",
+      "answer": "yes",
+      "comment": "Neplnění smluvního závazku v NATO je velmi špatná věc. Pak nemůžeme očekávat plnění smluvních závazků ostatních. Důležité je, mít výdaje efektivní pro naši obranyschopnost."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-36",
+      "comment": "Nevznikne riziko módních deformací populace? Nevíme, jak dlouho přirozené oplodnění bude převažovat."
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-37",
+      "answer": "yes",
+      "comment": "Lépe bez předpony \"při-\". Zdravotní pojištění by mělo být bez uvozovek vedle nezbytné zdravotní péče zajištěné státem (z daní). Nezbytná péče je léčení při akutním ohrožení života nebo zdraví a ochrana společnosti před akutním ohrožením života a zdraví občanů infekcí."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-38",
+      "comment": "Proč?"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-40",
+      "answer": "no",
+      "comment": "Proč nevyužít stroj ke kontrole dodržování pravidel hry? (Děláme to i ve sportech.)"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-41",
+      "answer": "no",
+      "comment": "Jak by se ten zákaz vymáhal?"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-42",
+      "comment": "Ukrajina je suverenní stát a nemáme jí říkat, co by měla."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-43",
+      "comment": "Ukrajina je suverenní stát a nemáme jí říkat, co by měla."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-44",
+      "answer": "no",
+      "comment": "Cena je výsledek shody dvou stran. Já mohu zastropovat cenu místního zmrzlináře pouze tak, že si u něj nekoupím."
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-45"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-46",
+      "answer": "yes",
+      "comment": "Poneseme je všichni, proč ne Rusko?"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-47",
+      "comment": "O čem?"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-48",
+      "comment": "Násilí je trestné snad ve všech zemích EU. Už se ví, jak ho lépe potírat?"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-49",
+      "answer": "no",
+      "comment": "Rozhodně NE. Prý \"po 19 letech dekarbonizace se o ní nediskutuje\", jenže naše uhelné elektrárny teď vyrábějí trvale naplno, zhruba o 10% více než v roce 2010. Proto  nemohou vyrovnávat vyšší spotřebu výkonu ve dne a dělají to za ně drahé plynové elektrárny vždy ráno i večer. Nebo celý den, když jim počasí nepřeje. Máme štěstí, že zásoby našeho uhlí stačí na desítky let a jaderné palivo se dá nakoupit z několika zdrojů rovněž na desítky let."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-50",
+      "answer": "no",
+      "comment": "Ten pojem je výplod evropského náboženství."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-52",
+      "comment": "S agresorem bych se moc nebratříčkoval."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-54",
+      "comment": "Dotace znamenají vzít peníze těm, kdo si to nechají líbit, a dát je těm, kdo mají ostré lokty. Je to vřed na těle naší krásné země. Bohužel ho nemůžeme odstranit v zemědělství uprostřed dotujících sousedů. "
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-55",
+      "answer": "no",
+      "comment": "Kde by byla hranice, co nejsou povinny poskytovat? A co když neposkytnou? Není ta otázka vtip? "
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-57",
+      "comment": "Jde o volbu Ukrajiny, nemáme jí říkat, co má dělat. Ale nesmíme odmítnout sousedovi, u kterého hoří, svou hadici s vodou, když nás požádá. Zvlášť když požár může přeskočit k nám."
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-40-c-353870",
+      "question_id": "senatni-2022-40-q-58",
+      "comment": "Pokud ponese náklady exekuce věřitel, tak je pro stát nezajímavé něco (ne)zastavovat."
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-2",
+      "answer": "no",
+      "comment": "U bytů, vybudovaných díky dotaci, jsem pro regulaci ceny nájemného. "
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-9",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-54",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-40-c-500322",
+      "question_id": "senatni-2022-40-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-1",
+      "answer": "no",
+      "comment": "Bude se podvádět, vždy lze do bytu někoho nahlásit, těžká kontrola, může to ovlivňovat RUD"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-2",
+      "answer": "no",
+      "comment": "Pokud jich nebude zoufalý nedostatek"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-3",
+      "answer": "no",
+      "comment": "V naší společnosti nejsem zastáncem referend na vše, volíme si přece zástupce. Pouze v tak stěžejních otázkách, jako byl např. vstup do EU apod."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-5",
+      "answer": "no",
+      "comment": "Vypadá to ovšem, že s důchodovou reformou si tak nějak nikdo neví rady."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-6",
+      "answer": "yes",
+      "comment": "Kvalitní voda bude mít v budoucnu cenu zlata, proto zadržovat, využívat. Vím, je to těžké, každý souhlasí do chvíle, kdy se mluví o jeho lokalitě.  "
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-7",
+      "answer": "no",
+      "comment": "Ne, pokud budeme kvalitně třídit a budou technologie na jejich recyklaci a využití."
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-8",
+      "answer": "no",
+      "comment": "Kolik je 15% ze 40 tisíc a kolik je 15% ze 120 tisíc, nehledě na úlevy a příspěvky. Není už tohle trochu progrese?"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-9",
+      "comment": "Jaká je potřeba jednotlivce, co kontrola. Už to dnešní množství \"větší než malé\" je pofidérní."
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-10",
+      "answer": "yes",
+      "comment": "Je málo hanebnějších trestných činů...."
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-11"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-12",
+      "answer": "yes",
+      "comment": "Těžko lze hledat většího \"ovlivňovatele\" než jsou sociální sítě. Hlavně pro mládež."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-13",
+      "answer": "yes",
+      "comment": "Asi ano, ale po prověření, což bude . . . . "
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-15",
+      "answer": "yes",
+      "comment": "Zejména těch, které mají pod sebou cizince a dost je \"šidí\"!"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-16",
+      "answer": "yes",
+      "comment": "Ano, stejná práva, ale jiný pojem, institutu \"manželství\" bych ponechal historický statut MUŽ-ŽENA"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-19",
+      "comment": "Jaká je definice sociálního bytu? Třeba v Praze a v Zadní Lhotě? Jsou byty malé a velké, levné a drahé a také sociální a nesociální? Na které jsou příspěvky na bydlení?"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-20",
+      "answer": "no",
+      "comment": "Myslím, že Češi si v oblasti sociálních dávek umí poradit."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-21",
+      "comment": "Které státní instituce myslíte?"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-22",
+      "answer": "yes",
+      "comment": "Ano, ale jen v případě, že to zabrání \"kolonizaci\" naší kvalitní orné půdy."
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-23",
+      "answer": "yes",
+      "comment": "Jsme v 21. století...."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-25",
+      "answer": "yes",
+      "comment": "S výjimkou opravdu mimořádně talentovaných (až geniálních) dětí, jinak úroveň ZŠ upadá."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-26",
+      "answer": "yes",
+      "comment": "Inkluze ano, ale ne na úkor kvality výuky....Aby na škole nebylo 3x více asistentů než učitelů"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-27",
+      "answer": "no",
+      "comment": "Jak tohle může někoho vůbec napadnout?"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-28",
+      "answer": "yes",
+      "comment": "Ne hned, ale v určitém horizontu ano, do roku 2030 určitě, jen chybí politická odvaha"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-29",
+      "answer": "no",
+      "comment": "Tak to je stejně hloupá otázka jako u EU."
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-30",
+      "answer": "yes",
+      "comment": "Jsme v srdci Evropy, nikoli někde na kraji."
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-31",
+      "comment": "Myslím, že v této oblasti nejsme špatní."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-32"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-33",
+      "answer": "no",
+      "comment": "Je třeba reagovat na události, které vedou k migraci."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-34",
+      "answer": "yes",
+      "comment": "Jednoznačně."
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-35",
+      "comment": "Nesdílel jsem tento názor, ale v zrcadle posledních událostí ho přehodnocuji."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-36",
+      "answer": "no",
+      "comment": "A za chvíli ještě IQ, ne?"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-37"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-38",
+      "answer": "no",
+      "comment": "Možná pouze některé obory, ale za účelem zkvalitňování péče."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-39",
+      "comment": "Asi v míře velké než menší ano. "
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-40",
+      "answer": "no",
+      "comment": "Zastavit nikoli, ale používat jako prevenci, nikoli k výběru financí."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-41",
+      "comment": "Asi jak kde."
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-42",
+      "comment": "V tuto chvíli určitě ne, v budoucnu - pokud budou podmínky."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-43",
+      "comment": "Alespoň ne v této době. Těžko předpovídat, co bude v blízké budoucnosti...Nejdříve je třeba nastolit MÍR"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-44",
+      "comment": "Protože nevím, zda to vůbec lze, je to spíše přání než možnost, kohouty se zavřou..."
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-45",
+      "answer": "no",
+      "comment": "Člověk s jeho názory by tam být neměl."
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-46",
+      "answer": "yes",
+      "comment": "Nic není jen černé a bílé. Ale těžko může něco ospravedlnit napadení sousední země a  rozpoutání války."
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-47",
+      "comment": "Jsme EU, o čem bychom my sami vyjednávali?"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-49",
+      "comment": "Záleží na ekonomické a energetické situaci."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-50",
+      "answer": "yes",
+      "comment": "Ano, ale jen Evropa nestačí, je třeba celosvětový přístup, jsme malá planeta."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-52",
+      "answer": "no",
+      "comment": "Koneckonců, kdo by s námi v úrovni vztahů, které s Ruskem máme, vyjednával? Nemáme tu Orbána."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-54",
+      "answer": "yes",
+      "comment": "Nejlépe správně odstupňovat, což se jeví jako velmi těžký úkol. Také jde o konkurenceschopnost, a to i velkých firem."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-57",
+      "answer": "no",
+      "comment": "Ukončit konflikt ano, vzdát se území nikoli."
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-40-c-815996",
+      "question_id": "senatni-2022-40-q-58",
+      "answer": "yes",
+      "comment": "Pokud jde o situace \"vezmi chlup na dlani\", tak ano."
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-1",
+      "answer": "no",
+      "comment": "Byty mohou být prázdné z řady důvodů a plošné vyšší zdanění by mohlo být pro vlastníka likvidační."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-2",
+      "comment": "Obce by měly vlastnit byty s regulovaným nájemným. Soukromý vlastník potom bude muset své ceny hlídat. Celkově neregulované nájemné je v současných podmínkách cesta pod most."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-3",
+      "answer": "yes",
+      "comment": "Referendum i petice ovšem musí mít své mantinely, aby se pak nehlasovalo za housky zdarma."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-4",
+      "answer": "no",
+      "comment": "Především je zapotřebí dobře zprovoznit stávající infrastrukturu. Naše silnice a tratě jsou samá výluka, objížďka a semafory řízený provoz. Kdo musí cestovat, ví, o čem mluvím."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-5",
+      "answer": "no",
+      "comment": "Průměrný věk dožití se sice zvyšuje, ale únava, zejména psychická, nastupuje ve stejné době jako v minulosti."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-6",
+      "answer": "no",
+      "comment": "Toto je technická otázka pro vodohospodáře a ekology. Jsem toho názoru, že soustava přehrad v České republice je velmi nadstandardní, zejména pak Vltavská kaskáda."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-7",
+      "answer": "no",
+      "comment": "Běžný spotřebitel by měl další peníze vázané v obalech. Delší čekací doby v obchodech. Věřím lidem, že sami dobře třídí odpad."
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-8",
+      "answer": "yes",
+      "comment": "Státní dluh vesele roste, tím pádem stoupají i úroky a dostáváme se do dluhové spirály. Získávat peníze z nízkopříjmových skupin lze jen za cenu jejich bídy."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-9",
+      "comment": "Pokud ano, zajistit kontrolu, aby vše bylo pro vlastní potřebu. Pokud ne, zajistit, aby bylo v lékárenském sortimentu."
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-10",
+      "answer": "yes",
+      "comment": "Důležité je přesně specifikovat, co je znásilnění, aby zákon nemohl být zneužit. Potom bych byl pro zvýšení spodní hranice."
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-11",
+      "answer": "no",
+      "comment": "Pokud by tyto firmy platily speciální daň, došlo by ke zpoplatnění služeb a projevilo by se to na peněžence občanů. Ztratili bychom kousek svobody."
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-12",
+      "comment": "Sociální sítě částečně jsou zodpovědné za obsah, který zpřístupňují. Pokud na ně budou tlačit další zákony, budou uživatelé velmi omezeni ve svých projevech. Automat vše nevyhodnotí a lidi je třeba zaplatit."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-13",
+      "answer": "no",
+      "comment": "Kdo určí, co je falešná zpráva? A na šíření pomluv a poplašných zpráv zákon už pamatuje."
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-14",
+      "answer": "yes",
+      "comment": "Pokud by bylo opravdu nestranné a skutečně veřejnoprávní a objektivní, nikým neplacené, pak si dotace zaslouží."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-15",
+      "answer": "no",
+      "comment": "Sice je názor, že pracovní agentury \"parazitují\" na trhu práce, ovšem řadě lidí práci zajistí. "
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-16",
+      "answer": "no",
+      "comment": "Pro stejnopohlavní páry chci naprosto stejná práva ve všech detailech jako pro manžele. Manželství to však být nemůže, neboť tento výraz přímo označuje muže a ženu. Mal-žen znamená muž - žena. Slovo manželství vzniklo přesmyčkou. Proto je třeba hledat nový název."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-17"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-19",
+      "answer": "yes",
+      "comment": "Budoucnost a ceny na trhu ukazují, že sociální byty budou stále důležitější."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-20",
+      "answer": "yes",
+      "comment": "Stát má především tvořit takové podmínky, aby lidé sociální dávky nepotřebovali."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-21",
+      "answer": "no",
+      "comment": "Univerzální pravidlo bych neuvítal, jsou instituce, jejichž rozmístění není reálné. Navíc by to značně zvýšilo náklady. Řešením je spolupráce mezi obecními a státními institucemi. Občan nemusí tolik cestovat ani platit na daních."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-23",
+      "answer": "no",
+      "comment": "I při osobní účasti je velký počet stížností. Navíc nízkopříjmové skupiny a starší lidé by tímto byli znevýhodněni."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-24",
+      "answer": "no",
+      "comment": "Máme i jiné velmi důležité obory, jako například zdravotnictví, zemědělství a další."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-25",
+      "answer": "no",
+      "comment": "Pokud je touto otázkou myšlena naše slavná inkluze, pak nesouhlasím. Každá skupina dětí potřebuje jinou péči a možnosti rozvoje. Vzdělávat všechny podle jejich možností. Třída se většinou řídí podle schopností žáka v čele poslední třetiny."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-26",
+      "comment": "Vzdělávací systém má co nejvíce pomáhat VŠEM žákům. "
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-27",
+      "comment": "ČR by měla vyhlásit referendum o setrvání v Evropské unii. EU potřebuje změnu, jinak se rozpadne sama."
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-28",
+      "answer": "no",
+      "comment": "Zatím pro tento krok nejsou vhodné podmínky."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-29",
+      "comment": "V Evropě je válečný stav a proto není vhodné konat zásadní kroky."
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-30",
+      "answer": "no",
+      "comment": "Místo ČR je v jádru Evropy."
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-31",
+      "answer": "yes",
+      "comment": "Ano, pokud napřed bude mít dostatek prostředků na své potřebné."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-33",
+      "answer": "no",
+      "comment": "Azyl je závažný krok i z hlediska bezpečnosti země. Proto v našem zájmu nemůže být zcela snadný."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-34",
+      "answer": "yes",
+      "comment": "Pokud zůstaneme v EU, pak ano."
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-35",
+      "answer": "no",
+      "comment": "ČR by měla vést politiku tak, aby naše armáda zářila především při přehlídkách a přírodních pohromách."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-36"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-37",
+      "comment": "Tato možnost je, zpravidla ji obsahuje životní pojištění."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-38",
+      "answer": "no",
+      "comment": "Technické prostředky poskytují široké možnosti i v regionálních podmínkách."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-39",
+      "comment": "Zatím se stále zkoumají jeho účinky. "
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-40",
+      "answer": "no",
+      "comment": "S kontrolou rychlosti musí být spjato i rozumné nastavení omezení. Třicítka po dobu půl roku na rovném úseku svádí k porušení. I toto by se mělo kontrolovat."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-42",
+      "comment": "Pokud splní všechny podmínky jako ostatní země, může vstoupit jako ostatní země."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-43",
+      "answer": "no",
+      "comment": "Nyní pro to není vhodný čas. Do vojenských bloků mohou rozumně přijímat nové členy pouze v době míru. Potom, po splnění všech podmínek, je cesta otevřena."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-44",
+      "answer": "yes",
+      "comment": "Ano, ale věc má dvě strany. EU může zastropovat ceny pouze dotacemi do vlastního trhu. Nákup se řídí dvoustrannými dohodami."
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-45"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-46",
+      "comment": "Podporuji co nejrychlejší ukončení konfliktu, aby přestali umírat lidé a přestala se ničit zem."
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-47",
+      "answer": "no",
+      "comment": "V současné době by to pouze zvýšilo napětí v celé oblasti. Je zapotřebí mír."
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-48",
+      "answer": "yes",
+      "comment": "Opět je zapotřebí velmi přesná specifikace, aby nedocházelo ke zneužití směrnice."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-49",
+      "answer": "no",
+      "comment": "Zatím není náhrada"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-50",
+      "comment": "Podporuji ekologii v rozumné míře. Kde lze znečišťující prvek nahradit, ať se nahradí. Plán, co vše uděláme do roku 2050, stojí tak trochu na vodě."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-51"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-52",
+      "comment": "Dokud patříme do EU, je to velmi obtížné."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-53"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-55"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-57",
+      "comment": "Na takto postavenou otázku se těžko odpovídá"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-40-c-602069",
+      "question_id": "senatni-2022-40-q-58",
+      "answer": "no"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/43.json
+++ b/data/kalkulacka/senatni-2022/43.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-43",
-  "name": "43",
-  "description": "43 - DESCRIPTION",
+  "name": "Pardubice",
+  "description": "Pardubice",
   "district_code": "43",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-43-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-43-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-43-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-43-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-43-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-43-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-43-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-43-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-43-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-43-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-43-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-43-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-43-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-43-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-43-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-43-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-43-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-43-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-43-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-43-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-43-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-43-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-43-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-43-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-43-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-43-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-43-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-43-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-43-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-43-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-43-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-43-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-43-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-43-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-43-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-43-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-43-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-43-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-43-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-43-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-43-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-43-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-43-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-43-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-43-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-43-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-43-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-43-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-43-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-43-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-43-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-43-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-43-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-43-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-43-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-43-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-43-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-43-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,16 +479,16 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-43-candidate-191288",
+      "id": "senatni-2022-43-c-191288",
       "name": "Milan Bušek",
-      "type": "party",
+      "type": "person",
       "description": "Milan Bušek - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-43-191288-party",
+          "id": "senatni-2022-43-c-191288-p",
           "name": "Milan Bušek",
           "description": "Milan Bušek - DESCRIPTION",
           "contacts": {
@@ -497,9 +499,9 @@
       ]
     },
     {
-      "id": "senatni-2022-43-candidate-143881",
+      "id": "senatni-2022-43-c-143881",
       "name": "Martin Charvát",
-      "type": "party",
+      "type": "person",
       "description": "Martin Charvát - DESCRIPTION",
       "contacts": {
         "web": [
@@ -516,7 +518,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-43-143881-party",
+          "id": "senatni-2022-43-c-143881-p",
           "name": "Martin Charvát",
           "description": "Martin Charvát - DESCRIPTION",
           "contacts": {
@@ -537,16 +539,16 @@
       ]
     },
     {
-      "id": "senatni-2022-43-candidate-849519",
+      "id": "senatni-2022-43-c-849519",
       "name": "Jaromír Nosek",
-      "type": "party",
+      "type": "person",
       "description": "Jaromír Nosek - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-43-849519-party",
+          "id": "senatni-2022-43-c-849519-p",
           "name": "Jaromír Nosek",
           "description": "Jaromír Nosek - DESCRIPTION",
           "contacts": {
@@ -557,9 +559,9 @@
       ]
     },
     {
-      "id": "senatni-2022-43-candidate-742106",
+      "id": "senatni-2022-43-c-742106",
       "name": "Miluše Horská",
-      "type": "party",
+      "type": "person",
       "description": "Miluše Horská - DESCRIPTION",
       "contacts": {
         "web": [
@@ -581,7 +583,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-43-742106-party",
+          "id": "senatni-2022-43-c-742106-p",
           "name": "Miluše Horská",
           "description": "Miluše Horská - DESCRIPTION",
           "contacts": {
@@ -607,9 +609,9 @@
       ]
     },
     {
-      "id": "senatni-2022-43-candidate-191858",
+      "id": "senatni-2022-43-c-191858",
       "name": "Vladimír Ninger",
-      "type": "party",
+      "type": "person",
       "description": "Vladimír Ninger - DESCRIPTION",
       "contacts": {
         "web": [
@@ -626,7 +628,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-43-191858-party",
+          "id": "senatni-2022-43-c-191858-p",
           "name": "Vladimír Ninger",
           "description": "Vladimír Ninger - DESCRIPTION",
           "contacts": {
@@ -647,16 +649,16 @@
       ]
     },
     {
-      "id": "senatni-2022-43-candidate-650117",
+      "id": "senatni-2022-43-c-650117",
       "name": "Svatopluk Pleva",
-      "type": "party",
+      "type": "person",
       "description": "Svatopluk Pleva - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-43-650117-party",
+          "id": "senatni-2022-43-c-650117-p",
           "name": "Svatopluk Pleva",
           "description": "Svatopluk Pleva - DESCRIPTION",
           "contacts": {

--- a/data/kalkulacka/senatni-2022/46.json
+++ b/data/kalkulacka/senatni-2022/46.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-46",
-  "name": "46",
-  "description": "46 - DESCRIPTION",
+  "name": "Ústí nad Orlicí",
+  "description": "Ústí nad Orlicí",
   "district_code": "46",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-46-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-46-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-46-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-46-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-46-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-46-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-46-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-46-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-46-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-46-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-46-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-46-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-46-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-46-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-46-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-46-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-46-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-46-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-46-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-46-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-46-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-46-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-46-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-46-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-46-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-46-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-46-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-46-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-46-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-46-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-46-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-46-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-46-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-46-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-46-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-46-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-46-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-46-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-46-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-46-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-46-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-46-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-46-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-46-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-46-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-46-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-46-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-46-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-46-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-46-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-46-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-46-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-46-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-46-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-46-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-46-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-46-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-46-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-46-candidate-367047",
+      "id": "senatni-2022-46-c-367047",
       "name": "Petr Fiala",
-      "type": "party",
+      "type": "person",
       "description": "Petr Fiala - DESCRIPTION",
       "contacts": {
         "web": [
@@ -497,7 +499,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-46-367047-party",
+          "id": "senatni-2022-46-c-367047-p",
           "name": "Petr Fiala",
           "description": "Petr Fiala - DESCRIPTION",
           "contacts": {
@@ -519,16 +521,16 @@
       ]
     },
     {
-      "id": "senatni-2022-46-candidate-835047",
+      "id": "senatni-2022-46-c-835047",
       "name": "Josef Kopecký",
-      "type": "party",
+      "type": "person",
       "description": "Josef Kopecký - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-46-835047-party",
+          "id": "senatni-2022-46-c-835047-p",
           "name": "Josef Kopecký",
           "description": "Josef Kopecký - DESCRIPTION",
           "contacts": {
@@ -539,16 +541,16 @@
       ]
     },
     {
-      "id": "senatni-2022-46-candidate-490291",
+      "id": "senatni-2022-46-c-490291",
       "name": "Stanislav Ešner",
-      "type": "party",
+      "type": "person",
       "description": "Stanislav Ešner - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-46-490291-party",
+          "id": "senatni-2022-46-c-490291-p",
           "name": "Stanislav Ešner",
           "description": "Stanislav Ešner - DESCRIPTION",
           "contacts": {
@@ -559,5 +561,351 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-2",
+      "answer": "yes",
+      "comment": "nájemné by mělo být odpovídající lokalitě a zohledňovat amortizaci"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-4",
+      "answer": "no",
+      "comment": "Je potřeba dostavět silnice"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-10"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-16",
+      "comment": "Měly by mít uzákoněny stejná práva (i povinnosti), název svazku dle mne není až tak zásadní."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-28",
+      "answer": "yes",
+      "comment": "do 5 let"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-31"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-33"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-37"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-45"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-54",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-46-c-367047",
+      "question_id": "senatni-2022-46-q-58",
+      "answer": "yes"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/49.json
+++ b/data/kalkulacka/senatni-2022/49.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-49",
-  "name": "49",
-  "description": "49 - DESCRIPTION",
+  "name": "Blansko",
+  "description": "Blansko",
   "district_code": "49",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-49-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-49-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-49-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-49-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-49-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-49-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-49-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-49-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-49-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-49-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-49-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-49-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-49-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-49-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-49-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-49-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-49-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-49-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-49-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-49-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-49-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-49-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-49-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-49-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-49-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-49-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-49-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-49-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-49-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-49-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-49-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-49-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-49-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-49-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-49-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-49-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-49-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-49-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-49-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-49-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-49-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-49-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-49-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-49-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-49-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-49-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-49-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-49-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-49-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-49-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-49-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-49-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-49-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-49-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-49-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-49-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-49-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-49-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,16 +479,16 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-49-candidate-631671",
+      "id": "senatni-2022-49-c-631671",
       "name": "Jiří Rokos",
-      "type": "party",
+      "type": "person",
       "description": "Jiří Rokos - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-49-631671-party",
+          "id": "senatni-2022-49-c-631671-p",
           "name": "Jiří Rokos",
           "description": "Jiří Rokos - DESCRIPTION",
           "contacts": {
@@ -497,9 +499,9 @@
       ]
     },
     {
-      "id": "senatni-2022-49-candidate-770071",
+      "id": "senatni-2022-49-c-770071",
       "name": "Antonín Žirovnický",
-      "type": "party",
+      "type": "person",
       "description": "Antonín Žirovnický - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -507,7 +509,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-49-770071-party",
+          "id": "senatni-2022-49-c-770071-p",
           "name": "Antonín Žirovnický",
           "description": "Antonín Žirovnický - DESCRIPTION",
           "contacts": {
@@ -519,16 +521,16 @@
       ]
     },
     {
-      "id": "senatni-2022-49-candidate-523550",
+      "id": "senatni-2022-49-c-523550",
       "name": "Martin Sklář",
-      "type": "party",
+      "type": "person",
       "description": "Martin Sklář - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-49-523550-party",
+          "id": "senatni-2022-49-c-523550-p",
           "name": "Martin Sklář",
           "description": "Martin Sklář - DESCRIPTION",
           "contacts": {
@@ -539,9 +541,9 @@
       ]
     },
     {
-      "id": "senatni-2022-49-candidate-229934",
+      "id": "senatni-2022-49-c-229934",
       "name": "Filip Vítek",
-      "type": "party",
+      "type": "person",
       "description": "Filip Vítek - DESCRIPTION",
       "contacts": {
         "web": [
@@ -555,7 +557,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-49-229934-party",
+          "id": "senatni-2022-49-c-229934-p",
           "name": "Filip Vítek",
           "description": "Filip Vítek - DESCRIPTION",
           "contacts": {
@@ -573,9 +575,9 @@
       ]
     },
     {
-      "id": "senatni-2022-49-candidate-439462",
+      "id": "senatni-2022-49-c-439462",
       "name": "Drago Sukalovský",
-      "type": "party",
+      "type": "person",
       "description": "Drago Sukalovský - DESCRIPTION",
       "contacts": {
         "web": [
@@ -587,7 +589,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-49-439462-party",
+          "id": "senatni-2022-49-c-439462-p",
           "name": "Drago Sukalovský",
           "description": "Drago Sukalovský - DESCRIPTION",
           "contacts": {
@@ -603,9 +605,9 @@
       ]
     },
     {
-      "id": "senatni-2022-49-candidate-744028",
+      "id": "senatni-2022-49-c-744028",
       "name": "Jaromíra Vítková",
-      "type": "party",
+      "type": "person",
       "description": "Jaromíra Vítková - DESCRIPTION",
       "contacts": {
         "web": [
@@ -626,7 +628,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-49-744028-party",
+          "id": "senatni-2022-49-c-744028-p",
           "name": "Jaromíra Vítková",
           "description": "Jaromíra Vítková - DESCRIPTION",
           "contacts": {
@@ -651,9 +653,9 @@
       ]
     },
     {
-      "id": "senatni-2022-49-candidate-882688",
+      "id": "senatni-2022-49-c-882688",
       "name": "Zdeněk Wetter",
-      "type": "party",
+      "type": "person",
       "description": "Zdeněk Wetter - DESCRIPTION",
       "contacts": {
         "web": [
@@ -666,7 +668,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-49-882688-party",
+          "id": "senatni-2022-49-c-882688-p",
           "name": "Zdeněk Wetter",
           "description": "Zdeněk Wetter - DESCRIPTION",
           "contacts": {
@@ -683,5 +685,1055 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-1",
+      "answer": "yes",
+      "comment": "Vyšším zdaněním bych donutil majitele bytu, aby ho pronajal."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-2",
+      "answer": "yes",
+      "comment": "Ceny nájemného by se měly regulovat u obecních a družstevních bytů, aby na bydlení za únosnou sumu měly hlavně mladé rodiny s dětmi."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-3",
+      "answer": "yes",
+      "comment": "Petici k možnosti celostátního referenda by mělo podepsat nejméně 50 tisíc lidí, což je stejný počet jako u nezávislého kandidáta na prezidenta ČR."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-4",
+      "answer": "yes",
+      "comment": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury, protože za posledních 50 let se do železniční infrastruktury obecně investoval mnohem menší objem financí než do výstavby silnic a dalších komunikací. Doprava rychlovlaky přitom patří k nejlepším způsobům dopravy v Evropě i ve světě."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-5",
+      "answer": "no",
+      "comment": "Důchodový věk by se už neměl dál zvyšovat, protože poctivě pracující a podnikající lidé si zaslouží jít v 65 letech do zaslouženého odpočinku a stát (potažmo vláda) by měl už konečně najít vyvážený a rozumný systém penzijního připojištění, v němž by měli být zvýhodněni odpovědní občané, kteří si poctivě šetří na přilepšení k penzi."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-6",
+      "answer": "yes",
+      "comment": "Více nových přehrad znamená víc zadržené vody v krajině, která pomalu ale jistě vysychá a trpí nedostatkem vody a následky změny klimatu. Z nádrží se pak dá voda v případě potřeby upouštět do koryt řek a potoků. A další předností přehrady je její případné rekreační využití všude tam, kde to ráz krajiny dovoluje. Kolem přehrad se pak často dají sázet stromy, které v létě poskytnou stín a dokáží zadržet a využít vodu v krajině."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-7",
+      "answer": "yes",
+      "comment": "PET lahve a nápojové plechovky by měly být zálohované, protože by se tak lidé naučili lépe třídit a nakládat s odpady, které pak lze znovu využít k recyklaci. Například v Norsku to funguje perfektně. "
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-8",
+      "answer": "yes",
+      "comment": "Vyšší daně pro lidi s vysokými příjmy jsou důležité už jen proto, že by měl ve společnosti fungovat princip solidárnosti. Například špičkově placení manažeři nebo bohatí podnikatelé by tak (ne)přímo přispívali třeba samoživitelkám s dětmi nebo důchodcům s nízkými penzemi."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-9"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-10",
+      "answer": "yes",
+      "comment": "Tresty za znásilnění by se měly určitě zvýšit, protože znásilněné ženy a dívky často utrpí doživotní psychické trauma a v některých brutálních případech i fyzické následky."
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-11",
+      "answer": "yes",
+      "comment": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR, protože jde o globální světové společnosti s vysokými zisky. A jejich vyšší zdanění by navíc oživilo konkurenci."
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-12"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-14",
+      "answer": "no",
+      "comment": "Na veřejnoprávní vysílání by se nemělo dávat méně peněz, protože například Česká televize má už několik let omezené příjmy z reklamy. Jiná věc je objektivita a vyváženost zpravodajství ve veřejnoprávním vysílání, která v poslední době často pokulhává."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-15"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-16",
+      "answer": "yes",
+      "comment": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry, ale gayové a lesbičky by neměli mít možnost vychovávat adoptované děti."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-18",
+      "answer": "yes",
+      "comment": "Zavedení pravidla 1 dlužník - 1 exekutor by odstranilo roztříštěnost při vymáhání dluhů."
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-19",
+      "answer": "yes",
+      "comment": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty, protože by se tak ke slušnému bydlení dostali lidé s nižšími příjmy a matky samoživitelky."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-20",
+      "comment": "K této otázce bych podotkl, že každý svéprávný, odpovědný a normálně uvažující člověk v nouzi, který má nárok na sociální dávky, si dokáže dojít na úřad, kde lze o dávky požádat."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-21"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-22",
+      "answer": "no",
+      "comment": "Myslím si, že společnost v ČR teď má vzhledem k energetické krizi, vysoké inflaci a válce na Ukrajině úplně jiné starosti než kolonizaci Marsu... :-)"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-23",
+      "answer": "yes",
+      "comment": "Volby online by jednak ušetřily cestu do volebních místností především všem nemocným a starým lidem, ke kterým jinak musí jezdit volební komise s urnou, a jednak by se tak ušetřila spousta peněz, které je nutné vynaložit na odměny členů volebních komisí, kterých by při dobře zabezpečené online volbě rapidně ubylo."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-24",
+      "answer": "yes",
+      "comment": "Podle mého názoru by se měly podporovat technické obory především na středních školách, protože v posledních desetiletích rapidně ubývá počet řemeslníků a technických profesí."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-25",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-26",
+      "answer": "yes",
+      "comment": "Vzdělávací systém by měl být spravedlivý a slabší nebo hendikepovaní žáci by měli mít možnost být ve společnosti svých vrstevníků, kteří je spolu s učiteli můžou táhnout k lepším výsledkům a následné integraci do společnosti."
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-27"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-28"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-29",
+      "answer": "no",
+      "comment": "ČR by neměla vystupovat z NATO, protože má malou profesionální armádu a členství v silném vojenském paktu zaručuje lepší obranyschopnost. Jinou otázkou je, proč se ČR nestala hned po roce 1989 neutrální zemí."
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-30"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-31",
+      "comment": "Větší humanitární pomoc ano, ale vyšší zahraniční rozvojová spolupráce je v současné ekonomické krizi otázkou. Současná vláda Petra Fialy by se měla lépe postarat o vlastní občany a lépe řešit jejich současné problémy a potřeby."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-32"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-33",
+      "answer": "no",
+      "comment": "Udělení azylu v ČR by se nemělo usnadnit, protože současná vláda už tak dost pomohla uprchlíkům z Ruskem napadené Ukrajiny a snazší získání azylu by mohlo vést k opětovné neúnosné migrační vlně obyvatel Asie či Afriky."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-35",
+      "answer": "yes",
+      "comment": "ČR by měla dávat více peněz na armádu, protože by se tak zvýšila obranyschopnost země a snížila by se tak i nezaměstnanost a potažmo i inflace."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-36",
+      "answer": "no",
+      "comment": "Hrátky s genetikou jsou etickou cestou do pekel."
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-37",
+      "answer": "yes",
+      "comment": "Lidé s vyššími příjmy by si tak zaplatili lepší zdravotní péči a přispěli by jednak na větší platy zdravotníků, jednak na zdravotní péči obecně."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-38",
+      "answer": "no",
+      "comment": "Specializovaná lékařská péče v ČR by měla být stejně dostupná ve všech krajích, aby za ní lidé nemuseli často složitě dojíždět."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-40",
+      "answer": "no",
+      "comment": "Radary slouží k vyšší bezpečnosti provozu na silnicích zvláště v obcích a na nebezpečných úsecích. A kdo jezdí neurvale a nedodržuje zákony a vyhlášky, ať platí. Hazardéři za volantem totiž často způsobují nehody s fatálními následky."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-41",
+      "comment": "Velmi těžká otázka, související s ochranou osobních údajů. Tyto chytré systémy by se měly využívat jen pro potřeby policie a obecně bezpečnosti."
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-42",
+      "answer": "yes",
+      "comment": "EU by totiž mohla Ukrajině jako členské zemi pomoci jak ekonomicky, tak politicky. "
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-43",
+      "answer": "yes",
+      "comment": "Zvýšila by se tak její obranyschopnost a možnost vojenské pomoci ze strany dalších členských zemí NATO. Otázkou však je, jak by na to zareagoval ruský prezident Putin, protože při jeho nevyzpytatelnosti by členství Ukrajiny v NATO mohlo vést i k rozpoutání 3. světové války."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-45"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-47",
+      "answer": "yes",
+      "comment": "Souhlasím s účastí českých zákonodárců při vyjednávání s Rusy na Krymu, protože každé diplomatické řešení válečného konfliktu je pořád lepší než umírání nevinných lidí."
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-48",
+      "answer": "yes",
+      "comment": "Násilí vůči ženám (a dětem) a domácí násilí je nepřípustné, protože často přispívá k rozvratu rodin."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-49",
+      "comment": "Vzhledem k energetické krizi je ukončení spalování uhlí velmi diskutabilní."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-50"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-51",
+      "comment": "I tato otázka je velmi diskutabilní vzhledem k historickým souvislostem, kdy Krym byl už za cara Petra Velikého součástí Ruska a až sovětští komunisté v čele s Chruščovem ho administrativně připojili k Ukrajině."
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-52",
+      "answer": "yes",
+      "comment": "Když může o nákupech plynu a ropy jednat s Ruskem Maďarsko a další země, tak proč ne ČR?"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-53",
+      "answer": "yes",
+      "comment": "NATO získá do svých řad důležité severské státy a Finsko tak zabrání další potenciální válce s Ruskem, se kterou má smutno historickou zkušenost ze 40.let 20.století."
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-54",
+      "answer": "yes",
+      "comment": "Na malých farmách totiž často hospodaří drobní zemědělci (živnostníci), kteří se na rozdíl od velkých koncernů typu Agrofert chovají ekologicky a udržitelně."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-55",
+      "comment": "Myslím, že úřady a státní instituce by v současnosti měly řešit mnohem důležitější věci než jsou vložky a tampony."
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-56",
+      "comment": "Spíš než státní bytový fond by měly při výstavbě soukromých developerů vznikat sociální byty - viz moje odpověď na jednu z předchozích otázek, která se tohoto tématu týkala."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-57",
+      "answer": "no",
+      "comment": "Žádnému agresorovi se nesmí ustupovat, a už vůbec ne Rusku, jehož prezident Putin se chová jako car a Hitler. Po Ukrajině by totiž bylo na řadě Slovensko, Polsko a Česká republika..."
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-49-c-523550",
+      "question_id": "senatni-2022-49-q-58",
+      "answer": "yes",
+      "comment": "Na tuhle otázku odpovím příslovím \"Kde nic není, ani smrt nebere!\""
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-3"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-4",
+      "answer": "no",
+      "comment": "Důležitá je železniční i silniční infrastruktura. Nelze upřednostňovat jednu před druhou."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-9",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-13",
+      "answer": "no",
+      "comment": "Co je fake news? Kdo o tom rozhodne? Tedy nemazat, nejvýše opatřit upozorněním na kontroverzní obsah."
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-15"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-16"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-19",
+      "comment": "Vždy záleží na místních podmínkách a konkrétních projektech."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-21"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-22",
+      "comment": "Tahle otázka je test pozornosti? :-)"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-31"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-39",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-40",
+      "comment": "Tyto systémy by měly být užívány tam, kde mají opodstatnění dané snižování rizik pro ostatní účastníky silničního provozu."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-42",
+      "answer": "no",
+      "comment": "Za současného stavu (míněn i stav do ruské agrese) nikoliv, v budoucnu pokud možno ano. "
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-43",
+      "answer": "no",
+      "comment": "Za současného stavu (míněn i stav do ruské agrese) nikoliv, v budoucnu podle konkrétní geopolitické situace. "
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-44"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-48"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-52"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-54",
+      "comment": "Nejlépe bez dotací, což, bohužel, nelze. Dotace jsou nutné pro farmy všech velikostí, měly by být diferencované."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-56",
+      "answer": "no",
+      "comment": "Bytová politika má být věcí obce, stát má k obecní bytové politice vytvořit vhodné legislativní a finanční podmínky"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-49-c-439462",
+      "question_id": "senatni-2022-49-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-2"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-4"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-9"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-15"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-18"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-21"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-22"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-23"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-28"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-33"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-38"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-41"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-50"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-54"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-55"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-49-c-744028",
+      "question_id": "senatni-2022-49-q-58",
+      "answer": "yes"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/52.json
+++ b/data/kalkulacka/senatni-2022/52.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-52",
-  "name": "52",
-  "description": "52 - DESCRIPTION",
+  "name": "Jihlava",
+  "description": "Jihlava",
   "district_code": "52",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-52-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-52-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-52-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-52-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-52-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-52-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-52-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-52-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-52-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-52-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-52-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-52-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-52-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-52-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-52-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-52-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-52-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-52-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-52-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-52-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-52-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-52-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-52-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-52-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-52-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-52-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-52-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-52-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-52-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-52-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-52-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-52-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-52-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-52-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-52-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-52-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-52-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-52-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-52-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-52-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-52-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-52-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-52-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-52-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-52-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-52-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-52-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-52-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-52-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-52-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-52-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-52-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-52-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-52-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-52-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-52-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-52-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-52-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,16 +479,16 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-52-candidate-787854",
+      "id": "senatni-2022-52-c-787854",
       "name": "Luděk Růžička",
-      "type": "party",
+      "type": "person",
       "description": "Luděk Růžička - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-52-787854-party",
+          "id": "senatni-2022-52-c-787854-p",
           "name": "Luděk Růžička",
           "description": "Luděk Růžička - DESCRIPTION",
           "contacts": {
@@ -497,9 +499,9 @@
       ]
     },
     {
-      "id": "senatni-2022-52-candidate-975208",
+      "id": "senatni-2022-52-c-975208",
       "name": "Tomáš Nielsen",
-      "type": "party",
+      "type": "person",
       "description": "Tomáš Nielsen - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -507,7 +509,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-52-975208-party",
+          "id": "senatni-2022-52-c-975208-p",
           "name": "Tomáš Nielsen",
           "description": "Tomáš Nielsen - DESCRIPTION",
           "contacts": {
@@ -519,9 +521,9 @@
       ]
     },
     {
-      "id": "senatni-2022-52-candidate-406075",
+      "id": "senatni-2022-52-c-406075",
       "name": "Miloš Vystrčil",
-      "type": "party",
+      "type": "person",
       "description": "Miloš Vystrčil - DESCRIPTION",
       "contacts": {
         "web": [
@@ -535,7 +537,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-52-406075-party",
+          "id": "senatni-2022-52-c-406075-p",
           "name": "Miloš Vystrčil",
           "description": "Miloš Vystrčil - DESCRIPTION",
           "contacts": {
@@ -553,16 +555,16 @@
       ]
     },
     {
-      "id": "senatni-2022-52-candidate-520609",
+      "id": "senatni-2022-52-c-520609",
       "name": "Václav Lhotský",
-      "type": "party",
+      "type": "person",
       "description": "Václav Lhotský - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-52-520609-party",
+          "id": "senatni-2022-52-c-520609-p",
           "name": "Václav Lhotský",
           "description": "Václav Lhotský - DESCRIPTION",
           "contacts": {
@@ -573,9 +575,9 @@
       ]
     },
     {
-      "id": "senatni-2022-52-candidate-829521",
+      "id": "senatni-2022-52-c-829521",
       "name": "Josef Pavlík",
-      "type": "party",
+      "type": "person",
       "description": "Josef Pavlík - DESCRIPTION",
       "contacts": {
         "web": [
@@ -587,7 +589,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-52-829521-party",
+          "id": "senatni-2022-52-c-829521-p",
           "name": "Josef Pavlík",
           "description": "Josef Pavlík - DESCRIPTION",
           "contacts": {
@@ -603,16 +605,16 @@
       ]
     },
     {
-      "id": "senatni-2022-52-candidate-800084",
+      "id": "senatni-2022-52-c-800084",
       "name": "Jana Nagyová",
-      "type": "party",
+      "type": "person",
       "description": "Jana Nagyová - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-52-800084-party",
+          "id": "senatni-2022-52-c-800084-p",
           "name": "Jana Nagyová",
           "description": "Jana Nagyová - DESCRIPTION",
           "contacts": {
@@ -623,5 +625,702 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-10",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-27",
+      "answer": "yes",
+      "comment": "V případě zrušení práva veta."
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-32"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-40"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-46"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-47"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-50"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-51"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-53",
+      "answer": "yes",
+      "comment": "Je to záležitostí každého suverénního státu."
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-54",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-57"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-52-c-829521",
+      "question_id": "senatni-2022-52-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-1",
+      "answer": "no",
+      "comment": "Jinak to může být u bytů, které byly vystavěny s pomocí finančních prostředků z veřejného rozpočtu."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-2",
+      "answer": "no",
+      "comment": "Jinak to může být u bytů, které byly vystavěny s pomocí finančních prostředků z veřejného rozpočtu."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-3",
+      "answer": "no",
+      "comment": "Dovedu si představit zákonem stanovené výjimky."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-6"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-7",
+      "comment": "Je třeba dělat to, co je ekologičtější. Shoda, které řešení je ekologičtější, zatím není."
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-8",
+      "answer": "no",
+      "comment": "Již je již zvýšená například z důvodu existence odečitatelných položek."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-9"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-12"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-16",
+      "answer": "yes",
+      "comment": "Nejsem ale pro název manželství."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-19",
+      "answer": "no",
+      "comment": "Dovedu si představit jako podmínku při poskytnutí státní dotace."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-20",
+      "answer": "no",
+      "comment": "Jsem pro podporu neziskových organizací, které stát v tomto zastoupí. Stát má mít ale povinnost poradit a pomoci."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-22",
+      "comment": "Nevím, co si představit pod pojmem kolonizace Marsu."
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-23",
+      "answer": "no",
+      "comment": "Jsem však pro zavedení této možnosti pro české občany pobývající v zahraničí."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-26",
+      "answer": "yes",
+      "comment": "Speciální školy je však třeba zachovat.  Všem dětem musí zůstat zachována možnost radovat se z úspěchu."
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-28",
+      "answer": "yes",
+      "comment": "Při splnění podmínek."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-36"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-48"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-50",
+      "comment": "Záleží na situaci ve světě."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-54",
+      "answer": "no",
+      "comment": "Ideální je systém bez dotací, pokud dotovat, tak podle toho, jak se kdo stará o půdu a krajinu a přitom má živočišnou i rostlinnou produkci."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-55"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-52-c-406075",
+      "question_id": "senatni-2022-52-q-58",
+      "comment": "Je třeba hledat jiné řešení."
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/55.json
+++ b/data/kalkulacka/senatni-2022/55.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-55",
-  "name": "55",
-  "description": "55 - DESCRIPTION",
+  "name": "Brno-město (55)",
+  "description": "Brno-město (55)",
   "district_code": "55",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-55-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-55-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-55-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-55-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-55-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-55-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-55-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-55-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-55-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-55-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-55-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-55-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-55-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-55-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-55-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-55-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-55-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-55-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-55-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-55-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-55-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-55-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-55-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-55-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-55-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-55-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-55-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-55-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-55-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-55-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-55-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-55-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-55-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-55-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-55-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-55-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-55-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-55-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-55-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-55-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-55-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-55-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-55-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-55-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-55-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-55-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-55-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-55-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-55-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-55-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-55-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-55-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-55-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-55-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-55-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-55-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-55-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-55-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-55-candidate-716101",
+      "id": "senatni-2022-55-c-716101",
       "name": "Petra Rédová Fajmonová",
-      "type": "party",
+      "type": "person",
       "description": "Petra Rédová Fajmonová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -497,7 +499,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-55-716101-party",
+          "id": "senatni-2022-55-c-716101-p",
           "name": "Petra Rédová Fajmonová",
           "description": "Petra Rédová Fajmonová - DESCRIPTION",
           "contacts": {
@@ -519,9 +521,9 @@
       ]
     },
     {
-      "id": "senatni-2022-55-candidate-429934",
+      "id": "senatni-2022-55-c-429934",
       "name": "Radomír Pavlíček",
-      "type": "party",
+      "type": "person",
       "description": "Radomír Pavlíček - DESCRIPTION",
       "contacts": {
         "web": [
@@ -535,7 +537,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-55-429934-party",
+          "id": "senatni-2022-55-c-429934-p",
           "name": "Radomír Pavlíček",
           "description": "Radomír Pavlíček - DESCRIPTION",
           "contacts": {
@@ -553,9 +555,9 @@
       ]
     },
     {
-      "id": "senatni-2022-55-candidate-323222",
+      "id": "senatni-2022-55-c-323222",
       "name": "Pavel Trčala",
-      "type": "party",
+      "type": "person",
       "description": "Pavel Trčala - DESCRIPTION",
       "contacts": {
         "web": [
@@ -567,7 +569,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-55-323222-party",
+          "id": "senatni-2022-55-c-323222-p",
           "name": "Pavel Trčala",
           "description": "Pavel Trčala - DESCRIPTION",
           "contacts": {
@@ -583,9 +585,9 @@
       ]
     },
     {
-      "id": "senatni-2022-55-candidate-248878",
+      "id": "senatni-2022-55-c-248878",
       "name": "Bořek Semrád",
-      "type": "party",
+      "type": "person",
       "description": "Bořek Semrád - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -594,7 +596,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-55-248878-party",
+          "id": "senatni-2022-55-c-248878-p",
           "name": "Bořek Semrád",
           "description": "Bořek Semrád - DESCRIPTION",
           "contacts": {
@@ -607,9 +609,9 @@
       ]
     },
     {
-      "id": "senatni-2022-55-candidate-240503",
+      "id": "senatni-2022-55-c-240503",
       "name": "Tomáš Kotas",
-      "type": "party",
+      "type": "person",
       "description": "Tomáš Kotas - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -617,7 +619,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-55-240503-party",
+          "id": "senatni-2022-55-c-240503-p",
           "name": "Tomáš Kotas",
           "description": "Tomáš Kotas - DESCRIPTION",
           "contacts": {
@@ -629,9 +631,9 @@
       ]
     },
     {
-      "id": "senatni-2022-55-candidate-924292",
+      "id": "senatni-2022-55-c-924292",
       "name": "Tomáš Töpfer",
-      "type": "party",
+      "type": "person",
       "description": "Tomáš Töpfer - DESCRIPTION",
       "contacts": {
         "web": [
@@ -648,7 +650,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-55-924292-party",
+          "id": "senatni-2022-55-c-924292-p",
           "name": "Tomáš Töpfer",
           "description": "Tomáš Töpfer - DESCRIPTION",
           "contacts": {
@@ -669,9 +671,9 @@
       ]
     },
     {
-      "id": "senatni-2022-55-candidate-264620",
+      "id": "senatni-2022-55-c-264620",
       "name": "Bohumil Smutný",
-      "type": "party",
+      "type": "person",
       "description": "Bohumil Smutný - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -679,7 +681,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-55-264620-party",
+          "id": "senatni-2022-55-c-264620-p",
           "name": "Bohumil Smutný",
           "description": "Bohumil Smutný - DESCRIPTION",
           "contacts": {
@@ -691,5 +693,696 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-6"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-12"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-13"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-26"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-27"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-30"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-32"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-38"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-45"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-46"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-48"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-53",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-55"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-57"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-55-c-264620",
+      "question_id": "senatni-2022-55-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-1",
+      "comment": "Kdo bude vyhodnocovat obsazenost bytů, \"bytový úřad\"? "
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-3",
+      "answer": "yes",
+      "comment": "Je nutné vyřešit petiční podmínky, aby to dávalo smysl. "
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-6",
+      "answer": "yes",
+      "comment": "Bude ale problém najít vhodné lokality."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-10"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-16",
+      "comment": "Jsem pro stejná práva ve stejnopohlavních vztazích, ovšem nenazývejme je přímo manželstvím."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-19",
+      "answer": "no",
+      "comment": "Tento problémy lze řešit lepšími metodami, třeba kombinací seniorského a startovacího bydlení apod. "
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-22",
+      "comment": "Už víme konkrétní termín? "
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-24",
+      "answer": "yes",
+      "comment": "Je třeba se zaměřit hlavně na řemeslné obory."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-25",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-32"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-33",
+      "answer": "no",
+      "comment": "Institut azylu je aktuálně dostačující."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-36",
+      "comment": "Je to vůbec možné?"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-39",
+      "comment": "Dle možností by mělo být výrazně omezeno."
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-42",
+      "answer": "yes",
+      "comment": "Pokud splní přístupové podmínky."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-48",
+      "answer": "yes",
+      "comment": "Domácí násilí bychom měli potírat obecně."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-49",
+      "answer": "no",
+      "comment": "Aktuální energetická situace to neumožňuje."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-54",
+      "answer": "no",
+      "comment": "Menší farmy a ekologicky hospodařící zemedělci by měli být zvýhodněni. "
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-56",
+      "answer": "no",
+      "comment": "tyto kompetence bych ponechal obcím a městům."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-55-c-429934",
+      "question_id": "senatni-2022-55-q-58",
+      "answer": "no"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/58.json
+++ b/data/kalkulacka/senatni-2022/58.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-58",
-  "name": "58",
-  "description": "58 - DESCRIPTION",
+  "name": "Brno-město (58)",
+  "description": "Brno-město (58)",
   "district_code": "58",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-58-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-58-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-58-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-58-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-58-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-58-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-58-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-58-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-58-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-58-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-58-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-58-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-58-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-58-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-58-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-58-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-58-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-58-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-58-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-58-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-58-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-58-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-58-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-58-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-58-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-58-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-58-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-58-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-58-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-58-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-58-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-58-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-58-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-58-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-58-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-58-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-58-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-58-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-58-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-58-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-58-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-58-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-58-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-58-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-58-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-58-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-58-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-58-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-58-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-58-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-58-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-58-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-58-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-58-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-58-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-58-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-58-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-58-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-58-candidate-381319",
+      "id": "senatni-2022-58-c-381319",
       "name": "Jiří Dušek",
-      "type": "party",
+      "type": "person",
       "description": "Jiří Dušek - DESCRIPTION",
       "contacts": {
         "web": [
@@ -501,7 +503,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-58-381319-party",
+          "id": "senatni-2022-58-c-381319-p",
           "name": "Jiří Dušek",
           "description": "Jiří Dušek - DESCRIPTION",
           "contacts": {
@@ -527,9 +529,9 @@
       ]
     },
     {
-      "id": "senatni-2022-58-candidate-296693",
+      "id": "senatni-2022-58-c-296693",
       "name": "Petr Kunc",
-      "type": "party",
+      "type": "person",
       "description": "Petr Kunc - DESCRIPTION",
       "contacts": {
         "web": [
@@ -552,7 +554,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-58-296693-party",
+          "id": "senatni-2022-58-c-296693-p",
           "name": "Petr Kunc",
           "description": "Petr Kunc - DESCRIPTION",
           "contacts": {
@@ -579,16 +581,16 @@
       ]
     },
     {
-      "id": "senatni-2022-58-candidate-663420",
+      "id": "senatni-2022-58-c-663420",
       "name": "Lucie Zajícová",
-      "type": "party",
+      "type": "person",
       "description": "Lucie Zajícová - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-58-663420-party",
+          "id": "senatni-2022-58-c-663420-p",
           "name": "Lucie Zajícová",
           "description": "Lucie Zajícová - DESCRIPTION",
           "contacts": {
@@ -599,9 +601,9 @@
       ]
     },
     {
-      "id": "senatni-2022-58-candidate-995955",
+      "id": "senatni-2022-58-c-995955",
       "name": "Zdeněk Koudelka",
-      "type": "party",
+      "type": "person",
       "description": "Zdeněk Koudelka - DESCRIPTION",
       "contacts": {
         "web": [
@@ -622,7 +624,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-58-995955-party",
+          "id": "senatni-2022-58-c-995955-p",
           "name": "Zdeněk Koudelka",
           "description": "Zdeněk Koudelka - DESCRIPTION",
           "contacts": {
@@ -647,9 +649,9 @@
       ]
     },
     {
-      "id": "senatni-2022-58-candidate-630883",
+      "id": "senatni-2022-58-c-630883",
       "name": "Michal Sedláček",
-      "type": "party",
+      "type": "person",
       "description": "Michal Sedláček - DESCRIPTION",
       "contacts": {
         "web": [
@@ -672,7 +674,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-58-630883-party",
+          "id": "senatni-2022-58-c-630883-p",
           "name": "Michal Sedláček",
           "description": "Michal Sedláček - DESCRIPTION",
           "contacts": {
@@ -699,9 +701,9 @@
       ]
     },
     {
-      "id": "senatni-2022-58-candidate-260752",
+      "id": "senatni-2022-58-c-260752",
       "name": "Petr Vokřál",
-      "type": "party",
+      "type": "person",
       "description": "Petr Vokřál - DESCRIPTION",
       "contacts": {
         "web": [
@@ -715,7 +717,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-58-260752-party",
+          "id": "senatni-2022-58-c-260752-p",
           "name": "Petr Vokřál",
           "description": "Petr Vokřál - DESCRIPTION",
           "contacts": {
@@ -733,5 +735,1426 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-1",
+      "answer": "no",
+      "comment": "Dlouhodobě prázdné byty a domy mají pouze města, v Brně je to cca 1000 bytů. Pro soukromou nebo právnickou osobu nedává ekonomický smysl držet prázdné byty, proto je takových případů naprosté minimum. "
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-2",
+      "answer": "no",
+      "comment": "ČR může regulovat nájemné u obecních domů, v žádném případě však u soukromých. "
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-5",
+      "answer": "yes",
+      "comment": "Z důvodu zachování fungujícího penzijního systému to bude nutnost. "
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-6",
+      "comment": "Nelze posuzovat všechny záměry stejně."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-7",
+      "answer": "yes",
+      "comment": "Ano, sníží to objem odpadu i nepořádek v ulicích. "
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-13",
+      "comment": "Vhodný systém využívá Twitter, který \"fake news\" nemaže, ale upozorní na ně. "
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-16",
+      "answer": "yes",
+      "comment": "Jednoznačně ano. "
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-19",
+      "answer": "no",
+      "comment": "Obecní a státní ano, soukromá ne. "
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-21",
+      "answer": "no",
+      "comment": "Rozmístění institucí musí splňovat mnohem více kritérií, než jen rovnoměrné rozmístění po ČR. "
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-23",
+      "answer": "yes",
+      "comment": "Za předpokladu zajištění naprosté anonymity při hlasování."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-26",
+      "comment": "Tato problematika je příliš složitá a necítím se být v ní dostatečně erudovaný. "
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-32"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-33"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-38"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-42",
+      "answer": "yes",
+      "comment": "Ano, za předpokladu provedení nutných reforem. "
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-44"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-49",
+      "answer": "yes",
+      "comment": "Ale je potřeba mít v době ukončení spalování uhlí alternativu k produkci dostatku elektrické energie. "
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-56",
+      "answer": "no",
+      "comment": "Ne, tuto funkci plní a mají plnit obce a městské části. "
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-58-c-296693",
+      "question_id": "senatni-2022-58-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-3",
+      "comment": "Záleží na okruzích, o kterých by se hlasovalo."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-5"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-12",
+      "answer": "yes",
+      "comment": "Není však možné zavádět cenzuru."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-14"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-15"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-16"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-18"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-22"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-28"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-42"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-48"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-52"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-54",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-56"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-57"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-58-c-381319",
+      "question_id": "senatni-2022-58-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-2",
+      "answer": "no",
+      "comment": "Regulace pouze u obecních bytů a ze sociálních důvodů. \nSoukromé vlastnictví je nedotknutelné v každém smyslu, a je nemyslitelné, že by Stát - ČR někomu, kdo své vydělané peníze vložil investičně do nemovitosti  - třeba k pronájmu na přilepšení v důchodu, nebo dokud nedorostou děti, určoval jeho smluvní ceny. Ty vyřeší tržní prostředí."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-4",
+      "answer": "no",
+      "comment": "ČR není tak velkou zemí, aby se taková obrovská investice vyplatila. Alternativou pro spěchající cestující by mohlo být obnovení vnitrostátní letecké dopravy, kde ceny letenek jsou srovnatelné s cenami jízdenek rychlovlaků."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-5",
+      "answer": "no",
+      "comment": "Při absenci státního důchodového fondu nemůže být řešena otázka důchodové reformy zaměstnáváním lidí až do smrti..."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-6",
+      "answer": "yes",
+      "comment": "Nejenom retence vody, ale i výroba el. energie."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-8",
+      "answer": "no",
+      "comment": "Je absurdní trestat ty, kteří se snaží a pracují více, než ti, kteří by se klidně spokojili s nepodmíněným příjmem - bez práce. Procentuální sazba znamená, že ten, kdo vydělává více, odvádí také více do státního rozpočtu - procentuálně. (Pokud ovšem nedaní v daňovém ráji...- viz zákaz dvojího zdanění))"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-9",
+      "answer": "yes",
+      "comment": "Ale pouze pro osobní spotřebu a to už v malé míře je. Konopí je však také velmi pevný technický materiál - například jako plnivo laminátových kompozitů."
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-12",
+      "answer": "no",
+      "comment": "Pouze za obsah, který je v rozporu se zákonem - např. pornografie, pedofilie, cyberterorismus ,  vybízení k násilí a ohrožování života, přístupné dětem a mladistvým. U dospělých se předpokládá, že vědí, co dělají a jsou odpovědní za své konání."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-13",
+      "answer": "no",
+      "comment": "I podle zákona je svoboda slova a svoboda názoru v ČR zaručena a naopak jakákoliv cenzura je nepřípustná a antidemokratická. Dodržování zákona je základem právního státu. "
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-14",
+      "answer": "yes",
+      "comment": "Veřejnoprávní média, placená ze státního rozpočtu, mají sloužit k nestranné  informaci veřejnosti a obohacování kultury občanstva. Tuto službu již platí každý pracující z daní. Proto by neměli ani občané platit ještě podruhé tuto jednu službu povinnými \"poplatky\" a tato státní media by ani neměla podnikat prodejem vysílacího času pro lukrativní reklamy, na rozdíl od komerčních médií."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-15",
+      "answer": "yes",
+      "comment": "K tomu účelu jsou určeny (a ze státního rozpočtu placeny) Úřady práce. Pokud pracují neefektivně, je třeba to napravit, a ne platit desetitisíce \"neziskovek\", které z této situace mají svůj soukromý byznys.za státní peníze."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-16",
+      "answer": "no",
+      "comment": "Nevidím k tomu důvod.\nBeru manželství jako přirozený právní rámec k zabezpečení zdravého vývoje a výchovy potomstva, zplozeného (přirozeně) mužem a ženou, a manželství, které takto právně kodifikuje rodinu, je pak, přinejmenším psychologicky, stabilním a bezpečným zázemím rodiny a dětí do doby jejich samostatnosti.\nDlužno dodat, že je  i mnoho rodin s dětmi, kde muž a žena řeší rodinný statut zákonným  institutem  partnerství.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-17",
+      "comment": "Žádná z nabízených odpovědí.\nExekutor by měl být státní úředník, nikoliv podnikatel s chudobou."
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-19",
+      "answer": "yes",
+      "comment": "Ano obecní a státní výstavba, ne soukromá. Soukromá osoba nemá povinnost zajišťovat nebo kompenzovat sociální povinnosti státu."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-20",
+      "answer": "no",
+      "comment": "Stát má především zajišťovat takové životní podmínky svých občanů preventivní sociální politikou, aby se lidi do nouze nedostali (např. nabídkou pracovních míst, řádnou zdravotní péčí, zákazem lichvy, a především občanskou výchovou už od základní školy)"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-22",
+      "answer": "no",
+      "comment": "\"Snaha o kolonizaci Marsu\" je úsměvná za stavu, kdy Mars ještě žádný živý člověk naživo ani neviděl. je to stejně úsměvné, jako jistý \"Mars Architekt\", který představoval svoje projekty obydlí pro Mars na ČT24... "
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-23",
+      "answer": "no",
+      "comment": "Rozhodně ne. Každá elektronika se dá \"hacknout\" a demokratický proces voleb tak ovlivnit dle libosti. (Viz elektronický volební systém Dominion v USA při volbě Prezidenta). \nNaopak v opravdu demokratickém a svobodném státě by člověk neměl mít problém sdělit svoji volbu svých zástupců, kterým důvěřuje, osobně a jmenovitě."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-24",
+      "answer": "yes",
+      "comment": "Protože jsou potřeba a je jich nedostatek."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-25",
+      "answer": "no",
+      "comment": "Je nestoudné sakrifikovat talenty kvůli kolektivizaci. To nebylo ani za totality."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-26",
+      "answer": "no",
+      "comment": "Naopak - děti by se měly vzdělávat v kolektivu podobné úrovně, aby slabší žáci nebyli silnějšími, nebo výrazně schopnějšími dětmi zesměšňováni, a netrpěli pocity méněcennosti. \nŠkola by měla pomáhat tomu, aby každý, podle svých schopností, našel svoje platné místo ve společnosti. Fakt, že někdo nemá na kvantové rovnice neznamená, že nemůže být skvělým kuchařem, nebo zahradníkem, která dělá svoji hodnotnou práci s láskou."
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-27",
+      "answer": "yes",
+      "comment": "ČR za současného stavu nemá suverenitu rozhodování - viz např. rozhodnutí EU o odmítnutí levného ruského plynu, na kterém je postavena většina průmyslu naší země. "
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-28",
+      "answer": "no",
+      "comment": "ČR by tak ztratila možnost regulace vlastní měny, a mohla by dopadnout jako Řecko, nebo Itálie."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-29",
+      "answer": "yes",
+      "comment": "ČR, i díky své poloze ve středu Evropy - na rozhraní dvou vlivových pásem, by měla být vojensky neutrální zemí, jako třeba Rakousko, nebo Švýcarsko."
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-30",
+      "answer": "no",
+      "comment": "Místo ČR je v naší zemi - v Čechách, na Moravě a ve Slezsku."
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-31",
+      "answer": "no",
+      "comment": "ČR musí přede vším ostatním zabezpečit teplo, světlo, potravinovou dostatečnost, zdravotní péči a mír svým občanům. Proto tento stát naši předkové před 100 lety založili."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-32",
+      "answer": "no",
+      "comment": "Politici ČR musí především chránit zdravé klima v naší zemi."
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-33",
+      "answer": "no",
+      "comment": "Pouze pro opravdu potřebné a prověřené osoby - tak, jak to dělá každý stát v zájmu své bezpečnosti. Je rozdíl mezi prchajícími před válkou nebo pronásledovanými politicky  a ekonomickými přistěhovalci možného kriminálního původu.\nPři aktuálním naředění naší pracující společnosti o téměř 6% naší populace nepracujícími imigranty hrozí kolaps našeho sociálního systému."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-34"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-35",
+      "answer": "no",
+      "comment": "ČR by měla vyhlásit vojenskou neutralitu. Většina našich občanů jsou mírumilovní lidé, kteří chtějí mír a sami nikoho neohrožují ani nekolonizují."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-37",
+      "answer": "no",
+      "comment": "Diskriminační praktiky nepodporuji a naše současné státní zdravotnictví je na dostatečné úrovni i pro ty náročnější."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-39",
+      "answer": "yes",
+      "comment": "Rozhodně! Je toxický, prokazatelně rakovinotvorný a mutagenní - působí na DNA člověka."
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-40"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-41",
+      "answer": "yes",
+      "comment": "Vlastní biometrické údaje jsou osobními údaji, a musí spadat do GDPR."
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-42",
+      "answer": "no",
+      "comment": "ČR by měla vystoupit."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-43",
+      "answer": "no",
+      "comment": "Ukrajina tím riskuje otevřenou válku NATO s Ruskem na celém svém území. Dohody o sférách vlivu  po 2WW hovořily o jasném rozdělení pásem v Evropě, a RF má již nyní NATO na téměř celé své západní hranici, a tu, jak sdělil ruský Ministr zahraničí, chce mít v bezpečí."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-44",
+      "answer": "no",
+      "comment": "EU by měla zastropovat ceny plynu pro obyvatele EU - členských států na stejné, snesitelné úrovni. \nEU místo toho však chce \"zastropovat\" = určovat RF prodejní ceny plynu do EU. \nDůsledkem tohoto EU \"koumáctví\" je, že RF k 31.8.2022 zastavila přívod plynu do EU plynovodem Nordstream, a prodává plyn podle svých podmínek jinde."
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-46",
+      "answer": "no",
+      "comment": "Ukrajinské vedení od počátku otevřeně bojkotovalo plnění Minských dohod pro mír na jihu Ukrajiny, kde do začátku ozbrojeného konfliktu v únoru 2022 již od roku 2014 bylo přes 20.000 obětí, včetně dětí (viz foto v \"Aleji Andělů\") na ruskojazyčném obyvatelstvu. \nZajímavé je, že tyto oběti na Ukrajině např.  Premier Fiala, ani jiní, nikdy nezmínili."
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-47",
+      "answer": "yes",
+      "comment": "Diplomatické řešení tohoto konfliktu je jediné možné, aby se předešlo jeho rozšíření do celé Evropy."
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-48",
+      "answer": "no",
+      "comment": "EU se snaží stále dělat z žen nějaké bezduché chudinky a z mužů tyrany, a s tím, jako žena, nesouhlasím. Nevím, jak to mají třeba v Německu, nebo ve Francii, ale tady u nás si normální žena umí sjednat pořádek, a nenechá se nikým utlačovat, tím spíše, že naše právo takové případné situace řeší i v trestní rovině, a toto je ve všeobecném povědomí."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-49",
+      "answer": "no",
+      "comment": "Naopak jsem pro znovuotevření uhelných dolů, protože, vzhledem k našemu podnebnému pásmu, pokud nemáme plyn, tak nějak budeme muset topit a vařit.\nUhlí není ani toxické, ani karcinogenní - lidské tělo je převážně složeno z uhlíku.\nMoje babička topila celý život uhlím a dřevem a dožila se 98 let."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-50",
+      "answer": "no",
+      "comment": "Co to je \"klimaticky neutrální\"?\nPokud v Radiožurnálu bývalý Ministr ŽP Moldán říká, že \"80 % snížení CO2 je podle něj málo, že on by šel dále (i přes 100%?), tak mu zřejmě nedochází, že by asi musel on a všichni ostatní museli přestat dýchat, navždy."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-51",
+      "answer": "yes",
+      "comment": "Už jí je."
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-52",
+      "answer": "yes",
+      "comment": "Bilaterálními smlouvami."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-53",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-54",
+      "answer": "no",
+      "comment": "Zemědělské dotace EU ničí naše zemědělství .\nNa podrobné vysvětlení zde, bohužel, není dost prostoru (vysvětlení EU Programu MZ Greening), ale ve zkratce to vypadá následovně:  např. dle směrnic EU, pod záminkou „biodiversity“ byly na Mikulovsku vykáceny hektary broskvoní, a půda osázena, tuším, jetelem se štědrými dotacemi EU. Stejný model byl aplikován na „záměnu kultur“, kdy místo naší pšenice se lány polí osely, bohatě z EU dotovanou,  řepkou, a navíc, dle doporučení EU, i geneticky modifikovanou.  Výsledkem této štědré dotační politiky EU dnes je, že v ČR nejsme potravinově soběstační, a kilo broskví z Alžíru si naši občané mohou koupit i za 150,- Kč/kg.\n"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-55",
+      "answer": "no",
+      "comment": "Takovou \"ideu\" musel opravdu někdo dlouze vymýšlet!\nŽena většinou menstruuje v produktivním věku, a pokud pracuje, tak snad ty dvě stovky za měsíc na hygienu má.  \nAle fakt, že někteří důchodci musí volit mezi léky a jídlem, evidentně takové myslitele míjí."
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-56",
+      "answer": "no",
+      "comment": "To by se se státními byty spekulovalo ještě více, než dnes.\nBude úplně stačit, když se státní instituce, města a obce, budou starat o svěřené nemovitosti s péčí řádného hospodáře, a nebudou nechávat stovky zchátralých bytů prázdných ladem.\nAno, chce to práci."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-57",
+      "comment": "To se uvidí podle toho, kolik a jakých zbraní ještě NATO na Ukrajinu naveze."
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-58-c-663420",
+      "question_id": "senatni-2022-58-q-58",
+      "answer": "yes",
+      "comment": "Měl by řešit stát, ne soukromý podnikatel - exekutor."
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-8"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-12"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-22"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-26"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-31"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-33"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-43"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-49"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-58-c-630883",
+      "question_id": "senatni-2022-58-q-58",
+      "answer": "yes"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/61.json
+++ b/data/kalkulacka/senatni-2022/61.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-61",
-  "name": "61",
-  "description": "61 - DESCRIPTION",
+  "name": "Olomouc",
+  "description": "Olomouc",
   "district_code": "61",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-61-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-61-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-61-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-61-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-61-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-61-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-61-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-61-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-61-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-61-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-61-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-61-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-61-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-61-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-61-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-61-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-61-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-61-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-61-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-61-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-61-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-61-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-61-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-61-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-61-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-61-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-61-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-61-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-61-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-61-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-61-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-61-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-61-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-61-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-61-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-61-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-61-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-61-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-61-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-61-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-61-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-61-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-61-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-61-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-61-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-61-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-61-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-61-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-61-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-61-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-61-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-61-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-61-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-61-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-61-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-61-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-61-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-61-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-61-candidate-131643",
+      "id": "senatni-2022-61-c-131643",
       "name": "Ctirad Musil",
-      "type": "party",
+      "type": "person",
       "description": "Ctirad Musil - DESCRIPTION",
       "contacts": {
         "web": [
@@ -496,7 +498,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-61-131643-party",
+          "id": "senatni-2022-61-c-131643-p",
           "name": "Ctirad Musil",
           "description": "Ctirad Musil - DESCRIPTION",
           "contacts": {
@@ -517,16 +519,16 @@
       ]
     },
     {
-      "id": "senatni-2022-61-candidate-504062",
+      "id": "senatni-2022-61-c-504062",
       "name": "Petr Vrána",
-      "type": "party",
+      "type": "person",
       "description": "Petr Vrána - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-61-504062-party",
+          "id": "senatni-2022-61-c-504062-p",
           "name": "Petr Vrána",
           "description": "Petr Vrána - DESCRIPTION",
           "contacts": {
@@ -537,9 +539,9 @@
       ]
     },
     {
-      "id": "senatni-2022-61-candidate-330603",
+      "id": "senatni-2022-61-c-330603",
       "name": "Michal Malacka",
-      "type": "party",
+      "type": "person",
       "description": "Michal Malacka - DESCRIPTION",
       "contacts": {
         "web": [
@@ -564,7 +566,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-61-330603-party",
+          "id": "senatni-2022-61-c-330603-p",
           "name": "Michal Malacka",
           "description": "Michal Malacka - DESCRIPTION",
           "contacts": {
@@ -593,9 +595,9 @@
       ]
     },
     {
-      "id": "senatni-2022-61-candidate-290618",
+      "id": "senatni-2022-61-c-290618",
       "name": "Milan Brázdil",
-      "type": "party",
+      "type": "person",
       "description": "Milan Brázdil - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -604,7 +606,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-61-290618-party",
+          "id": "senatni-2022-61-c-290618-p",
           "name": "Milan Brázdil",
           "description": "Milan Brázdil - DESCRIPTION",
           "contacts": {
@@ -617,9 +619,9 @@
       ]
     },
     {
-      "id": "senatni-2022-61-candidate-836627",
+      "id": "senatni-2022-61-c-836627",
       "name": "Lumír Kantor",
-      "type": "party",
+      "type": "person",
       "description": "Lumír Kantor - DESCRIPTION",
       "contacts": {
         "web": [
@@ -641,7 +643,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-61-836627-party",
+          "id": "senatni-2022-61-c-836627-p",
           "name": "Lumír Kantor",
           "description": "Lumír Kantor - DESCRIPTION",
           "contacts": {
@@ -667,9 +669,9 @@
       ]
     },
     {
-      "id": "senatni-2022-61-candidate-146752",
+      "id": "senatni-2022-61-c-146752",
       "name": "Václav Ranc",
-      "type": "party",
+      "type": "person",
       "description": "Václav Ranc - DESCRIPTION",
       "contacts": {
         "web": [
@@ -686,7 +688,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-61-146752-party",
+          "id": "senatni-2022-61-c-146752-p",
           "name": "Václav Ranc",
           "description": "Václav Ranc - DESCRIPTION",
           "contacts": {
@@ -707,9 +709,9 @@
       ]
     },
     {
-      "id": "senatni-2022-61-candidate-405277",
+      "id": "senatni-2022-61-c-405277",
       "name": "Čestmír Neoral",
-      "type": "party",
+      "type": "person",
       "description": "Čestmír Neoral - DESCRIPTION",
       "contacts": {
         "web": [
@@ -727,7 +729,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-61-405277-party",
+          "id": "senatni-2022-61-c-405277-p",
           "name": "Čestmír Neoral",
           "description": "Čestmír Neoral - DESCRIPTION",
           "contacts": {
@@ -749,9 +751,9 @@
       ]
     },
     {
-      "id": "senatni-2022-61-candidate-202876",
+      "id": "senatni-2022-61-c-202876",
       "name": "Zuzana Majerová",
-      "type": "party",
+      "type": "person",
       "description": "Zuzana Majerová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -774,7 +776,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-61-202876-party",
+          "id": "senatni-2022-61-c-202876-p",
           "name": "Zuzana Majerová",
           "description": "Zuzana Majerová - DESCRIPTION",
           "contacts": {
@@ -801,5 +803,1097 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-2",
+      "answer": "no",
+      "comment": "Tržní nájemné by státem být regulováno nemělo. Pokud budou obce disponovat bytovým fondem, pak bude na nich, jak si výši nájemného stanoví. Proto je důležité, aby byl obecní bytový fond dostatečný."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-3",
+      "answer": "yes",
+      "comment": "Piráti podporují uzákonění celostátního referenda od svého počátku"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-5",
+      "answer": "no",
+      "comment": "Je zásadnější  adekvátně odměňovat ty, co se dobrovolně rozhodnou do důchodu neodcházet, protože to je výhodné jak pro stát, tak i pro seniory."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-6",
+      "answer": "no",
+      "comment": "Vodu je potřeba zadržovat především v samotné půdě a přirozeně v krajině. Výstavbu megalomanských přehrad tedy nepodporuji."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-7",
+      "answer": "no",
+      "comment": "Zálohování PET láhví je dobrovolně na výrobci, což považuji za správné."
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-8",
+      "answer": "yes",
+      "comment": "Progrese by však nejprve měla být vytvořena snížením daňové zátěže nízkopříjmových obyvatel. Další danění lidí s vyššími příjmy je na další debatu."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-10",
+      "answer": "yes",
+      "comment": "Problém v tuto chvíli není v přímo v rozsahu trestů vymezených zákonem, ale obecně v praxi, kdy jsou v rámci trestních řízení udělovány nízké tresty. Za důležitou též považuji nápravu definice znásilnění tak, aby zahrnovala i situace, kdy oběť nedokáže projevit odpor, nebo zažívá paralýzu."
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-11",
+      "answer": "yes",
+      "comment": "Dlouhodobě podporuji zavedení globální minimální daně na úrovni EU."
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-12",
+      "answer": "no",
+      "comment": "Zavedení této povinnosti by vedlo k omezení svobody slova a k právním nejistotám. Nicméně sítě mají již nyní povinnost nezákonný obsah na podnět soudu odstraňovat."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-14",
+      "answer": "no",
+      "comment": "Další snížení financování veřejnoprávního vysílání není dle mého názoru správnou cestou."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-15",
+      "answer": "no",
+      "comment": "Problém nevidím v působnosti, jako takové, ale spíše v kontrole jejich činností."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-16",
+      "answer": "yes",
+      "comment": "Rovné manželství pomůže tisícům párů a jejich dětem, neohrozí nikoho"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-19",
+      "answer": "no",
+      "comment": "Sociální bydlení by mělo být svázáno s potřebou v konkrétní lokalitě a rozhodovat o něm by tedy měly jednotlivé obce."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-21",
+      "comment": "Je stále diskutabilní, jestli by decentralizace měla na regiony efekt. Z dostupných dat to není zcela jasné."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-22",
+      "answer": "yes",
+      "comment": "Nicméně prioritou by měl být nejprve měsíc. "
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-23",
+      "answer": "yes",
+      "comment": "Zásadní je však realizace a technické provedení, které musí být jednoduché a zcela spolehlivé."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-24",
+      "answer": "no",
+      "comment": "Nejsem pro, aby stát silově určoval prioritu jednotlivých oborů. Vyšší potřeba technických oborů by však měla být lépe propagována."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-25",
+      "answer": "yes",
+      "comment": "Jsem pro individualizaci talentovaných dětí, pokud o to projeví zájem. Ale ne v současném systému, který nahrává spíše dětem z rodin s lepším ekonomickým zázemím. "
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-26",
+      "comment": "Obecně ano, ale je potřeba současný systém redefinovat a opravit jeho nedostatky. "
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-32",
+      "answer": "yes",
+      "comment": "Určitě ano."
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-33",
+      "answer": "yes",
+      "comment": "Žádost o azyl musí být zefektivněna tak, abychom byli schopni vyřídit větší množství žádostí o azyl bez vyvolání humanitární krize."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-35",
+      "answer": "yes",
+      "comment": "V případě navyšování výdajů na obranu je potřeba postupovat dle racionálních kapacit s cílem zajistit co nejvyšší efektivitu vynaložených prostředků."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-36",
+      "answer": "no",
+      "comment": "Tohle zcela odmítám. Výběr pohlaví dítěte je za hranicí toho, co by měl člověk ovlivňovat."
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-37",
+      "answer": "yes",
+      "comment": "Podporuji možnost soukromého pojištění, kde si každý bude moct vybrat produkt dle svých zájmů."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-38",
+      "answer": "yes",
+      "comment": "Podporuji centralizaci, která by mohla vést k vyšší úspěšnosti léčby a zároveň k vyšší efektivitě zdravotní péče."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-39",
+      "answer": "yes",
+      "comment": "Existují i jiné prostředky, které nedevastují půdu a nejsou toxické."
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-41",
+      "answer": "yes",
+      "comment": "S používáním hromadného biometrického sledování jsou spojena jednoznačná rizika v podobě zvýšené mocenské nerovnováhy, diskriminace, rasismu, nerovností a autoritářské společenské kontroly."
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-42",
+      "answer": "yes",
+      "comment": "Vstup Ukrajiny do EU podpořím hned, jakmile bude plnit podmínky vstupu, tzv. Kodaňská kritéria."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-44"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-45",
+      "answer": "no",
+      "comment": "Ombudsman má především chránit lidská práva bez rozdílů, což bohužel dlouhodobě nečiní. "
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-47",
+      "answer": "no",
+      "comment": "Podmínky ústupu Ruska z Ukrajiny, vč. Krymu, by měla vyjednávat především ukrajinská strana."
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-48",
+      "answer": "yes",
+      "comment": "Istanbulská úmluva od jednotlivých států vyžaduje silnější ochranu obětí a efektivní stíhání pachatelů. Přijetím úmluvy symbolizujeme a zároveň se i zavazujeme k potírání těchto forem násilí."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-49",
+      "answer": "yes",
+      "comment": "Zároveň je však potřeba zásadně investovat do obnovitelných zdrojů energie."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-54",
+      "comment": "Prosazuji princip “veřejné peníze za veřejné statky”. Platby, které zemědělci v rámci dotací dostávají, by měly kompenzovat zvýšené úsilí, které investují do aktivit výrazně nad rámec zákona. Typicky jde o péči o životní prostředí a lepší podmínky pro zvířata."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-56",
+      "answer": "no",
+      "comment": "Obce mají ten nejlepší předpoklad k tomu tuto situaci zvládnou. Obce znají potřeby obyvatel a výstavba městských bytů by tedy měla být v jejich režii. Stát by měl zajistit funkční legislativní rámec, případně metodickou podporu a pomoc k zajištění efektivního fungování trhu s bydlením."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-61-c-146752",
+      "question_id": "senatni-2022-61-q-58",
+      "comment": "Nejprve by měl existovat funkční právní rámec, který zajistí, že možnost zastavení exekuce nepovede ke zneužívání."
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-1",
+      "answer": "no",
+      "comment": "Není definována dlouhodobost, může se jednat o dlouhodobý pracovní pobyt v zahraničí apod. Jiný režim by měl být zaveden k vlastníkům nemovitostí, kteří si je drží s ohledem na jejich investiční záměr a nepronajímají je. Ale i zde je nutno definovat pojem dlouhodobosti. "
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-2",
+      "answer": "no",
+      "comment": "Lepší je cílená výstavba nízkometrážních sociálních nájemních bytů prostřednictvím obcí a obdobně družstevního bydlení."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-4",
+      "comment": "Za předpokladu, že se bude jednat o hlavní komunikační tratě spojené se strategií udržitelnosti ČR, tak ano. "
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-5",
+      "answer": "no",
+      "comment": "Stát by měl účinnými nástroji podporovat růst demografické křivky a zabezpečovat udržitelný trend v rámci produktivní populace. "
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-6",
+      "answer": "yes",
+      "comment": "Předložené materiály týkající se systémových opatření vláda ČR již 10 let nevykonávala  opatření proti suchu. Nejedná se jen o přehrady, ale o systém zavlažovacích kanálů a běžně dostupných standardních opatření proti vysychání vody v krajině. ČR je územím, ze kterého se voda odtéká, takže tato otázka a opatření s ní spojené jsou pro naši krajinu velmi důležité. "
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-8",
+      "answer": "no",
+      "comment": "Český daňový systém je nastaven poměrně úspěšně, což není případ daní z nemovitosti a systému soc. zabezpečení. "
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-9"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-10",
+      "comment": "Je nutno upravit otázku souhlasu či nesouhlasu s pohlavním stykem. Lze uvažovat o zvýšení dolní hranice trestní sazby. "
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-11",
+      "answer": "yes",
+      "comment": "Daňový systém je jedním z nejdůležitějších příjmů státu. Tyto společnosti na našem území dosahují svou činností nezanedbatelných zisků, což je nutno zohlednit. "
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-13",
+      "answer": "yes",
+      "comment": "V současnosti je vedena informační válka, je nutno jí zamezit. "
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-15"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-16",
+      "comment": "Jsem pro zrovnoprávnění instituce manželství v otázce majetkových a jiných práv, ale s ohledem na institut církevního sňatku, kde pravděpodobně nikdy nedojde k prosazení této myšlenky, je problematické garantovat tuto možnost.  "
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-17"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-19",
+      "answer": "yes",
+      "comment": "Je to nástroj, který podporuji místo regulaci nájmů. "
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-20",
+      "answer": "no",
+      "comment": "Stát musí přesně specifikovat osoby, které v této nouzi jsou. Zákon musí přesně definovat okruh těchto oprávněných osob. "
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-21",
+      "answer": "yes",
+      "comment": "Tuto problematiku bych spojil s revizí reformy organizace krajů v ČR. "
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-22",
+      "answer": "no",
+      "comment": "Nejdřív musíme zajistit, aby fungovala Česká republika. "
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-23",
+      "answer": "yes",
+      "comment": "Toto opatření je nutno spojit s adekvátním zabezpečením a zašifrováním jednotlivých hlasů tak, aby nedocházelo k falšování volebních výsledků a aby byla zajištěna ochrana jednotlivých voličů. Tento nástroj je potřebný nejen z hlediska posílení demokracie, ale i s ohledem na řešení pandemických situací a obdobných krizí. "
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-24",
+      "answer": "yes",
+      "comment": "Byť tato problematika souvisí s činností krajů, musí jít krajská aktivita ruku v ruce s politikou státu. "
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-26",
+      "answer": "yes",
+      "comment": "Asistenti a asistentky mají pomáhat slabším, ale výborné a talentované děti nesmí být ve svém růstu omezovány, právě naopak. "
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-27",
+      "answer": "no",
+      "comment": "Přes některé výhrady je členství v EU pro ČR nevyhnutelné. "
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-28",
+      "answer": "yes",
+      "comment": "Po náležitém přípravném procesu a přechodném období. Česká republika se k přijetí eura zavázala již v minulosti. Tento postup je nutné realizovat plánovaně. Ale toto téma nelze upřednostňovat před řešením jiných aktuálních palčivých problémů.  "
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-29",
+      "answer": "no",
+      "comment": "V současné bezpečnostní krizi by se jednalo o šílenství. "
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-30",
+      "answer": "yes",
+      "comment": "Pokud v EU, tak v jejím jádru. Dvourychlostní EU nemá význam. "
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-31"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-32"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-33",
+      "answer": "no",
+      "comment": "Usnadnit v případě uprchlické krize v rámci Ukrajiny jako krátkodobý nástroj, ale jinak musíme zachovávat bezpečnostní kritéria a dbát na ochranu zájmů občanů ČR a jejich bezpečí. "
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-35",
+      "answer": "yes",
+      "comment": "Lze spojit s přínosem armády pro státní správu, bojem proti živelným pohromám, pandemickým situacím atp. "
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-36",
+      "answer": "yes",
+      "comment": "Při současné krizi demografické křivky je nutno podpořit konstruktivním způsobem nástroje, které ji můžou změnit. "
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-37",
+      "answer": "yes",
+      "comment": "Zdravý životní styl by měl být benefitem při stanovení výše povinného zdravotního pojištění a naopak při nezdravém zdravotním stylu a sebedestruktivním chování by mělo být přistoupeno k vyššímu zdravotnímu pojištění. "
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-40",
+      "answer": "no",
+      "comment": "Jedná se mj. o významný příjem obcí. Je potřeba dbát na bezpečnostní a preventivní dopad. "
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-41",
+      "answer": "no",
+      "comment": "Ne, dokud jsou potřebné tyto nástroje v boji proti terorismu. "
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-42",
+      "answer": "yes",
+      "comment": "Jakmile splní všechna ekonomická a právní kritéria. Ne jako politický benefit - s ohledem na to, že je napadna nelze ustoupit těmto kritériím. "
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-43",
+      "answer": "yes",
+      "comment": "Jiný než bezpečnostní obranný systém není zárukou obrany proti agresivitě Ruska. "
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-44",
+      "answer": "yes",
+      "comment": "Jedná se o opatření řešení energetické krize. Zároveň iniciaci nutnosti systému dodávek z jiných států. Zastropováním také zajistíme, že agresor nebude mít dostatek finančních prostředků k vedení války. "
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-46",
+      "answer": "yes",
+      "comment": "Jako každá jiná země, která se dopustí takového jednání, které odporuje mezinárodnímu právu. "
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-47",
+      "comment": "Je rozdíl mezi vyjednáváním o zrušení anexe Krymu a navazováním standardních diplomatických vztahů."
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-48",
+      "answer": "yes",
+      "comment": "Boj proti domácímu násilí je podceňovaným, ale nesmírně důležitým tématem. "
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-49",
+      "answer": "no",
+      "comment": "Fosilní paliva je přechodně nutno využít k řešení energetické krize. "
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-51",
+      "answer": "no",
+      "comment": "Tento akt agrese není možno uznat, výjimečně se ztotožňuji s tureckým prezidentem Erdoganem. "
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-52",
+      "answer": "no",
+      "comment": "Systém individuálního postupu a zabezpečení finančních zdrojů pro vedení války pro Rusko se jeví z dlouhodobého hlediska jako velmi rizikový. Přistoupit k tomuto kroku lze až jako k poslední možnosti. "
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-53",
+      "answer": "yes",
+      "comment": "Jedná se o posílení evropské bezpečnostní platformy. "
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-54"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-56",
+      "answer": "yes",
+      "comment": "Je to jedno z řešení, jak vytvořit systém záchytného a sociálního bydlení. "
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-57",
+      "answer": "no",
+      "comment": "Historie se opakuje, nezapomínejme na Protektorát Čechy a Morava. "
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-61-c-330603",
+      "question_id": "senatni-2022-61-q-58",
+      "answer": "yes",
+      "comment": "Souvisí s racionálním systémem oddlužení. "
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-2"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-9"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-13"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-15"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-16"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-18"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-21"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-22"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-33"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-38",
+      "comment": "Jak v kterém medicinském oboru..."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-41"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-48"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-55"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-61-c-836627",
+      "question_id": "senatni-2022-61-q-58",
+      "answer": "yes"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/64.json
+++ b/data/kalkulacka/senatni-2022/64.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-64",
-  "name": "64",
-  "description": "64 - DESCRIPTION",
+  "name": "Bruntál",
+  "description": "Bruntál",
   "district_code": "64",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-64-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-64-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-64-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-64-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-64-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-64-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-64-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-64-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-64-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-64-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-64-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-64-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-64-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-64-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-64-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-64-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-64-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-64-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-64-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-64-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-64-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-64-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-64-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-64-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-64-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-64-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-64-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-64-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-64-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-64-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-64-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-64-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-64-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-64-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-64-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-64-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-64-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-64-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-64-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-64-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-64-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-64-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-64-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-64-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-64-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-64-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-64-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-64-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-64-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-64-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-64-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-64-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-64-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-64-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-64-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-64-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-64-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-64-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-64-candidate-337974",
+      "id": "senatni-2022-64-c-337974",
       "name": "Ladislav Šupina",
-      "type": "party",
+      "type": "person",
       "description": "Ladislav Šupina - DESCRIPTION",
       "contacts": {
         "web": [
@@ -492,7 +494,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-64-337974-party",
+          "id": "senatni-2022-64-c-337974-p",
           "name": "Ladislav Šupina",
           "description": "Ladislav Šupina - DESCRIPTION",
           "contacts": {
@@ -509,9 +511,9 @@
       ]
     },
     {
-      "id": "senatni-2022-64-candidate-188030",
+      "id": "senatni-2022-64-c-188030",
       "name": "Pavla Löwenthalová",
-      "type": "party",
+      "type": "person",
       "description": "Pavla Löwenthalová - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -519,7 +521,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-64-188030-party",
+          "id": "senatni-2022-64-c-188030-p",
           "name": "Pavla Löwenthalová",
           "description": "Pavla Löwenthalová - DESCRIPTION",
           "contacts": {
@@ -531,9 +533,9 @@
       ]
     },
     {
-      "id": "senatni-2022-64-candidate-419952",
+      "id": "senatni-2022-64-c-419952",
       "name": "Luděk Šarman",
-      "type": "party",
+      "type": "person",
       "description": "Luděk Šarman - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -541,7 +543,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-64-419952-party",
+          "id": "senatni-2022-64-c-419952-p",
           "name": "Luděk Šarman",
           "description": "Luděk Šarman - DESCRIPTION",
           "contacts": {
@@ -553,9 +555,9 @@
       ]
     },
     {
-      "id": "senatni-2022-64-candidate-542456",
+      "id": "senatni-2022-64-c-542456",
       "name": "Miroslava Hustáková",
-      "type": "party",
+      "type": "person",
       "description": "Miroslava Hustáková - DESCRIPTION",
       "contacts": {
         "web": [
@@ -568,7 +570,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-64-542456-party",
+          "id": "senatni-2022-64-c-542456-p",
           "name": "Miroslava Hustáková",
           "description": "Miroslava Hustáková - DESCRIPTION",
           "contacts": {
@@ -585,9 +587,9 @@
       ]
     },
     {
-      "id": "senatni-2022-64-candidate-298500",
+      "id": "senatni-2022-64-c-298500",
       "name": "Ladislav Václavec",
-      "type": "party",
+      "type": "person",
       "description": "Ladislav Václavec - DESCRIPTION",
       "contacts": {
         "web": [
@@ -604,7 +606,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-64-298500-party",
+          "id": "senatni-2022-64-c-298500-p",
           "name": "Ladislav Václavec",
           "description": "Ladislav Václavec - DESCRIPTION",
           "contacts": {
@@ -625,9 +627,9 @@
       ]
     },
     {
-      "id": "senatni-2022-64-candidate-419215",
+      "id": "senatni-2022-64-c-419215",
       "name": "Antonín Staněk",
-      "type": "party",
+      "type": "person",
       "description": "Antonín Staněk - DESCRIPTION",
       "contacts": {
         "web": [
@@ -644,7 +646,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-64-419215-party",
+          "id": "senatni-2022-64-c-419215-p",
           "name": "Antonín Staněk",
           "description": "Antonín Staněk - DESCRIPTION",
           "contacts": {
@@ -665,5 +667,371 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-1",
+      "answer": "yes",
+      "comment": "Nicméně je třeba upozornit i na fakt, že zdánlivě bohulibý záměr bude dál komplikovat český daňový systém a také na problematickou kontrolu obsazenosti bytů"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-7",
+      "answer": "no",
+      "comment": "Souhlasím s názorem, že v současnosti občané ČR velmi zodpovědně třídí odpad a případné zálohování PET lahví nevyřeší situaci, kdy nedochází k recyklaci, ale plasty jsou spalovány. Je třeba zajistit dohled nad recyklací separovaného plastového odpadu, případně vybudovat ekologické provozy na jeho zpracování a tak vytvořit nová pracovní místa například v regionech jako je právě můj volební obvod č. 64 Bruntálsko."
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-9",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-16",
+      "answer": "yes",
+      "comment": "Stejnopohlavní páry vstupující do registrovaného partnerství by měly mít stejná práva a povinnosti jako páry vstupující do manželství. Nicméně pokud jde o pojmenování takového soužití jsem konzervativní a považuji rozdílné označení takového soužití za správné. Termín manželství by měl zůstat vyhrazen pro svazek muže a ženy, termín registrované partnerství nechť pojmenovává svazek stejnopohlavních párů."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-23",
+      "answer": "no",
+      "comment": "Rozhodně nejsem zastáncem volby online po internetu neboť tato forma negarantuje přímou volbu (tj. volbu bez zprostředkovatele), nezajišťuje tajnost volby, nezajišťuje ani to, že volba bude osobní a nebude případně možné spojit voliče s jím odevzdaným hlasem."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-26",
+      "answer": "no",
+      "comment": "Doposud neexistují relevantní studie, které by potvrzovaly nebo vyvracely domněnku, že čím více inkluzivní školství bude, tím více to bude pomáhat slabším žáků zapojit se do kolektivu a motivovat je k učení. Osobně se domnívám, že aktuální pojetí inkluzivního školství je spíše kontraproduktivní a demotivující jak pro slabé žáky tak i pro průměrné a nadané žáky. "
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-27",
+      "answer": "no",
+      "comment": "Otázka vystoupení ČR z EU není na místě, nicméně sama EU a její nadnárodní orgány by měly více respektovat své vlastní motto \"Jednotná v rozmanitosti\" a tak respektovat odlišnosti jednotlivých členských států. Bez toho respektu k rozmanitosti bude EU jen novým žalářem národů.  "
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-31",
+      "answer": "no",
+      "comment": "Jsem přesvědčen, že ČR má podporovat zahraniční rozvojovou spolupráci a humanitární pomoc v takovém rozsahu a výši, která odpovídá jejím možnostem po té, co zabezpečí nezbytné potřeby svých občanů."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-32",
+      "answer": "no",
+      "comment": "Na tuto otázku neumím jednoznačně odpovědět, neboť ne vždy je možné zajistit nezbytné potřeby občanů ČR a současně brát ohled na rozvojové země."
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-33",
+      "answer": "no",
+      "comment": "Současné azylové zákony jsou dostačující a není potřeba je více liberalizovat."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-35",
+      "answer": "yes",
+      "comment": "Ani na tuto otázku není jednoznačná odpověď. Resort obrany je na jedné straně dlouhodobě podfinancovaný a zastaralá technika ohrožuje zejména zdraví a životy našich vojáků.  I proto by měla mít armáda dostatečné finanční prostředky na svou modernizaci. Je však také pravdou, že značné prostředky jsou vynakládány nesystémově a tudíž i nehospodárně, a to je třeba změnit. "
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-38",
+      "answer": "yes",
+      "comment": "Opět - pokud jde o centralizaci specializované lékařské péče, pak je zřejmě na místě tam, kde jde o mimořádně nákladnou nebo velmi individuální specifickou léčbu - tedy je potřeba v takovém případě jasně vymezit co je touto specializovanou léčbou myšleno. "
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-42",
+      "answer": "yes",
+      "comment": "Podmínkou by však mělo být splnění standardních přístupových podmínek, které si EU v minulosti stanovila a jejich splnění striktně vyžadovala od kandidátských zemí."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-43",
+      "answer": "no",
+      "comment": "Případné rozšiřování NATO o nové evropské státy zásadním způsobem mění rozložení sil v Evropě a mohlo by se stát bezpečnostním rizikem. Bez jednání a vyjednávání s těmi státy, které by se takovou politikou mohly cítit ohroženy, je případné rozšiřování NATO velmi rizikové."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-46",
+      "answer": "yes",
+      "comment": "Otázkou ale bude vymahatelnost takových reparací - viz historie."
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-53",
+      "answer": "yes",
+      "comment": "Případné rozšiřování NATO o nové evropské státy zásadním způsobem mění rozložení sil v Evropě a mohlo by se stát bezpečnostním rizikem. Bez jednání a vyjednávání s těmi státy, které by se takovou politikou mohly cítit ohroženy, je případné rozšiřování NATO velmi rizikové."
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-54",
+      "answer": "no",
+      "comment": "Zemědělské dotace mají být poskytovány tak, aby zajistily schopnost českých zemědělců obstát jak v konkurenci se zahraničním, tak i s ohledem na rostoucí ceny energií a dalších vstupních surovin - tedy bez ohledu na velikost."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-55",
+      "answer": "no",
+      "comment": "To je věc místních samospráv a stát by do tohoto problému vůbec neměl vstupovat."
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-64-c-419215",
+      "question_id": "senatni-2022-64-q-58",
+      "answer": "yes"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/67.json
+++ b/data/kalkulacka/senatni-2022/67.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-67",
-  "name": "67",
-  "description": "67 - DESCRIPTION",
+  "name": "Nový Jičín",
+  "description": "Nový Jičín",
   "district_code": "67",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-67-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-67-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-67-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-67-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-67-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-67-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-67-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-67-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-67-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-67-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-67-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-67-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-67-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-67-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-67-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-67-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-67-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-67-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-67-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-67-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-67-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-67-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-67-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-67-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-67-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-67-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-67-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-67-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-67-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-67-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-67-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-67-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-67-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-67-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-67-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-67-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-67-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-67-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-67-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-67-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-67-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-67-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-67-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-67-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-67-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-67-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-67-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-67-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-67-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-67-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-67-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-67-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-67-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-67-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-67-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-67-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-67-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-67-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-67-candidate-965702",
+      "id": "senatni-2022-67-c-965702",
       "name": "Jaromír Radkovský",
-      "type": "party",
+      "type": "person",
       "description": "Jaromír Radkovský - DESCRIPTION",
       "contacts": {
         "web": [
@@ -491,7 +493,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-67-965702-party",
+          "id": "senatni-2022-67-c-965702-p",
           "name": "Jaromír Radkovský",
           "description": "Jaromír Radkovský - DESCRIPTION",
           "contacts": {
@@ -507,9 +509,9 @@
       ]
     },
     {
-      "id": "senatni-2022-67-candidate-301471",
+      "id": "senatni-2022-67-c-301471",
       "name": "Jan Mužík",
-      "type": "party",
+      "type": "person",
       "description": "Jan Mužík - DESCRIPTION",
       "contacts": {
         "web": [
@@ -528,7 +530,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-67-301471-party",
+          "id": "senatni-2022-67-c-301471-p",
           "name": "Jan Mužík",
           "description": "Jan Mužík - DESCRIPTION",
           "contacts": {
@@ -551,9 +553,9 @@
       ]
     },
     {
-      "id": "senatni-2022-67-candidate-775013",
+      "id": "senatni-2022-67-c-775013",
       "name": "Petr Orel",
-      "type": "party",
+      "type": "person",
       "description": "Petr Orel - DESCRIPTION",
       "contacts": {
         "web": [
@@ -570,7 +572,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-67-775013-party",
+          "id": "senatni-2022-67-c-775013-p",
           "name": "Petr Orel",
           "description": "Petr Orel - DESCRIPTION",
           "contacts": {
@@ -591,9 +593,9 @@
       ]
     },
     {
-      "id": "senatni-2022-67-candidate-405244",
+      "id": "senatni-2022-67-c-405244",
       "name": "Ivana Váňová",
-      "type": "party",
+      "type": "person",
       "description": "Ivana Váňová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -611,7 +613,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-67-405244-party",
+          "id": "senatni-2022-67-c-405244-p",
           "name": "Ivana Váňová",
           "description": "Ivana Váňová - DESCRIPTION",
           "contacts": {
@@ -633,16 +635,16 @@
       ]
     },
     {
-      "id": "senatni-2022-67-candidate-745404",
+      "id": "senatni-2022-67-c-745404",
       "name": "Pavel Liška",
-      "type": "party",
+      "type": "person",
       "description": "Pavel Liška - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-67-745404-party",
+          "id": "senatni-2022-67-c-745404-p",
           "name": "Pavel Liška",
           "description": "Pavel Liška - DESCRIPTION",
           "contacts": {
@@ -653,9 +655,9 @@
       ]
     },
     {
-      "id": "senatni-2022-67-candidate-175924",
+      "id": "senatni-2022-67-c-175924",
       "name": "Dana Váhalová",
-      "type": "party",
+      "type": "person",
       "description": "Dana Váhalová - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -663,7 +665,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-67-175924-party",
+          "id": "senatni-2022-67-c-175924-p",
           "name": "Dana Váhalová",
           "description": "Dana Váhalová - DESCRIPTION",
           "contacts": {
@@ -675,9 +677,9 @@
       ]
     },
     {
-      "id": "senatni-2022-67-candidate-129902",
+      "id": "senatni-2022-67-c-129902",
       "name": "Leo Luzar",
-      "type": "party",
+      "type": "person",
       "description": "Leo Luzar - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -685,7 +687,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-67-129902-party",
+          "id": "senatni-2022-67-c-129902-p",
           "name": "Leo Luzar",
           "description": "Leo Luzar - DESCRIPTION",
           "contacts": {
@@ -697,5 +699,1131 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-1",
+      "answer": "yes",
+      "comment": "Jedná se o daň určovanou samosprávou obcí a měst a tak by to mělo zůstat, aby mohli regulovat bytové potřeby, které sami nejlépe znají. Nesouhlasím s plošným zdaněním v rámci ČR"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-2",
+      "answer": "yes",
+      "comment": "Ale to již v rámci obecního bytového fondu funguje a pomáhá to řešit tíživou ekonomickou situaci mnohých rodin."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-3",
+      "answer": "yes",
+      "comment": "Už dnes je pozdě na všeobecné referendum! To by řešilo otázky typu, manželství pro všechny, euro ano/ne a kdy, vícepohlavní identitu nebo znásilnění či adopci dětí, ale i trest smrt, eutanázii nebo naše členství v EU a NATO. Je velmi mnoho otázek, které čím dál více rozdělují společnost a bez referenda a znalosti většinového názoru rozdělovat budou."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-4",
+      "answer": "yes",
+      "comment": "Pokud opravdu chceme chránit životní prostředí musíme umožnit lidem efektivní a kvalitní hromadnou dopravu! Investice do potřebné infrastruktury také pomůže ekonomice ČR a nabídne různorodou práci za dobrou odměnu po mnoho let. "
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-5",
+      "answer": "no",
+      "comment": "Pokud nebude důchodový věk reflektovat fyzickou nebo psychickou náročnost povolání, je jednotný a prodlužující se věk nástupu penze pouze útěk od zodpovědnosti za kvalitní a důstojný život seniorů.    "
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-6",
+      "comment": "Otázka není jednoznačná v účelu výstavby a dosaženého efektu. Protipovodňové poldry nebo přehrady ochraňující vodu a obydlí občanů podporuji. Vodu jako byznys  odmítám."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-7",
+      "answer": "no",
+      "comment": "Třídění plastů v ČR zatím funguje právě díky zájmu o výkup PET láhví, když budou vratné nebude o ostatní plasty zájem pro ekonomickou neefektivitu. Souhlasil bych pokud by se k systému odpadového hospodářství a cirkulární ekonomice přistoupilo komplexně. Nesouhlasím s vyzobáním zlatých zrnek pro někoho a zbytek ať řeší někdo jiný! "
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-8",
+      "answer": "yes",
+      "comment": "Ale pouze v rámci minimálně 5 daňových pásem zohledňujících nízké příjmy a životní náklady pro důstojný život a mzdu ve výši, která umožní život bez dávek a podpor."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-9",
+      "comment": "Je rozdíl mezi pěstováním a užitím. Proč má být legalizováno pěstování?"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-10",
+      "comment": "Trest stanoví soudy a pokud se soudy nebo lidé v referendu shodnou na nutnosti tuto oblast zpřísnit potom podpořím tuto iniciativu."
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-11",
+      "answer": "yes",
+      "comment": "Proč jen tyto dvě nadnárodní společnosti, je jich přece více a proč by se nemělo progresívní zdanění týkat i právnických osob? Další a důležitější pro ekonomiku je potírání daňových rájů a různých optimalizací znamenajících pouze vyhnutí se daňové povinnosti na úkor států."
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-12",
+      "answer": "no",
+      "comment": "Nesouhlasím z jakoukoliv cenzurou názorů, myšlenek a postojů. Nechť každý jedinec-uživatel zodpovídá za své chování na síti."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-13",
+      "answer": "no",
+      "comment": "Nesouhlasím z jakoukoliv cenzurou názorů, myšlenek a postojů. Nechť každý jedinec-uživatel zodpovídá za své chování na síti. Zneužívání \"zprav\" nelze zabránit jejich nálepkováním, že jsou falešné. Jen a pouze pluralita, vysvětlování a důkazy jsou schopny řešit faleš, polopravdy a lži."
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-14",
+      "answer": "no",
+      "comment": "Že je ČT přikloněna k jednomu názoru neznamená, že ČRo nebo ČTK má být postiženo finančně. Zde pouze pluralita informací a návrat k seriózní novinařině může změnit veřejné mínění.  "
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-15",
+      "answer": "yes",
+      "comment": "Šmejdi pronikli do různých oborů kde cítí šanci rychle získat prachy. Práce musí zůstat zdrojem příjmu k důstojnému životu pracujících a ne rychlému zbohatnutí zprostředkovatelům!"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-16",
+      "comment": "Stejné podmínky. To by znamenalo i uzavřít manželství v kostele, synagoze nebo mešitě? Je to již vyjasněná otázka? A jakých dalších pohlaví se to má týkat?  To je otázka pro celostátní referendum nemyslíte? "
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-17",
+      "answer": "yes",
+      "comment": "Podporuji zrušení soukromých exekutorů a navrácením exekučních činností pod soudní moc."
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-18",
+      "answer": "yes",
+      "comment": "Když budou zrušeni soukromí exekutoři bude i tato otázka řešena soudem a bude zcela jednoznačná dle již platného zákona."
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-19",
+      "answer": "no",
+      "comment": "Pokud není definováno sociální bydlení není možné ani určit parametry sociálního bytu. Je nutná státní bytová výstavby prostřednictvím neziskových stavebních firem nebo družstevní bytová výstavba, vše v masovém měřítku. Tím dojde k uvolnění stávajících již dávno \"zaplacených\" bytů 30 až 70 let starých, a spolu s řešením danění více bytů nesloužících k vlastnímu uspokojení potřeb rodiny na bydlení přinese rychlé řešení i sociálního bydlení. Bydlení není investice, ale základní lidské právo!"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-20",
+      "answer": "yes",
+      "comment": "To je způsob objektivizace ekonomické i životní úrovně občanů a politici začnou díky tomu velice rychle hledat řešení problému. To je dnes příliš nezajíma a tisíce lidí díky tomu končí v exekucích, bez střech nad hlavou nebo i sebevraždou."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-21",
+      "answer": "yes",
+      "comment": "Decentralizace sídel státních institucí přinese kvalitativní změnu a povede k lepší státní správě spolu z pomůže s rozvojem regionům."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-22",
+      "answer": "yes",
+      "comment": "Kolonizace oblasti mezi Seinou a Rýnem potažmo Labem je prvořadá úkol každého Marťana z Čech, Moravy a Slezska - howgh."
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-23",
+      "answer": "no",
+      "comment": "Volit se musí \"nohama\" a osobně za plentou, pokud chceme mít zachovánu aspoň minimální míru důvěry ve volební proces. Měly by nás varovat události posledních let v zemích, kde tato  procedura vyhovují lenochům je zavedena. "
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-24",
+      "answer": "yes",
+      "comment": "Investice do vzdělávání v technických směrech je jednoznačně nákladnější než v rámci humanitních oborů. Chceme li pozvednout úroveň ekonomiky musíme být také připraveni i na investice do těchto technických oborů. Výsledky dosavadního směřování školství a následného kolapsu úrovně vzdělávání v ČR již vidíme."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-25",
+      "answer": "yes",
+      "comment": "Diskuse mezi reálnými odborníky o víceletých gymnáziích a o další budoucnosti paralelního školství poukazují na chybné předpoklady a \"elitářství\" vedoucí k přesvědčivým negatívním  výsledkům pro společnost."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-26",
+      "comment": "Termín inkluze byl zdiskreditován a zneužit ke zrušení fungujícího systému, který byl sice hlavně náš, ale dlouhodobě se osvědčil. To ale neznamená, že se nebude pomáhat  slabším žákům zapojit se do kolektivu a motivovat je k učení!"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-27",
+      "comment": "To by neměli rozhodovat politici, ale občané. Každopádně pokud nebude na stole k jednání rekonstrukce EU a návrat zpět ke společnému ekonomickému prostoru, potom dojde v brzké době k rozpadu Evropské únie. O všem, ale musí rozhodnout celostátní referendum! A to podporuji spolu s jeho brzkým vyhlášením."
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-28",
+      "comment": "To by neměli rozhodovat politici, ale občané. Záleží na podmínkách a výhodách pro naše občany. Opět se jedná o otázku celospolečenského významu a měly by o ní rozhodnout občané v referendu. Jeho vypsání podporuji. "
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-29",
+      "comment": "To by neměli rozhodovat politici, ale občané v celostátním referendu!"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-30",
+      "answer": "no",
+      "comment": "Z pohledu starých členů jsme osina a rádi by tak upravili hlasovací proces jednomyslnosti v základních věcech rozhodování EU."
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-31",
+      "answer": "no",
+      "comment": "Naše zahraniční pomoc je již nyní velmi štědrá a spíše bychom se měli zaměřit na efektivitu protože mnoho finanční pomoci končí v nesprávných rukou a nedorazí k potřebným."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-32",
+      "answer": "no",
+      "comment": " Máme reciproční mezinárodní smlouvy s drtivou většinou států světa i rozvojových zemí. Tam se tyto věci řeší. Nyní uzavíráme tyto smlouvy v rámci EU jako celek a nejsem si vědom nějakého neohleduplného zákonodárství."
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-33",
+      "answer": "no",
+      "comment": "Udělení azylu je jednoduché a jsme tomu svědky. Jednodušší snad už ani nemůže být protože je na našem území desetitisíce lidí o kterých nic nevíme ani kde nyní jsou. "
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-34",
+      "answer": "yes",
+      "comment": "Jedna z výhod EU, kterou občané jednoznačně oceňují."
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-35",
+      "answer": "no",
+      "comment": "Pokud armáda nedokáže smysluplně realizovat nákupy, jak jsme nyní svědky (transportéry, houfnice, tanky, stíhačky, drogy) a provází tato akvizice jeden problém za druhým, nemám důvěru, že více peněz znamená lepší armádu. "
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-36",
+      "answer": "no",
+      "comment": "To snad nikdo nemyslí vážně?"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-37",
+      "answer": "no",
+      "comment": "Nesouhlasím, aby si někdo mohl koupit léčení a druhý umřel jen proto, že nemá dost peněz! Proto jsem pro všeobecné a solidární zdravotní pojištění! "
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-38",
+      "comment": "Neorientuji se v této problematice a dám na radu odborníků."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-39",
+      "comment": "Neorientuji se v této otázce a je na zemědělských odbornících, aby dodali fakta a argumenty.."
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-40",
+      "answer": "yes",
+      "comment": "Pokud to bude sloužit ke zlepšení financování obcí na úkor řidičů mnohdy s nesmyslným umístěním radarů jen s cílem vybrat peníze. Ale ji to otázka opět pro referendum a třeba i v rámci obcí."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-41",
+      "answer": "yes",
+      "comment": "Bohužel vždy bude mít stát a tajné služby \"výjimku\" a tak je vaše otázka bezpředmětná. Vždyť už dnes se mají mazat náhodné odposlechy pořízené mimo soudní povolení a nikdo neví zda se tak děje a kde potom tyto odposlechy končí."
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-42",
+      "comment": "Až splní všechny podmínky pro členství, a sami občané Ukrajiny v referendu tak rozhodnou, ale nesouhlasím s žádnými výjimkami. "
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-43",
+      "comment": "Pokud občané Ukrajiny rozhodnou v referendu pak ano, ale stále je tu riziko dalších konfliktu stejně jako kdyby třeba Mexiko po referendu uzavřelo s Ruskem vojenskou dohodu. Já podporuji jednoznačně mír a je mi bujno ze všech, kteří vidí řešení problémů v jakékoliv válce!"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-44",
+      "answer": "yes",
+      "comment": "Ne jen Ruského, ale veškerého plynu a energií na evropském trhu (ten Ruský plyn je snad zatím nejlevnější ze všech, ne?). Ale stejně pokud Evropa neuzná jadernou energetiku za ekologickou a nepřestane odstavovat stávající elektrárny bez technického a ekonomického zdůvodnění, jen dle přání politiků a také nezačne řešit spekulace s emisními povolenkami je takto položená otázka hloupá a nic neříkající. U nás musí stát rychle získat zpět  100% ČEZu a zabezpečit tím levnou energii pro ČR a pouze nadbytek prodávat, to je otázka dní a týdnů. Vládo ukaž se zda vládneš ty, nebo ti vládne ČEZ! "
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-45",
+      "comment": "Nesleduji práci úřadu ombudsmana a tak nevím zda jsou lidé s jejich prací spokojeni. Já hodnotím oficiální výstupy a zatím nemám osobně důvod kritizovat nebo chválit."
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-46",
+      "answer": "yes",
+      "comment": "Jsem odpůrce všech válek a ti co je vyvolali by vždy měli být potrestání a nést následky, bez rozdílu. A Rusko už následky nese a bude tímto poznamenáno na dlouhá léta minimálně na Ukrajině, ale i doma, protože smrt lidí nikdy není bez následků. A jak známe z nedávné historie, válka nikdy nepřinesla mír, ale jen utrpení. Bohužel se ale i na válkách dá dělal kšeft."
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-47",
+      "comment": "Nás nikdo k nějakému vyjednávání nepotřebuje, jsme jen stát střední velikosti pod kuratelou velkých a vlivných států v EU a měli by jsme si uvědomit, že až nám zavedli tak holt půjdeme tam, kde nám řeknou. Samostatnou Českou zahraniční politiku už velmi dlouho neděláme a snad jen za první republiky jsme tyto tendence měli. "
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-48",
+      "comment": "Neznám ji tak nevím."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-49",
+      "answer": "no",
+      "comment": "Ano jen za předpokladu, že bude k dispozici dost levné a alternativní elektrické energie a taky tepla. Stále se zapomíná, že statisíce lidí jsou závislí na centralizovaném zásobování teplem! "
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-50",
+      "answer": "no",
+      "comment": "Rád bych aby tomu tak bylo, ale to co EU předvádí poslední roky mě překvapuje, že dělá vše proto, aby naštvala své občany a pohřbila všechny naděje na technologický rozvoj. Pokud neuvidím technické a ekonomické podklady, tak mě pouze zbožná přání nemohou přesvědčit pro podporu. "
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-51",
+      "answer": "yes",
+      "comment": "Když jsem uznali Kosovo tak nám nic jiného nezbývá na rozdíl třeba od Slovenska. Jsem zastáncem práva na sebeurčení a sice se nám to nemusí líbit, ale i Katalánci mají právo na svou zem nebo třeba Baskové či Skotové, podmínkou je ovšem referendum! My bychom  měli spíše spitovat svědomí za rozdělení Masarykova dítěte Československa bez referenda, se kterým jsem se nikdy nesmířil. "
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-52",
+      "answer": "yes",
+      "comment": "Stejně jako ostatní státy EU závislé na plynu z Ruska s ním jednají tak i my buď získáme tentýž Ruský plyn od těchto státu, ale bohužel za jinou spekulatívní cenu, nebo si jej nakoupíme sami. Je pokrytecké a vůči vlastním občanům zločinné nutit je kupovat tentýž plyn, jen z jiné trubky a dráž. A nebo využít voleb a uspořádat referendum k těmto otázkám."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-53",
+      "answer": "yes",
+      "comment": "Pokud to chtějí občané Finska a Švédska."
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-54",
+      "comment": "Nejsem odborník na zemědělství, jen budu rád za efektivní využití podpory a schopnost uživit co nejvíce našich občanů z produkce naší země."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-55",
+      "comment": "To jsme opravdu na tak bídné sociální úrovni v 21.století??? Státe styď se!!!"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-56",
+      "answer": "yes",
+      "comment": "Proč ne, ale hlavní je aby je stát stavěl prostřednictvím státní a neziskové výstavby. To vše spolu s podporou družstevní výstavby."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-57",
+      "comment": "Je věcí Ukrajiny jak se rozhodne ukončit tuto válku, ale rozhodně by neměli poslouchat lidi sedící v cizině a bezpečí vládních rezidencí. "
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-67-c-129902",
+      "question_id": "senatni-2022-67-q-58",
+      "answer": "yes",
+      "comment": "Už dávno tak má stát činit, ale zastavovat je hlavně na úkor těch institucí, které i po prověření dlužníka a zjištění, že dluží kde se podívá mu přesto půjčí. Ty bych naopak sankcionoval, jsou to totiž šmejdi snažící se vydělat na neštěstí lidí."
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-1",
+      "answer": "no",
+      "comment": "Nejsem pro zbytečné zasahování státu do volného trhu, který má řídit nabídka a poptávka. Jsem odpůrce mnohých regulací, nadbytečného zdanění všeho a dalších legislativních marasmů, které k nám přicházejí ze všech stran a zejména z EU."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-2",
+      "answer": "no",
+      "comment": "Nejsem pro zbytečné zasahování státu do volného trhu, který má řídit nabídka a poptávka. Jsem odpůrce mnohých regulací, nadbytečného zdanění všeho a dalších legislativních marasmů, které k nám přicházejí ze všech stran a zejména z EU."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-3",
+      "answer": "yes",
+      "comment": "Souhlasím, ale pouze v případě počtu více jak 50% počtu občanů způsobilých k volbám. Petiční podpisy musí být řádně, či digitálně překontrolovány (např. blockchain) a až na základě výsledků této ověřené petice, která projevuje většinový pohled na situaci v naší zemi zahájit referendum o tom, či onom problému, který národ trápí."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-4",
+      "answer": "no",
+      "comment": "Nejsem odborník na dopravu, ale jeden aspekt by neměl být upřednostňován na úkor druhého. Výstavba dopravní infrastruktury by měla být kontinuální, navzájem navazující na další projekty a hlavně řádně a transparentně vysoutěžená včetně ekonomicky udržitelné a vysoutěžené následné správy."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-5",
+      "answer": "no",
+      "comment": "Nemyslím si, občané v tomto věku by již měli mít nárok za své odvody do solidárního důchodového systému spočinout v důchodu a stát by se o ně postarat tak, aby měli důstojné stáří. Náš důchodový systém je založen na takovém zvláštním sytému přerozdělování financí a reformu tohoto systému nám slibuje každá vláda, která je a přijde."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-6",
+      "comment": "Bohužel nejsem profesionální vodohospodář, ale je mi jasné, že tato problematika má dvě strany jako mince. Na jednu stranu přehrady zadržují vodu v krajině a dokážeme takto vodu a její kapacity uměle korigovat v nezávislosti na počasí a delším suchům. Druhá strana je ale v stále se zvyšující se ztrátě přirozené krajiny, živočichů, kteří nemohou migrovat, vylidňování  a ztrátě obydlí v zatopených oblastech, což nese s sebou i zásah do životů obyvatel. Je to podle mě komplexní téma a mělo by se k němu přistupovat velice obezřetně a vyhodnocovat všechny dopady na nově vznikající přehrady a přehradní systémy na našich řekách."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-7",
+      "answer": "yes",
+      "comment": "V tomto případě jsem pro zálohování a hlavně využívání ekologických a volně rozložitelných materiálů v přírodě. Jakákoliv záloha na obal motivuje koncového spotřebitele ten obal navrátit do oběhu za své peníze a nedovoluje mu ho jen tak někde pohodit a následně devastovat naši krajinu a životní prostředí."
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-8",
+      "answer": "yes",
+      "comment": "Vždy jsem zastával progresivní zdanění. Samozřejmě je diskutabilní limit a výše, ale tohle bych nechal na odbornících, nebo se s nimi rád i pobavil, jaké dopady to bude mít na mnoho aspektů ekonomiky, jak už makro, tak lokální ve spojitosti s kraji a jejich příjmy. Na všechno existují matematické a statistické modely, takže bych vybíral bod zvratu, který určí ty správné výše a limity pro progresivní zdanění v daném čase a hospodářské kondici naší země."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-9",
+      "answer": "yes",
+      "comment": "Zastávám tezi, že svobodné rozhodování o své léčbě a jejích dopadech je na každém z nás a proti THC, CBD, CBG a dalším kanabinoidům nemám žádné výhrady, pokud se užívají pro vlastní potřebu."
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-10",
+      "answer": "yes",
+      "comment": "Tresty zvýšit a hlavně jasně definovat co to \"znásilnění\" je, takže změna trestněprávního výkladu jdoucí ruku v ruce s legislativními parametry tohoto paragrafu."
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-11",
+      "answer": "yes",
+      "comment": "Nadnárodní korporace tohoto typu by měli odvádět určitě více financí do rozpočtu naší země, když už je z ní vytahují. Jsem pro tyto speciální daně nadnárodních koncernů všude ve světě."
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-12",
+      "answer": "yes",
+      "comment": "Určitě ano a ty technologie na to mají!"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-13",
+      "answer": "no",
+      "comment": "Určitě ne, neboť kdo bude rozhodovat o tom v dnešním divokém světě naší civilizace, co je pravda, co je lež, co je relevantní a ověřený zdroj informací a co už je fakenews. Nechal bych tomu prostor, nic necenzuroval a už vůbec nezasahoval do svobody projevu, kdekoliv a kdykoliv a konečný čtenář, nebo uživatel dané sítě ať si udělá obrázek sám. Jsem proti jakékoliv cenzuře a filtrování informací ve všech médiích po celém světě."
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-14",
+      "answer": "yes",
+      "comment": "Veřejnoprávní média totálně selhávají, informují tendenčně na základě politické objednávky a jejich produkce je nedostačující v poměru příjmů z veřejného rozpočtu, kterým disponují."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-15",
+      "answer": "no",
+      "comment": "Jsem pro volný trh práce i institucí, které se na něm podílí."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-16",
+      "answer": "no",
+      "comment": "Manželství a z tohoto stavu plynoucí práva a povinnosti jsou určeny pouze pro Muže a Ženu, tak jak to je zařízeno v přírodě, prostě existují jen dvě pohlaví a pak už jen hermafroditi na jiné evoluční úrovni, než je člověk."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-17",
+      "answer": "yes",
+      "comment": "Určitě ano a zabránilo by to tak obchodování s chudobou a prohlubování dluhové spirály."
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-20",
+      "answer": "no",
+      "comment": "Na vojně se říká \"Voják se stará, voják má\", takže každý ať se stará!"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-21",
+      "answer": "yes",
+      "comment": "Určitě ano, v rámci možností a hlavně ekonomické udržitelnosti."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-22",
+      "answer": "yes",
+      "comment": "Nemám s tím problém, naše vědce a AV považuji za světové pracoviště, které by mělo dostávat více z veřejných rozpočtů a pomáhat tak svým dílem k celosvětové progresi naší civilizace do vesmíru a tamních objevů. Nepovažuji to však za prioritu, neboť v naší zemi máme více než dost problémů sami se sebou, než kolonizovat Mars. Prvně si stabilizovat naši Českou republiku a až pak vzhlížet ke hvězdám a planetám."
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-23",
+      "answer": "yes",
+      "comment": "Určitě ano, formou decentralizované databáze (blockchain) s jasným ověřovacím tokenem a volby by byly dokonale transparentní ve všech směrech."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-24",
+      "answer": "no",
+      "comment": "Jsem pro \"rovnoprávnost\" mezi jednotlivými akademickými obory a neupřednostňoval bych jeden před druhým."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-25",
+      "answer": "yes",
+      "comment": "Určitě ano!"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-26",
+      "answer": "no",
+      "comment": "Jsem odpůrce inkluze, zejména v našem školství a pojetí."
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-27",
+      "answer": "no",
+      "comment": "Ale určitě bych velmi důrazně korigoval její legislativu a jsem zastáncem toho, že v mnoha směrech nemáme a neměli bychom podléhat bruselským nařízením a tu naši krásnou zem si spravovat sami, dle racionality a kulturních hodnot, ne diktátem bezdětných a úplatných elitních politiků EU."
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-28",
+      "answer": "no",
+      "comment": "Určitě ne, jsem zastáncem české koruny a vlastní měny."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-29",
+      "answer": "no",
+      "comment": "Určitě ne. Akorát jsem odpůrce vojenské logistické základny v Mošnově, neboť je to velmi zbytečný projekt a Letiště Leoše Janáčka Ostrava má sloužit k civilním účelům, zejména cargo privátní přepravě. Je to komplexnější téma a kdyby někdo chtěl, rád se k němu také komplexně vyjádřím."
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-30",
+      "answer": "yes",
+      "comment": "Ano, už geologicky tam minimálně je."
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-31",
+      "answer": "no",
+      "comment": "Nevidím důvod, proč by měla."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-32",
+      "answer": "no",
+      "comment": "Neumíme se postarat o náš stát a český národ, tak nevím proč bychom se měli více starat o klima. Pojďme stabilizovat naši Českou republiku a až posléze se zaobírat opatřeními zabraňujícímu změně klimatu, které se stejně mění samovolně už přes několik miliard let co je planeta Země našim domovem."
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-33",
+      "answer": "no",
+      "comment": "Určitě ne, tyhle azyly se zneužívají a stejně se už nyní rozdávají na počkání."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-34",
+      "answer": "yes",
+      "comment": "Určitě ano."
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-35",
+      "answer": "yes",
+      "comment": "Určitě ano, bezpečnostní situace v celém světě je napjatá a musíme se alespoň bránit, ale ne s tou paní Černochovou v čele!"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-36",
+      "answer": "no",
+      "comment": "Jsem proti genetickým úpravám embrya v jakémkoliv stádiu. Zastávám tezi, že příroda ví co je správné a člověk by si neměl hrát na Boha."
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-37",
+      "answer": "yes",
+      "comment": "Může být, ale ta následná péče musí být dostupná a vymahatelná."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-38",
+      "answer": "no",
+      "comment": "Nevidím důvod."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-39",
+      "comment": "Nejsem ekolog a ani biolog, takže Vám na tohle nedokážu odpovědět."
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-40",
+      "answer": "no",
+      "comment": "Určitě ne, je to výborný nástroj na neslušné řidiče porušujíc dopravní předpisy při provozu svých vozidel na pozemních komunikacích."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-41",
+      "answer": "no",
+      "comment": "Je to nutné zlo budoucnosti a evoluce lidské populace. Jen zastávám názor, že kontrola, monitorování a shromažďování těchto dat by měla být pod přísným dohledem, nezneužitelná a neměla by zasahovat do soukromí jedince, jako občana."
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-42",
+      "answer": "no",
+      "comment": "Bohužel nejsem zastáncem vstupu této země do EU. Nepovažuji ji za plnohodnotnou evropskou zemi s dostatečně vyvinutou ekonomikou, nekorupční vládou a netendenční zahraniční politikou."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-43",
+      "answer": "no",
+      "comment": "Určitě ne, nepatří do \"severoatlantické aliance\", měla by směřovat do \"východní aliance\", kde vždy patřila a patří."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-44",
+      "answer": "no",
+      "comment": "Nevidím důvod proč by stát, nebo EU měli někomu diktovat ceny. Jsem pro neviditelnou ruku trhu, kdy se cena odvíjí jako bod zvratu při střetu nabídky s poptávkou."
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-45",
+      "answer": "no",
+      "comment": "Určitě ne, nekoná a úřad je v rozkladu z důvodů neshod ombudsmana s jeho asistentkou."
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-46",
+      "comment": "Tole je komplexní geopolitické téma, mám na to svůj názor, ale je to na delší elaborát."
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-47",
+      "answer": "no",
+      "comment": "Možná nerozumím otázce, ale proč by čeští zákonodárci měli o něčem jednat a ještě na Krymu? Nevidím důvod proč by měli jezdit na Krym."
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-48",
+      "answer": "yes",
+      "comment": "Určitě ano."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-49",
+      "answer": "no",
+      "comment": "Bohužel není na to naše země ještě připravena."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-50",
+      "answer": "no",
+      "comment": "Nejdříve bych stabilizoval Českou republiku jako takovou, eliminoval její energetické a soběstačné problémy uvnitř a až pak bych se staral o klima a neutralitu."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-51",
+      "comment": "Tole je komplexní geopolitické téma, mám na to svůj názor, ale je to na delší elaborát."
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-52",
+      "answer": "yes",
+      "comment": "Určitě ano, aby zabezpečilo plyn pro své občany, podniky a infrastrukturu v dostatečném množství a za přijatelnou cenu."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-53",
+      "answer": "yes",
+      "comment": "Určitě ano, tyto země považuji za \"severoatlantické\"."
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-54",
+      "answer": "yes",
+      "comment": "Ano, nyní jsou bohužel dotace zneužívány velkými zemědělci, respektive jejich podniky a není to správné. Dotace, když už jsou v jakémkoliv ekonomickém odvětví by měli být efektivní, účelové a věcné, nikoliv zneužitelné, tendenční a plošné."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-55",
+      "answer": "no",
+      "comment": "Nevidím důvod. Stát by neměl suplovat nějakou drogerii. Pokud na to žena finančně nemá, existují další alternativní způsoby, které využívali ženy odjakživa a není tomu tak dávno, kdy v naší zemi nebyly vložky a tampony. Nijak nesnižuji tyto ženské hygienické potřeby, dámy prominou, ale opravdu nevidím důvod proč by úřady se měli zaobírat touto problematikou."
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-56",
+      "answer": "no",
+      "comment": "Určitě ne, je a má to být volný trh, ekonomicky udržitelný a tímto krokem bychom se vraceli do reálného socialismu s plánovaným hospodářstvím a to určitě nechci."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-57",
+      "comment": "Tole je komplexní geopolitické téma, mám na to svůj názor, ale je to na delší elaborát."
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-67-c-301471",
+      "question_id": "senatni-2022-67-q-58",
+      "answer": "yes",
+      "comment": "Ano, aby člověk měl ještě nějakou šanci v životě uspět, druhý pokus a svou produktivitou alespoň přispět společnosti. Tato legislativa by měla být ale důkladně vypracovaná proti zneužití a \"oddlužení\" každého dlužníka, který by se jen spekulativně vyhnul zaplacení svých dluhů."
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-1",
+      "comment": "Krize s energiemi  a příliv lidí dotčených válkou, byla příležitostí k opatření pro dostupnější bydlení pro mladé rodiny, samoživitele a seniory. Obce mají přispívat na tržní nájemné pro tyto skupiny lidí a vytvářet fond bydlení, nebo obecní byty. Ten kdo podniká pronájmem bytů musí vše řádně danit."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-2",
+      "answer": "yes",
+      "comment": "V této době především zastropovat ceny energií."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-4"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-6",
+      "answer": "yes",
+      "comment": "Především malých přehrad s přečerpávacími vodními elektrárnami. Řeší problém s vodou i energií."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-8",
+      "answer": "yes",
+      "comment": "Nízkopříjmové skupiny mají vysoké zdanění práce a tím zatěžujeme strukturálně znevýhodněné regiony kde lidé chudnou."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-9"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-10",
+      "answer": "yes",
+      "comment": "Není možné, aby za krádeže byly větší tresty než za násilné TČ "
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-14"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-16",
+      "comment": "Institut manželství byl právně ukotven za účelem  vytváření rodiny, jako jednotky  společenství, národa a státu. Pokud jakýkoliv pár splňuje tyto podmínky nemám námitek.  "
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-17",
+      "answer": "yes",
+      "comment": "Jsem pro návrat exekutorů pod soudní moc. Nyní dlužník platí víc exekutorovi než věřiteli."
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-20",
+      "answer": "no",
+      "comment": "Stát by měl především vytvářet podmínky, aby občan v nouzi nebyl. "
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-22"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-23"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-24"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-25",
+      "answer": "no",
+      "comment": "Dítě by mělo mít šanci rozvíjet svůj talent např. hudební či sportovní.  "
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-26"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-28",
+      "comment": "Otázka ke které by se měli vyjádřit občané."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-29"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-30",
+      "answer": "yes",
+      "comment": "Tato otázka je na rozhodnutí občanů."
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-32"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-35"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-36"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-37",
+      "answer": "yes",
+      "comment": " V případě že lékařská péče bude dostupná všem stejně a bude se jednat o nadstandard."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-41"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-44"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-46"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-50"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-51"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-53"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-54",
+      "answer": "yes",
+      "comment": "Podporuji dotace do českého zemědělství  které zajišťuje potraviny,   tvoří krajinu,  podporuje rozšíření služeb na venkově a zamezuje vylidňování. Konkurenceschopnost a zajištění potravinové soběstačnosti je velmi důležité téma ať se jedná o malé či velké zemědělské a potravinářské  podniky."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-55"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-56",
+      "answer": "no",
+      "comment": "Bytová politika by měla být realizována na úrovni obcí."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-57"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-67-c-175924",
+      "question_id": "senatni-2022-67-q-58"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/7.json
+++ b/data/kalkulacka/senatni-2022/7.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-7",
-  "name": "7",
-  "description": "7 - DESCRIPTION",
+  "name": "Plzeň-město",
+  "description": "Plzeň-město",
   "district_code": "7",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-7-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-7-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-7-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-7-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-7-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-7-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-7-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-7-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-7-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-7-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-7-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-7-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-7-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-7-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-7-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-7-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-7-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-7-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-7-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-7-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-7-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-7-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-7-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-7-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-7-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-7-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-7-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-7-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-7-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-7-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-7-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-7-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-7-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-7-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-7-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-7-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-7-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-7-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-7-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-7-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-7-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-7-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-7-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-7-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-7-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-7-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-7-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-7-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-7-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-7-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-7-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-7-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-7-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-7-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-7-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-7-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-7-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-7-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-7-candidate-883400",
+      "id": "senatni-2022-7-c-883400",
       "name": "Jiří Valenta",
-      "type": "party",
+      "type": "person",
       "description": "Jiří Valenta - DESCRIPTION",
       "contacts": {
         "web": [
@@ -502,7 +504,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-7-883400-party",
+          "id": "senatni-2022-7-c-883400-p",
           "name": "Jiří Valenta",
           "description": "Jiří Valenta - DESCRIPTION",
           "contacts": {
@@ -529,9 +531,9 @@
       ]
     },
     {
-      "id": "senatni-2022-7-candidate-401024",
+      "id": "senatni-2022-7-c-401024",
       "name": "Jan Kůrka",
-      "type": "party",
+      "type": "person",
       "description": "Jan Kůrka - DESCRIPTION",
       "contacts": {
         "web": [
@@ -544,7 +546,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-7-401024-party",
+          "id": "senatni-2022-7-c-401024-p",
           "name": "Jan Kůrka",
           "description": "Jan Kůrka - DESCRIPTION",
           "contacts": {
@@ -561,9 +563,9 @@
       ]
     },
     {
-      "id": "senatni-2022-7-candidate-519910",
+      "id": "senatni-2022-7-c-519910",
       "name": "Pavel Šrámek",
-      "type": "party",
+      "type": "person",
       "description": "Pavel Šrámek - DESCRIPTION",
       "contacts": {
         "web": [
@@ -582,7 +584,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-7-519910-party",
+          "id": "senatni-2022-7-c-519910-p",
           "name": "Pavel Šrámek",
           "description": "Pavel Šrámek - DESCRIPTION",
           "contacts": {
@@ -605,9 +607,9 @@
       ]
     },
     {
-      "id": "senatni-2022-7-candidate-801538",
+      "id": "senatni-2022-7-c-801538",
       "name": "Václav Chaloupek",
-      "type": "party",
+      "type": "person",
       "description": "Václav Chaloupek - DESCRIPTION",
       "contacts": {
         "web": [
@@ -621,7 +623,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-7-801538-party",
+          "id": "senatni-2022-7-c-801538-p",
           "name": "Václav Chaloupek",
           "description": "Václav Chaloupek - DESCRIPTION",
           "contacts": {
@@ -639,9 +641,9 @@
       ]
     },
     {
-      "id": "senatni-2022-7-candidate-582714",
+      "id": "senatni-2022-7-c-582714",
       "name": "Daniela Kovářová",
-      "type": "party",
+      "type": "person",
       "description": "Daniela Kovářová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -663,7 +665,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-7-582714-party",
+          "id": "senatni-2022-7-c-582714-p",
           "name": "Daniela Kovářová",
           "description": "Daniela Kovářová - DESCRIPTION",
           "contacts": {
@@ -689,9 +691,9 @@
       ]
     },
     {
-      "id": "senatni-2022-7-candidate-161426",
+      "id": "senatni-2022-7-c-161426",
       "name": "Josef Váňa",
-      "type": "party",
+      "type": "person",
       "description": "Josef Váňa - DESCRIPTION",
       "contacts": {
         "web": [
@@ -704,7 +706,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-7-161426-party",
+          "id": "senatni-2022-7-c-161426-p",
           "name": "Josef Váňa",
           "description": "Josef Váňa - DESCRIPTION",
           "contacts": {
@@ -721,9 +723,9 @@
       ]
     },
     {
-      "id": "senatni-2022-7-candidate-189360",
+      "id": "senatni-2022-7-c-189360",
       "name": "Karel Naxera",
-      "type": "party",
+      "type": "person",
       "description": "Karel Naxera - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -732,7 +734,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-7-189360-party",
+          "id": "senatni-2022-7-c-189360-p",
           "name": "Karel Naxera",
           "description": "Karel Naxera - DESCRIPTION",
           "contacts": {
@@ -745,5 +747,696 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-7"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-9",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-17"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-25",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-27"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-46",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-53"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-57"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-7-c-883400",
+      "question_id": "senatni-2022-7-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-10",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-17",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-18",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-34",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-39",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-46",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-53",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-54",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-57",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-7-c-582714",
+      "question_id": "senatni-2022-7-q-58",
+      "answer": "yes"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/70.json
+++ b/data/kalkulacka/senatni-2022/70.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-70",
-  "name": "70",
-  "description": "70 - DESCRIPTION",
+  "name": "Ostrava-město",
+  "description": "Ostrava-město",
   "district_code": "70",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-70-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-70-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-70-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-70-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-70-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-70-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-70-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-70-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-70-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-70-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-70-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-70-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-70-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-70-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-70-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-70-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-70-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-70-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-70-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-70-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-70-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-70-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-70-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-70-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-70-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-70-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-70-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-70-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-70-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-70-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-70-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-70-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-70-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-70-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-70-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-70-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-70-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-70-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-70-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-70-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-70-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-70-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-70-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-70-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-70-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-70-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-70-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-70-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-70-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-70-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-70-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-70-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-70-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-70-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-70-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-70-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-70-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-70-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,16 +479,16 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-70-candidate-523255",
+      "id": "senatni-2022-70-c-523255",
       "name": "Radoslav Štědroň",
-      "type": "party",
+      "type": "person",
       "description": "Radoslav Štědroň - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-70-523255-party",
+          "id": "senatni-2022-70-c-523255-p",
           "name": "Radoslav Štědroň",
           "description": "Radoslav Štědroň - DESCRIPTION",
           "contacts": {
@@ -497,9 +499,9 @@
       ]
     },
     {
-      "id": "senatni-2022-70-candidate-894640",
+      "id": "senatni-2022-70-c-894640",
       "name": "Zdeněk Nytra",
-      "type": "party",
+      "type": "person",
       "description": "Zdeněk Nytra - DESCRIPTION",
       "contacts": {
         "web": [
@@ -517,7 +519,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-70-894640-party",
+          "id": "senatni-2022-70-c-894640-p",
           "name": "Zdeněk Nytra",
           "description": "Zdeněk Nytra - DESCRIPTION",
           "contacts": {
@@ -539,9 +541,9 @@
       ]
     },
     {
-      "id": "senatni-2022-70-candidate-397158",
+      "id": "senatni-2022-70-c-397158",
       "name": "Liana Janáčková",
-      "type": "party",
+      "type": "person",
       "description": "Liana Janáčková - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -549,7 +551,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-70-397158-party",
+          "id": "senatni-2022-70-c-397158-p",
           "name": "Liana Janáčková",
           "description": "Liana Janáčková - DESCRIPTION",
           "contacts": {
@@ -561,16 +563,16 @@
       ]
     },
     {
-      "id": "senatni-2022-70-candidate-550066",
+      "id": "senatni-2022-70-c-550066",
       "name": "Miroslav Antl",
-      "type": "party",
+      "type": "person",
       "description": "Miroslav Antl - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-70-550066-party",
+          "id": "senatni-2022-70-c-550066-p",
           "name": "Miroslav Antl",
           "description": "Miroslav Antl - DESCRIPTION",
           "contacts": {
@@ -581,9 +583,9 @@
       ]
     },
     {
-      "id": "senatni-2022-70-candidate-254017",
+      "id": "senatni-2022-70-c-254017",
       "name": "Peter Harvánek",
-      "type": "party",
+      "type": "person",
       "description": "Peter Harvánek - DESCRIPTION",
       "contacts": {
         "web": [
@@ -600,7 +602,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-70-254017-party",
+          "id": "senatni-2022-70-c-254017-p",
           "name": "Peter Harvánek",
           "description": "Peter Harvánek - DESCRIPTION",
           "contacts": {
@@ -621,16 +623,16 @@
       ]
     },
     {
-      "id": "senatni-2022-70-candidate-635788",
+      "id": "senatni-2022-70-c-635788",
       "name": "Patrik Hujdus",
-      "type": "party",
+      "type": "person",
       "description": "Patrik Hujdus - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-70-635788-party",
+          "id": "senatni-2022-70-c-635788-p",
           "name": "Patrik Hujdus",
           "description": "Patrik Hujdus - DESCRIPTION",
           "contacts": {
@@ -641,16 +643,16 @@
       ]
     },
     {
-      "id": "senatni-2022-70-candidate-938712",
+      "id": "senatni-2022-70-c-938712",
       "name": "Hana Zelená",
-      "type": "party",
+      "type": "person",
       "description": "Hana Zelená - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-70-938712-party",
+          "id": "senatni-2022-70-c-938712-p",
           "name": "Hana Zelená",
           "description": "Hana Zelená - DESCRIPTION",
           "contacts": {
@@ -661,5 +663,377 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-3",
+      "answer": "yes",
+      "comment": "už podle ústavy, zločinci, kteří jsou dnes u moci se referenda bojí jako čert kříže"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-5",
+      "answer": "no",
+      "comment": "to mohou hýkat jen ti co nikdy fysicky nepracovali"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-6",
+      "answer": "yes",
+      "comment": "že jsme střechou Evropy znamená - pokud nám nenaprší, nenasněží jsme bez vody, proto si ji tu musíme schraňovat - na té střeše - kapito?"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-7",
+      "comment": "plechovky ano s petkama je to těžké"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-12"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-13"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-16",
+      "answer": "no",
+      "comment": "největším vynálezem Boha - je rodina"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-22",
+      "answer": "no",
+      "comment": "třeba  i Jupiter, co?"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-25",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-27",
+      "answer": "yes",
+      "comment": "závazným referendem (o jehož výsledku parlament ani nešpitne); víte vůbec, že referendum v roce 2003 rozhodlo pro vstup pouze 3,4 miliony hlasů z celkového počtu voličů, který byl 8 200 000? Víte to? Co? Víte to vůbec?"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-28",
+      "answer": "no",
+      "comment": "v roce 2003 jsme o podmínkách zavedední Eura, které dnes platí, nevěděli vůbec nic - takže to dnes neplatí, že jsme se k něčemu tehdáž zavázali - rozumíte tomu?"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-29",
+      "answer": "yes",
+      "comment": "je to zločinecká organizace - ale rozhodnutí musí být pouze závazným referendem"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-31",
+      "answer": "no",
+      "comment": "neumíte položit otázku - potřebných na této Zemi jsou 2 miliardy lidí - a nás je tu 10 miliónů, pomáhat se musí jen do míry než se sám neožebračím"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-34",
+      "answer": "no",
+      "comment": "volně cestovat můžeme i bez něho"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-35",
+      "answer": "no",
+      "comment": "to vůbec není jenom otázka peněz, závaznýmn referendem se musí rozhodnout o povinné vojenské presenční službě, pro všechny občany ČR"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-36",
+      "answer": "no",
+      "comment": "vy jste banda debilů - co si to dovolujete mě na takové hovadiny se ptát? Co si to dovolujete?"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-39",
+      "comment": "co to je?"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-40",
+      "answer": "no",
+      "comment": "proč, někteří řidiči u nás jezdí jako hovada - nic jiné než toto na ně neplatí - kapito?"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-41"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-42",
+      "answer": "no",
+      "comment": "jde o jeden z nejzločinějších režimů, rozkradených a zkorumpovaných režimů na světě - jak Vás taková otázka vůbec může napadnout?"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-43",
+      "answer": "yes",
+      "comment": "určitě a Rusové pak budou mít povoleno mít své vojenské základny podél hranic v Kanadě a Mexiku, včetně Kuby"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-44",
+      "answer": "no",
+      "comment": "EU má rozhodovat o výši ceny komodit jiného státu?  Co to je za diktatura?"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-45"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-46",
+      "answer": "no",
+      "comment": "proč se mě neptáte na působení skupiny Azov pro politiku ukrajinského současného presidenta? Moudrý člověk se pídí po příčinách problému - vy se mě ptáte po následcích."
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-47",
+      "answer": "no",
+      "comment": "čeští zákonodárřci nechť si přečtou moji analýzu vztahů Ruska a novodobé Ukrajiny, kterou jsem umístil na www.stranaprace.cz v září 201;  stejně si přečtěte komu patřil v dějinách Krym"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-48",
+      "answer": "no",
+      "comment": "EU tu není od toho aby buzerovala české muže a ženy, aby zasahovala do soužití českého národa"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-49",
+      "answer": "no",
+      "comment": "těžba uhlí je dána konsekvencemi vyplývajícími z Krajíčkova zákona, protože ho neznáte opět se nekompetentně ptáte, vytěžíme všechno uhlí, které na našem území bude těžitelné "
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-50",
+      "answer": "no",
+      "comment": "věřím, že tento zločinecký spolek už dávno nebude existovat"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-51",
+      "answer": "yes",
+      "comment": "a nebo ho přiřkneme Turecku, i když tam dnes žijí z většiny jen Rusové?"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-52",
+      "answer": "yes",
+      "comment": "a taky to tak bude "
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-53",
+      "answer": "no",
+      "comment": "já mám rozhodovat za Finy a Švédy - co to je opět za otázku? To je absolutně věc jen těchto dvou národů, jestli chtějí "
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-54",
+      "answer": "no",
+      "comment": "žádné dotace a nikomu - a žádný dovoz jablek do Česka z Chile, rajčat z Francie, masa z Němec, brambor z Itálie , vinné révy z Jihoafrické republiky atd - a další zhůvěřilosti vymyšlené EU, viz náš cukrovar v Hrochově Týnci"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-55",
+      "answer": "no",
+      "comment": "zákonnou povinnost - to nevidíte, že Evropskou unií jde svět do háje a ještě bych vymyslel jak dlouho se mám denně sprchovat, mýt zuby a vyprazdňovat"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-56",
+      "answer": "no",
+      "comment": "víte vůbec, že v Česku je 830 000 neobydlených bytů?"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-57",
+      "comment": "to je věc těchto dvou států jak píšu ve své stati viz výše; a ne zločineckých band NATO a EU"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-70-c-523255",
+      "question_id": "senatni-2022-70-q-58",
+      "answer": "no"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/73.json
+++ b/data/kalkulacka/senatni-2022/73.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-73",
-  "name": "73",
-  "description": "73 - DESCRIPTION",
+  "name": "Frýdek-Místek",
+  "description": "Frýdek-Místek",
   "district_code": "73",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-73-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-73-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-73-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-73-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-73-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-73-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-73-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-73-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-73-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-73-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-73-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-73-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-73-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-73-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-73-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-73-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-73-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-73-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-73-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-73-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-73-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-73-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-73-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-73-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-73-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-73-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-73-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-73-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-73-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-73-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-73-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-73-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-73-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-73-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-73-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-73-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-73-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-73-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-73-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-73-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-73-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-73-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-73-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-73-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-73-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-73-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-73-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-73-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-73-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-73-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-73-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-73-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-73-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-73-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-73-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-73-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-73-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-73-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-73-candidate-805498",
+      "id": "senatni-2022-73-c-805498",
       "name": "Daniel Pawlas",
-      "type": "party",
+      "type": "person",
       "description": "Daniel Pawlas - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -487,7 +489,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-73-805498-party",
+          "id": "senatni-2022-73-c-805498-p",
           "name": "Daniel Pawlas",
           "description": "Daniel Pawlas - DESCRIPTION",
           "contacts": {
@@ -499,9 +501,9 @@
       ]
     },
     {
-      "id": "senatni-2022-73-candidate-245847",
+      "id": "senatni-2022-73-c-245847",
       "name": "Stanislav Folwarczny",
-      "type": "party",
+      "type": "person",
       "description": "Stanislav Folwarczny - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -510,7 +512,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-73-245847-party",
+          "id": "senatni-2022-73-c-245847-p",
           "name": "Stanislav Folwarczny",
           "description": "Stanislav Folwarczny - DESCRIPTION",
           "contacts": {
@@ -523,16 +525,16 @@
       ]
     },
     {
-      "id": "senatni-2022-73-candidate-817015",
+      "id": "senatni-2022-73-c-817015",
       "name": "Zdeněk Matušek",
-      "type": "party",
+      "type": "person",
       "description": "Zdeněk Matušek - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-73-817015-party",
+          "id": "senatni-2022-73-c-817015-p",
           "name": "Zdeněk Matušek",
           "description": "Zdeněk Matušek - DESCRIPTION",
           "contacts": {
@@ -543,16 +545,16 @@
       ]
     },
     {
-      "id": "senatni-2022-73-candidate-878616",
+      "id": "senatni-2022-73-c-878616",
       "name": "Gina Horylová",
-      "type": "party",
+      "type": "person",
       "description": "Gina Horylová - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-73-878616-party",
+          "id": "senatni-2022-73-c-878616-p",
           "name": "Gina Horylová",
           "description": "Gina Horylová - DESCRIPTION",
           "contacts": {
@@ -563,9 +565,9 @@
       ]
     },
     {
-      "id": "senatni-2022-73-candidate-866259",
+      "id": "senatni-2022-73-c-866259",
       "name": "Petr Hamrozi",
-      "type": "party",
+      "type": "person",
       "description": "Petr Hamrozi - DESCRIPTION",
       "contacts": {
         "web": [
@@ -584,7 +586,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-73-866259-party",
+          "id": "senatni-2022-73-c-866259-p",
           "name": "Petr Hamrozi",
           "description": "Petr Hamrozi - DESCRIPTION",
           "contacts": {
@@ -607,9 +609,9 @@
       ]
     },
     {
-      "id": "senatni-2022-73-candidate-795375",
+      "id": "senatni-2022-73-c-795375",
       "name": "Petr Gawlas",
-      "type": "party",
+      "type": "person",
       "description": "Petr Gawlas - DESCRIPTION",
       "contacts": {
         "web": [
@@ -623,7 +625,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-73-795375-party",
+          "id": "senatni-2022-73-c-795375-p",
           "name": "Petr Gawlas",
           "description": "Petr Gawlas - DESCRIPTION",
           "contacts": {
@@ -641,5 +643,390 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-1",
+      "answer": "yes",
+      "comment": "Určitě je to jedna z cest, jak motivovat k tomu, aby byly byty více využívány. Potkávají se zde dvě roviny - zájem jednotlivce (svoboda vlastníka) a veřejný zájem (nedostatek bytů). Podle mne v tomto by měl veřejný zájem převážit nad zájmy jednotlivce."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-2",
+      "answer": "no",
+      "comment": "Ne, myslím, že to, jaké podmínky si stanoví majitel, je zcela na něm - je to jeho majetek. Je to pak o dohodě nebo nedohodě s případným nájemcem (partnere). Zároveň bych šel ale druhou cestou, a to začít s novou masívní výstavbou nájemních bytů ve vlastnictví měst, obcí, krajů a státu. Tyto byty by měly být občanům k dispozici za příznivých podmínek. Lidé se pak budou moci rozhodnout pro nájem v bytech vlastněných \"veřejným sektorem\" nebo soukromým. Podmínkou výstavby je také ochrana před budoucí privatizací nebo prodejem - což považuji za hrubou chybu minulých vlád."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-3",
+      "answer": "yes",
+      "comment": "Ano, jsem pro zvýšení prvků přímé demokracie na všech úrovních - městské a obecní, krajské nebo celostátní. Bylo by potřeba ovšem dotáhnout několik s tímto souvisejících otázek."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-4",
+      "comment": "Určitě by měla být výstavba infrastruktury pro rychlovlaky jednou z priorit vlády. Měly by se okamžitě změnit příslušné zákony tak, aby vše šlo výrazně rychleji. Nicméně nesmí se zapomínat na výstavbu i další infrastruktury, která je důležitá pro občany, kteří žijí i v jiných regionech ČR (kde nebudou rychlovlaky). Můj závěr - vše by mělo být na stejné rovině. Měly by být provedeny audity připravenosti a také by měl být jasný přehled  (veřejně dostupný), jak je na tom která stavba (v jaké fázi a kdo to případně brzdí - například který úřad a to by mělo být ihned odstraněno)."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-5",
+      "answer": "no",
+      "comment": "Ne, to nepovažuji nyní za nutné. Je totiž otázkou, proč by se měl tento věk zvyšovat. Pokud je to kvůli financím, je nutné hledat i jiné zdroje na financování důchodů. A těch možností je několik. Tématu se podrobněji věnuji na svém webu www.petrhamrozi.cz"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-6",
+      "answer": "yes",
+      "comment": "Jednoznačně ano a to z několika důvodů. Jak ve vztahu k hospodaření s vodou, tak k možnému výraznému zvýšení výroby elektrické energie nebo například podpoře regionálního cestovního ruchu a možností relaxace a odpočinku.\nMnohy se ovšem nemusí jednat o přehrady velké, mohou to být i daleko menší, které jsou vhodně zasazeny do dané lokality."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-7",
+      "answer": "yes",
+      "comment": "Ano, systém dobře funguje na Slovensku a v další zemích, proto by to mohlo pomoci i v České republice."
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-8",
+      "comment": "Myslím si, že ne. Lidé s vyššími příjmy by neměli být trestáni za to, že se mnohdy snaží daleko více (například mají dvě práce). Téma není jednoduché a argumety pro a proti mnohdy dávají smysl. Nicméně jako společnost se prostě rozhodnout musíme (a žádné z řešení není ideální)."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-9",
+      "answer": "yes",
+      "comment": "Pokud se vlastní potřeba týká zdravotního hlediska  (například léčba některé z nemoci), měli by mít lidé tuto možnost. Pokud je to jen pro zábavu, tak ne."
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-10",
+      "answer": "yes",
+      "comment": "Určitě ano."
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-11",
+      "answer": "yes",
+      "comment": "Speciální daň asi ne. Nicméně velké společnosti by měly obecně platit stejné daně, jako kterákoliv jiná firma. Tyto společnosti by neměly být danově zvýhodňovány oproti malým firmám.\nZároveň bych rád inicioval změnu příslušné legislativy na národní i celoovropské úrovni, aby i v Evropě mohly začít vznikat takovéto mezinárodní kolosy (a tím přinés evropě a potažmu ČR a jejím regionům daleko větší příjmy) - prostě je nutné zjednodušit podnikání a dát prostor pro vznik nových a zajímavých projektů."
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-12",
+      "answer": "yes",
+      "comment": "Částečně ano. Zejména pokud se to týká nenávistného obsahu. Na jedné straně stojí svoboda slova - což je v pořádku, na straně druhé jsou ovšem mnohdy zneužívány k vylévání zlosti a šíření nenávisti - což je špatně."
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-13",
+      "comment": "Téma je velmi složité. Je zde totiž otázka, co je fake news a kdo to bude hodnotit (kdo bude hodnoti pravdivost). Je nutné si uvědomit, že i velká (například veřejnoprávní i soukromá média) často sdělují nepravdu nebo zkreslenou pravdu. Proto by se měla v tomto otevřít celospolečenská debata. Obecně byla ale fakt news na všech úrovních měla být omezována nebo dokonce u některých závažných forem trestána. Není možné jen tak svobodně a záměrně šířit lži a nenávist."
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-14",
+      "answer": "no",
+      "comment": "Myslím, že ne. ČT a ČRo dělají mnohdy velmi dobrou práci. Myslím ovšem, že by měly tyto instituce být více hlídány, aby si nedělaly, co chtějí. Je totiž otázka, co znamená svoboda projevu (může si redaktor a novinář napsat co chce? Nebo to má být omezováno - pokud si chce psát podle sebe, může si založit své vlastní médium). Bezpodmínečně by měly  být provedeny také audity hospodaření a veřejně zpřístupňovány některé investice a nákladov (například kolik bereou někteří moderátoři, herci, management a je-li ve veřejném zájmu platit mnohdy královské honoráře a odměny, apod.). Je také nutné provést audit potřebnosti profesí - nnapříklad, zda-li není zbytečá přezaměstnanost na některých pozicích, apod."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-15",
+      "comment": "Toto téma je velmi obecné. Nevím, za jakého úhlu pohledu je tato otázka myšlena. Proto se nemohu vyjádřit..."
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-16",
+      "answer": "no",
+      "comment": "Ne. Manželství považuji za obrovský dar. Proto by to měl být výlučně svazek jednoho muže a jedné ženy. Téma manželství pro všechny se objevuje v poslední době velmi často (až podezřele). Je ovšem otázka, co znamená „pro všechny“? Pokud tento termín vezmu\ndoslova, mohou si pak manželství nárokovat prakticky jakékoliv minority (pokud bychom měli být korektní, tak je nutné dát prostor všem minoritám a každému,  kdo si o to řekne). Může se tak například jednat o manželství s malými holčičkami, mnohoženství nebo jakékoliv formy „vztahu“ vyskytující se v různých částech světa. A touto cestou bych já osobně jít opravdu nechtěl."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-17",
+      "answer": "yes",
+      "comment": "Zcela jednoznačně ano. Zároveň by měla být zavedena trestní odpovědnost exekutorů a nutnost náhrady škody u špatně prováděných exekutorů. Zároveň by myl být zaveden nezávislý institut dohlížející nad činnostmi exekutorů (není možné abych jejich práci hodnotili jejich kolegové - evidentní střet zájmů a proto se téměř nikdy nic nevyřeší). Měl by být také zeveden institut státní exekutorů. Stát (a jeho složky - například pojišťovny) by neměl podporovat zhýralost a tento nechutnný business několika soukromých soukromých osob."
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-19",
+      "answer": "no",
+      "comment": "Soukromí vlastníci by se měli svobodně rozhodnout, co si postaví a komu to nabídnout. Pokud chceme podpořit výstavbu sociálně dostupného bydlení, jsou jiné nástroje - především masivní podpora výstavby bytů ve vlastnictví veřejného sektoru (města, obce, kraje, stát). Tyto byty by pak měly být dustupné za rozumných podmínek."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-20",
+      "answer": "no",
+      "comment": "Téma není jednoduché. Jsou lidé, kteří pomoc opravdu potřebují a jsou lidé, kteří vše zneužívají. S tímto by se mělo pracovat a podporovat ty, kteří pomoc opravdu potřebují."
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-21",
+      "answer": "yes",
+      "comment": "Ano, toto by mohlo přispět k rozvoji jednotlivých regionů a také ke snížení tlaku na potřebu bytů v Praze. Dnešní doba umožňuje velmi dobré způsoby komunikace na dálku - sdílení dat, telekonference, apod. Proto je tato forma velmi potřebná..."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-22",
+      "comment": "V rozumné míře. Jsou ovšem nyní jiné priority pro tuto zemi a pro celou Evropu."
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-23",
+      "answer": "yes",
+      "comment": "Mnoha lidem by to jistě pomohlo jít volit a to jak v ČR, tak v zahraničí. Technické možnosti dnes vše umožňují bez problémů."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-24",
+      "answer": "yes",
+      "comment": "V tuto chvíli ano. Jelikož sami máme aktivity, které podporují tento typ vzdělávání (například projekt Studuj techniku a řemeslo), pokládám toto téma za velmi důležité. Podpora by měla být konkrétní, například finanční již pro žáky SŠ. Forem podpory je několik."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-25",
+      "answer": "yes",
+      "comment": "Ano, nicméně měli by mít na ZŠ daleko více možností rozvíjet své talenty již v ranném věku - pod pojmem talent ovšem nemyslím jen sport, hudbu nebo umění. Ale jsou i jiné formy talentu - například technické dovednosti, apod."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-26",
+      "answer": "yes",
+      "comment": "Ano, ale v rozumné míře. Jsou prostě jedinci, kteří potřebují jít dále mnohem rychleji. Jsou jedinci, u kterých je to složitější. Neměli bychom v rámci \"korektnosti\" výrazně brzdit jedince, kteří potřebují jít rychleji dále - to bychom se jako společnost nikam moc neposunuli. Nehledě na to, že to mnohdy vyčerpává vyučující daleko více a ve finále to škodí všem.\nProto by měly znovu vzniknout instituce, které budou dávat slabším jedincům zvláštní péči."
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-27",
+      "comment": "V  tuto  chvíli ne, stále vnímám, že by se mělo udělat vše pro to, aby se EU reformovala a kladl se daleko větší důraz na potřeby menších zemí (ne jen Německa nebo Francie). Jednotlivé země mají být vzájemně partneři. Menší země nemají být vyživány a zneužívány těmi většími...."
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-28",
+      "comment": "Zatím ne. Zavedení Eura má své výhody i nevýhoda. Není too jednoznačné. Výhoda je nyní například ve výši úrokové sazby pro firmy i občany. Nevýhoda je ztráta suverenity a další zdražení (tak jak to proběhlo na Slovensku). Proto toto téma není jednoduché a měli bychom si říci jako země, chceme Euro (a za jakých podmínek)  nebo nechceme."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-29",
+      "answer": "no",
+      "comment": "Nyní v žádném případě. NATO je pro nás zárukou bezpečnosti proti agresorům, nyní zejména Rusku."
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-30",
+      "answer": "yes",
+      "comment": "Ano, v tuto chvíli neexistuje dostatečná kapacita v jiných zdrojích."
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-31",
+      "answer": "yes",
+      "comment": "Ano, ale ne vše. Záleží na konkrétních projektech a způsobech pomoci. Obecně by to měly být projekty, které pomohou nastartovat další projekty v dané zemi. Nedávat rybářům ryby, ale naučit je tyto ryby chytat  :-)."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-32",
+      "answer": "yes",
+      "comment": "Ano. Nové zákony by měl být přijímány s rozumem a ne fanatismem, jaký jsme doposud u některých z nich viděli (například Green Deal a jiné fanatické a nereálné představy některých organizací)."
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-33",
+      "answer": "yes",
+      "comment": "Ano, nicméně s příhlédnutím na zemi původu a jejich důvody. Opět ne všem a ne za jakýchkoliv okolností (například u zcela jasných ekonomických migrantů z mnoha zemí Afriky). Zde je totiž otázka, proč migrují - pokud z ekonomických důvodů, měla by Evropa daleko více řešit to (a snažit se pomoci), jak motivovat tyto občany zůstat v dané zemi. Například zvýšením počtu pracovních příležitostí (některé výrobky se nemusí vyrábět v Asii, ale mohou se začít vyrábět v některých částech Afriky, apod.)."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-34",
+      "answer": "yes",
+      "comment": "Ano, je ovšem otázka, zda-li Schengen opravdu funguje po celé Evropě. Schengen má své výhody a žel i nevýhody (a ty je potřeba řešit). Země by měly mít právo zakázaz vstup nepřizpůsobivým jedincům do své země nebo i do jiných zemí Schengenu."
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-35",
+      "answer": "yes",
+      "comment": "Ano, bezpečnost země je důležitá. Více peněz ovšem musí jít ruku v ruce audity hospodaření armády a potřebnosti navýšení investic. Musí být prostě jasné, že jsou finance správně vynaloženy - to ale platí i o jiných resortech..."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-36",
+      "answer": "no",
+      "comment": "Nedokážu si představit, jak by toto mohlo fungovat. Ale nepodporoval bych to. Pokud chtějí mít dítě, měli by respektovat to, že to může být jak chlapeček, tak holčička. I u klasické formy oplodnění si není možné vybrat, kdo se narodí :-)."
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-37",
+      "answer": "yes",
+      "comment": "Ano,  měly by být zavedeny i jiné formy, které pomohou šetřit finance ve zdravotnictví nebo mít možnost zvýšení komfortu (péče)."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-38",
+      "comment": "Nedokážu přesně posoudit, jak je tato otázka myšlena... Pokud tak, že různá pracoviště mají být i v jiných regionech, tak částečně ano. Vše ovšem záleží na konkrétní odbornosti a využitelnosti. Například některé technologie jsou extrémně drahé a prostě by se tyto technologie ve více městech neuživily (nezaplatily). Naštěstí ČR není tak velká.\nMožná bych v tomto daleko více začal spolupracovat i s okolními, nám, blízkými zeměmi - Slovensko a Polsko."
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-40",
+      "comment": "Ne, v drtivé většině případů pomáhají zvyšovat bezpečnost na některých úsecích. Samozřejmě jsou situace, kdy se jedná o zbytečnou a zcela záměrnou šikanu řidičů - v tom případně ano. Pak tyto systémy nemají být používány."
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-41",
+      "comment": "Téma je velmi citlivé. Na jedné straně je zde ochrana osobních údajů a soukromí osob. Na druhé straně to může pomoci vyřešit některé trestné činy. Proto by se o tom mělo diskutovat na celospolečenské úrovni, čemu dá společnost jako celek priority..."
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-42",
+      "answer": "yes",
+      "comment": "Ano, co nejdříve. Zároveň by se jí mělo maximálně pomoci splnit nutná kritéria. A když by se chtělo, šlo by to rychle..."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-43",
+      "answer": "yes",
+      "comment": "Může to dále pomcoi zvýšit bezpečnost Evropy."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-44",
+      "answer": "no",
+      "comment": "Ne, protože se vše zvrhne a země EU budou distributorům doplácet nehorázné sumy. Nebudou mít snahu snížit cenu v případě omezení spotřeby.\nEvropa by ovšem měla urychleně řešit náhradu za ruský plyn - jak u plynu samotného, tak u innvestic do alternativních zdrojů (třeba solární, vodní nebo větrné technologie). A toto by mohlo pomoci zemím, kde je například více světla nebo větru - třeba Španělsko, Itálie, Chorvatsko, Řecko nebo právě severní Afrika. Zároveň by měly být odstraněny zcela nesmyslné kroky, které zvýšují cenu energií (například emisní povolenky)."
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-45",
+      "comment": "Moc ne."
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-46",
+      "answer": "yes",
+      "comment": "Ano a to ne jen ve vztahu k Ukrajině, ale i celé Evropě. Postup Ruska poškodil nejen Ukrajinu samotnou, ale právě i firmy a občany v EU. A to by nemělo být necháno jen tak. Je ovšem nutné otevřít podporu této nesmyslné války také jiných zemí - Čína, Indie, apod. I tyto země, díky své podpoře Ruska, tuto agresi podporují a současně pomáhají způsobovat problémy Evropě a dalším regionům. I zde by se mělo začít jednat. Tyto země by se měly rozhodnout - zda-li chtějí být na straně Ruska nebo civilizovaného světa."
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-48",
+      "answer": "yes",
+      "comment": "Nicméně nesmí být k této směrnici \"přilepeny\" jiné věci a snahy. Tak jak je to například u tzv. Istambulské dohody."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-49",
+      "answer": "no",
+      "comment": "Ne, ani později. Uhlí je velmi důležitá komodita v mnoha oborech a ti, kteří toto podporují většinou průmyslu téměř nerozumí. Zároveň, i díky nynější zkušenosti s Ruskem, musíme být samostatní..."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-50",
+      "comment": "Co znamená \"klimaticky neutrální\" - není toto pouze o výrobě energie, ale i o výrobě těchto technologií, jejich provozu a následné recyklaci. Proto je nutné maximální úsilí v této oblasti, ale s rozumem a ne pod nátlakem některých ekologických fanatiků nebo tzv. ekoteroristů."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-54",
+      "comment": "I některé velké farmy dělají dobrou práci. Nicméně dotace by měly být obecně spravedlivé pro všechny."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-73-c-866259",
+      "question_id": "senatni-2022-73-q-58",
+      "answer": "yes",
+      "comment": "Samozřejmě je nutné definovat pojem \"bezvýsledné exekuce\". Pokud ti lidé mohou pracovat a svůj dluh splácet, má to být podporováno. Je ovšem otázka, zda-li díky chybě a liknavosti státu se z malých dluhů nestaly dluhy obrovské, kdy lidé už nemají šanci ani motivaci tento dluh splatit - ikdyby praovali dalších 100 let. A to je špatně."
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/76.json
+++ b/data/kalkulacka/senatni-2022/76.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-76",
-  "name": "76",
-  "description": "76 - DESCRIPTION",
+  "name": "Kroměříž",
+  "description": "Kroměříž",
   "district_code": "76",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-76-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-76-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-76-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-76-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-76-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-76-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-76-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-76-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-76-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-76-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-76-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-76-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-76-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-76-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-76-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-76-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-76-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-76-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-76-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-76-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-76-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-76-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-76-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-76-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-76-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-76-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-76-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-76-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-76-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-76-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-76-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-76-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-76-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-76-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-76-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-76-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-76-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-76-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-76-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-76-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-76-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-76-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-76-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-76-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-76-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-76-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-76-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-76-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-76-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-76-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-76-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-76-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-76-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-76-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-76-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-76-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-76-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-76-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,9 +479,9 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-76-candidate-132112",
+      "id": "senatni-2022-76-c-132112",
       "name": "Rudolf Seifert",
-      "type": "party",
+      "type": "person",
       "description": "Rudolf Seifert - DESCRIPTION",
       "contacts": {
         "web": [
@@ -492,7 +494,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-76-132112-party",
+          "id": "senatni-2022-76-c-132112-p",
           "name": "Rudolf Seifert",
           "description": "Rudolf Seifert - DESCRIPTION",
           "contacts": {
@@ -509,16 +511,16 @@
       ]
     },
     {
-      "id": "senatni-2022-76-candidate-592201",
+      "id": "senatni-2022-76-c-592201",
       "name": "Stanislav Skála",
-      "type": "party",
+      "type": "person",
       "description": "Stanislav Skála - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-76-592201-party",
+          "id": "senatni-2022-76-c-592201-p",
           "name": "Stanislav Skála",
           "description": "Stanislav Skála - DESCRIPTION",
           "contacts": {
@@ -529,16 +531,16 @@
       ]
     },
     {
-      "id": "senatni-2022-76-candidate-623635",
+      "id": "senatni-2022-76-c-623635",
       "name": "Lucie Pluhařová",
-      "type": "party",
+      "type": "person",
       "description": "Lucie Pluhařová - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-76-623635-party",
+          "id": "senatni-2022-76-c-623635-p",
           "name": "Lucie Pluhařová",
           "description": "Lucie Pluhařová - DESCRIPTION",
           "contacts": {
@@ -549,9 +551,9 @@
       ]
     },
     {
-      "id": "senatni-2022-76-candidate-179826",
+      "id": "senatni-2022-76-c-179826",
       "name": "Olga Sehnalová",
-      "type": "party",
+      "type": "person",
       "description": "Olga Sehnalová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -569,7 +571,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-76-179826-party",
+          "id": "senatni-2022-76-c-179826-p",
           "name": "Olga Sehnalová",
           "description": "Olga Sehnalová - DESCRIPTION",
           "contacts": {
@@ -591,9 +593,9 @@
       ]
     },
     {
-      "id": "senatni-2022-76-candidate-651961",
+      "id": "senatni-2022-76-c-651961",
       "name": "Šárka Jelínková",
-      "type": "party",
+      "type": "person",
       "description": "Šárka Jelínková - DESCRIPTION",
       "contacts": {
         "web": [
@@ -615,7 +617,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-76-651961-party",
+          "id": "senatni-2022-76-c-651961-p",
           "name": "Šárka Jelínková",
           "description": "Šárka Jelínková - DESCRIPTION",
           "contacts": {
@@ -641,9 +643,9 @@
       ]
     },
     {
-      "id": "senatni-2022-76-candidate-161118",
+      "id": "senatni-2022-76-c-161118",
       "name": "Jana Zwyrtek Hamplová",
-      "type": "party",
+      "type": "person",
       "description": "Jana Zwyrtek Hamplová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -655,7 +657,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-76-161118-party",
+          "id": "senatni-2022-76-c-161118-p",
           "name": "Jana Zwyrtek Hamplová",
           "description": "Jana Zwyrtek Hamplová - DESCRIPTION",
           "contacts": {

--- a/data/kalkulacka/senatni-2022/79.json
+++ b/data/kalkulacka/senatni-2022/79.json
@@ -1,17 +1,19 @@
 {
   "id": "senatni-2022-79",
-  "name": "79",
-  "description": "79 - DESCRIPTION",
+  "name": "Hodonín",
+  "description": "Hodonín",
   "district_code": "79",
   "election": {
     "id": "senatni-2022",
     "key": "senatni-2022",
-    "name": "senatni-2022",
-    "description": "senatni-2022"
+    "name": "Senátní volby 2022",
+    "description": "Volí se třetina senátních obvodů.",
+    "from": "2022-09-23 14:00",
+    "to": "2022-09-24 14:00"
   },
   "questions": [
     {
-      "id": "senatni-2022-79-question-1",
+      "id": "senatni-2022-global-q-1",
       "name": "Zdanění prázdných bytů",
       "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
       "gist": "Zastánců zdanění poukazují, že investiční byty křiví trh a vyčerpávají bytové zásoby. Zhoršují se tak šance pro lidi s nízkými a středními příjmy pořídit si vlastní bydlení. Kritici namítají, že zdanění zvýší ceny nemovitostí a nájemní bydlení zdraží. ČR má jednotný výpočet daně a nezohledňuje, kolik jich majitel vlastní a zda jsou dlouhodobě obydlené.",
@@ -19,7 +21,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-79-question-2",
+      "id": "senatni-2022-global-q-2",
       "name": "Regulace nájemného v bytech",
       "title": "ČR by měla regulovat ceny nájemného u bytů.",
       "gist": "Nájemné bylo v ČR regulované do roku 2012, nyní je tržní. Např. v Německu nebo Rakousku různé formy regulovaných nájmů existují. Regulace vycházejí z toho, že bydlení je pro lidi nutné a musí být finančně únosné. Žádná regulace naopak upřednostňuje právo majitele volně nakládat se svým majetkem.",
@@ -27,7 +29,7 @@
       "tags": ["bydlení"]
     },
     {
-      "id": "senatni-2022-79-question-3",
+      "id": "senatni-2022-global-q-3",
       "name": "Celostátní referendum",
       "title": "Měla by se uzákonit možnost celostátního referenda vypisovaného na základě petice.",
       "gist": "V ČR je možné vyhlásit celostátní referendum pouze tehdy, pokud o něm rozhodne Parlament. Např. na Slovensku je to možné po shromáždění 350 000 podpisů, v „referendovém“ Švýcarsku je třeba 50 000 podpisů.",
@@ -35,7 +37,7 @@
       "tags": ["demokracie"]
     },
     {
-      "id": "senatni-2022-79-question-4",
+      "id": "senatni-2022-global-q-4",
       "name": "Rychlovlaky priorita",
       "title": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury.",
       "gist": "Vysokorychlostní tratě mají výrazně zkrátit jízdní dobu, navýšit kapacity železniční sítě a zrychlit spojení. O výstavbě se v Česku hovoří od 90. let, přípravy začaly v posledních letech. Podle kritiků si to vyžádá rozsáhlé pořizovací náklady. Vyšší rychlost také zvyšuje spotřebu elektřiny a provoz je tak dražší.",
@@ -43,7 +45,7 @@
       "tags": ["doprava"]
     },
     {
-      "id": "senatni-2022-79-question-5",
+      "id": "senatni-2022-global-q-5",
       "name": "Zvýšení věku odchodu do důchodu",
       "title": "Věk odchodu do důchodu by se měl nadále zvyšovat nad 65 let.",
       "gist": "V současnosti je v ČR standardní věk odchodu do důchodu více než 64 let a postupně se zvyšuje na cílových 65 let.",
@@ -51,7 +53,7 @@
       "tags": ["důchody"]
     },
     {
-      "id": "senatni-2022-79-question-6",
+      "id": "senatni-2022-global-q-6",
       "name": "Nové přehrady",
       "title": "ČR by měla stavět více nových přehrad.",
       "gist": "ČR má vytipovaných přes 100 míst, kde by mohly vzniknout přehrady pro zadržování dešťové vody. Podzemních vod ubývá, nerovnoměrné srážky a málo sněhu je nestačí doplnit. Odpůrci poukazují, že vysychá i řada stávajících přehrad a jejich výstavba je součást problémů se suchem. Obří stavby pak podle nich nahrávají velkým stavebním firmám a tzv. betonářské lobby.",
@@ -59,7 +61,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-79-question-7",
+      "id": "senatni-2022-global-q-7",
       "name": "Zálohované PETky a plechovky",
       "title": "Měly by být PET lahve a nápojové plechovky zálohované podobně jako nyní skleněné pivní lahve?",
       "gist": "PET lahve a nápojové plechovky jsou zálohované v Německu, Chorvatsku či Dánsku. Odpůrci zálohování říkají, že se v ČR vytřídí osm z deseti PET lahví. Zastánci namítají, že se tříděný odpad často nerecykluje, ale končí ve spalovnách. To zatěžuje životní prostředí.",
@@ -67,7 +69,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-79-question-8",
+      "id": "senatni-2022-global-q-8",
       "name": "Daňová progrese zaměstnanců",
       "title": "Měla by se zvýšit progrese daně z příjmů u lidí (tj. vyšší sazba daně pro vyšší příjmy).",
       "gist": "V ČR existuje „jednotná daň z příjmu 15 %“. Díky slevě na poplatníka a tzv. solidární dani pro nejvíce vydělávající ovšem jde ve skutečnosti o daň mírně progresivní. Podle odpůrců změny je tato „rovná daň“ spravedlivější. V Německu je zdanění progresivnější než v ČR, na Slovensku je progrese podobná jako v ČR.",
@@ -75,7 +77,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-79-question-9",
+      "id": "senatni-2022-global-q-9",
       "name": "Pěstování konopí legální",
       "title": "Pěstovat konopí (marihuanu) pro vlastní potřebu by mělo být legální.",
       "gist": "V současnosti je v ČR pěstování konopí s vyšším obsahem láky THC (marihuany) v malém množství přestupek, v množství větším než malém potom trestný čin.",
@@ -83,7 +85,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-79-question-10",
+      "id": "senatni-2022-global-q-10",
       "name": "Vyšší tresty za znásilnění",
       "title": "Tresty za znásilnění by se měly zvýšit.",
       "gist": "V současné době jsou zhruba 2/3 pachatelů odsouzené za znásilnění k podmínečnému trestu a 1/3 k trestu vězení. Kritici poukazují na to, že nízké tresty jsou neadekvátní vzhledem ke společenské nebezpečnosti činu, ani nereflektují mnohdy doživotní traumata obětí.",
@@ -91,7 +93,7 @@
       "tags": ["justice"]
     },
     {
-      "id": "senatni-2022-79-question-11",
+      "id": "senatni-2022-global-q-11",
       "name": "Daň z digitálních služeb",
       "title": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR.",
       "gist": "Zdanění digitálních služeb pro velké internetové firmy ze všech jejich příjmů v ČR. Zastánci argumentují nízkými až nulovými daněmi, které tyto velké firmy v ČR platí. Např. v Rakousku, Velké Británii a Turecku, které zavedly obdobnou daň, Google odpovídajícím způsobem zvýšil ceny objednavatelům reklamy.",
@@ -99,7 +101,7 @@
       "tags": ["ekonomika"]
     },
     {
-      "id": "senatni-2022-79-question-12",
+      "id": "senatni-2022-global-q-12",
       "name": "Zodpovědnost sociálních sítí",
       "title": "Sociální sítě mají být zodpovědné za obsah, který zpřístupňují.",
       "gist": "Velké sociální sítě jako Facebook nebo YouTube jsou dnes pojímány spíše jako nástěnka: zodpovědnost (i trestní) za zveřejněný obsah je primárně na tom, kdo obsah na danou síť nahrál. Naopak např. média mají zodpovědnost za jakýkoliv obsah, který zveřejní.",
@@ -107,7 +109,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-79-question-13",
+      "id": "senatni-2022-global-q-13",
       "name": "Fake News – povinnost odstraňovat",
       "title": "Provozovatelé velkých internetových stránek a aplikací jako Facebook nebo Youtube mají být povinni vymazat „falešné zprávy“ (fake news), na které byli upozorněni.",
       "gist": "Jako fake news je obvykle označováno šíření nepravdivých a manipulativních informací plnících roli dezinformace. V Německu existuje několik let zákon, který velkým sociálním sítím takovou povinnost ukládá, v ČR žádný takový speciální zákon není.",
@@ -115,7 +117,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-79-question-14",
+      "id": "senatni-2022-global-q-14",
       "name": "Méně peněz na veřejnoprávní vysílání",
       "title": "Na veřejnoprávní vysílání by se mělo dávat méně peněz.",
       "gist": "Veřejnoprávní vysílání České televize a Českého rozhlasu je dnes financováno z koncesionářských poplatků, tedy veřejností.",
@@ -123,7 +125,7 @@
       "tags": ["média"]
     },
     {
-      "id": "senatni-2022-79-question-15",
+      "id": "senatni-2022-global-q-15",
       "name": "Omezení pracovních agentur",
       "title": "Působnost pracovních agentur by měla být výrazně omezena.",
       "gist": "V tento moment není práce agenturních pracovníků nijak regulovaná. Existuje např. návrh, že by podíl agenturních zaměstnanců ve firmách nesměl překročit 10 % lidí pracujících ve firmě.",
@@ -131,7 +133,7 @@
       "tags": ["práce"]
     },
     {
-      "id": "senatni-2022-79-question-16",
+      "id": "senatni-2022-global-q-16",
       "name": "Stejnopohlavní páry: manželství",
       "title": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry.",
       "gist": "Lidé v registrovaném partnerství mají v porovnání s manžely omezená práva. Nemají společné jmění, právo na bydlení v obydlí partnera, společné nájemní právo ani nárok na důchod v případě úmrtí jedno z nich. Pokud zesnulý partner nebyl biologickým rodičem, dítě nemá nárok na sirotčí důchod. Po úmrtí biologického rodiče může být dítě druhému z partnerů odebráno.",
@@ -139,7 +141,7 @@
       "tags": ["rodina"]
     },
     {
-      "id": "senatni-2022-79-question-17",
+      "id": "senatni-2022-global-q-17",
       "name": "Místní příslušnost exekutorů",
       "title": "Konkurence mezi exekutory by se měla odstranit zavedením místní příslušnosti exekutorů.",
       "gist": "Zavedení takzvané teritoriality dlouhodobě podporuje Exekutorská komora. Princip místní příslušnosti by podle ní výrazně pomohl stabilitě systému vymáhání práva. Odpůrci teritoriality namítají, že by tím mohlo dojít k poklesu vymahatelnosti dluhů.",
@@ -147,7 +149,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-79-question-18",
+      "id": "senatni-2022-global-q-18",
       "name": "1 dlužník = 1 exekutor",
       "title": "U exekucí by mělo platit pravidlo 1 dlužník = 1 exekutor.",
       "gist": "Různé dluhy jednoho dlužníka dnes obvykle vymáhá více exekutorů, čímž vysoce narůstá příslušenství dluhu. Systém 1 dlužník = 1 exekutor by znamenal, že lidé, kteří mají více exekucí, by komunikovali s jedním jim přiděleným exekutorem. Oponenti kritizují, že by to upřednostňovalo jen několik velkých exekutorů.",
@@ -155,7 +157,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-79-question-19",
+      "id": "senatni-2022-global-q-19",
       "name": "Sociální bydlení",
       "title": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty.",
       "gist": "",
@@ -163,7 +165,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-79-question-20",
+      "id": "senatni-2022-global-q-20",
       "name": "Aktivní vyhledávání lidí v nouzi",
       "title": "Stát má aktivně vyhledávat lidi v nouzi, kteří mají nárok na sociální dávky.",
       "gist": "Množství domácností nepobírá sociální dávky, na které mají nárok. Např. příspěvek na bydlení nepobírá více než 70 % domácností, které by na něj mohly dosáhnout. Jde zhruba o 800 tisíc domácností, z toho zhruba polovina by měla nárok na více než 1 000 Kč měsíčně.",
@@ -171,7 +173,7 @@
       "tags": ["sociálno"]
     },
     {
-      "id": "senatni-2022-79-question-21",
+      "id": "senatni-2022-global-q-21",
       "name": "Decentralizace ČR",
       "title": "Mělo by se zavést pravidlo, že státní instituce budou rozmisťovány rovnoměrně po celém území ČR.",
       "gist": "V ČR je velké množství státních a státem placených institucí v Praze. Naproti tomu v Německu existuje pravidlo, že takové instituce musejí být rozmisťovány rovnoměrně po celé zemi. Podle zastánců decentralizace např. podporuje chudší regiony a posiluje nezávislost kontrolních institucí, podle odpůrců to snižuje efektivitu státní správy.",
@@ -179,7 +181,7 @@
       "tags": ["státní správa"]
     },
     {
-      "id": "senatni-2022-79-question-22",
+      "id": "senatni-2022-global-q-22",
       "name": "Kolonizace Marsu",
       "title": "ČR by se měla více zapojit do snah o kolonizaci Marsu.",
       "gist": "Dnes je na Marsu 5 robotických průzkumných strojů (4x USA, 1x Čína). 9 družic krouží kolem Marsu, z toho 2 evropské. USA plánují let lidí na Mars do 10 let, podobné programy mají např. Spojené arabské emiráty nebo Čína.",
@@ -187,7 +189,7 @@
       "tags": ["věda a výzkum"]
     },
     {
-      "id": "senatni-2022-79-question-23",
+      "id": "senatni-2022-global-q-23",
       "name": "Volby online",
       "title": "Měla by být zavedena možnost volit online po internetu.",
       "gist": "Zastánci řadí elektronické volby k moderní demokracii (zvyšují volební účast, usnadňují volbu lidem v cizině či zdravotně postiženým, umožňují rychlé a spolehlivé zpracování výsledků). Kritici namítají, že naše současné technické možnosti nejsou zárukou spolehlivé ochrany proti volebním podvodům.",
@@ -195,7 +197,7 @@
       "tags": ["volby"]
     },
     {
-      "id": "senatni-2022-79-question-24",
+      "id": "senatni-2022-global-q-24",
       "name": "Podpora technického vzdělávání",
       "title": "Technické vzdělávání na středních a vysokých školách by mělo být státem podporováno více než jiné obory.",
       "gist": "Zastánci poukazují, že je největší poptávka po technických profesích napříč obory. Ödpůrci říkají, že stát nemá měnit podobu školství kvůli momentálním a rychle se měnícím potřebám pracovního trhu.",
@@ -203,7 +205,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-79-question-25",
+      "id": "senatni-2022-global-q-25",
       "name": "Nediferenciace žáků na ZŠ",
       "title": "Všechny děti by se měly bez ohledu na talent nebo schopnosti vzdělávat společně až do konce povinné školní docházky (do 15 let, základní škola).",
       "gist": "Dle zastánců vede společná docházka ke snížení nerovnosti ve vzdělání a ke zlepšení výsledků všech žáků. Země jako Finsko žáky neodděluje a má v celosvětových srovnáních nejlepší výsledky ve všech oborech vzdělávání. Kritici společné docházky podporují víceletá gymnázia jako možnost pro nadané žáky.",
@@ -211,7 +213,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-79-question-26",
+      "id": "senatni-2022-global-q-26",
       "name": "Inkluzivní vzdělávací systém",
       "title": "Vzdělávací systém má být co nejvíce inkluzivní, má pomáhat slabším žákům zapojit se do kolektivu a motivovat je k učení.",
       "gist": "Odpůrci inkluze se obávají, že by méně nadaní žáci brzdili ty nadané. Zastánci inkluze poukazují na to, že výzkumy nic takového nepotvrzují, a zmiňují prospěch z nulové selekce žáků pro celou společnost.",
@@ -219,7 +221,7 @@
       "tags": ["vzdělávání"]
     },
     {
-      "id": "senatni-2022-79-question-27",
+      "id": "senatni-2022-global-q-27",
       "name": "Výstup z EU",
       "title": "ČR by měla vystoupit z Evropské unie.",
       "gist": "Evropská unie (EU) je svazek 27 evropských zemí. Jejími členy jsou i všechny 4 sousední země ČR.",
@@ -227,7 +229,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-79-question-28",
+      "id": "senatni-2022-global-q-28",
       "name": "Zavedení eura",
       "title": "ČR by měla zavést společnou evropskou měnu (euro).",
       "gist": "Eurem platí 19 zemí EU, včetně sousedních Německa, Rakouska a Slovenska. Přijetí eura by snížilo transakční náklady na převod koruny a zjednodušilo zahraniční obchod. Bez eura má země vlastní centrální banku, která má pečovat o cenovou stabilitu.",
@@ -235,7 +237,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-79-question-29",
+      "id": "senatni-2022-global-q-29",
       "name": "Výstup z NATO",
       "title": "ČR by měla vystoupit z NATO.",
       "gist": "Severoatlantická aliance (NATO) je mezinárodní vojenský pakt 30 zemí z Evropy a Severní Ameriky. Ze sousedních zemí je v NATO také Německo, Polsko a Slovensko. Rakousko se po 2. světové válce zavázalo k neutralitě. Kvůli ruské invazi na Ukrajinu požádaly o vstup do aliance dosud neutrální Finsko a Švédsko.",
@@ -243,7 +245,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-79-question-30",
+      "id": "senatni-2022-global-q-30",
       "name": "ČR v jádru EU",
       "title": "Místo ČR je v jádru EU.",
       "gist": "Jako jádro EU se obvykle označují země, které patří a chtějí i v budoucnu patřit do projektů větší integrace EU (dnes např. měna euro nebo Schengenský prostor bez hraničních prostor, do budoucna např. společná armáda).",
@@ -251,7 +253,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-79-question-31",
+      "id": "senatni-2022-global-q-31",
       "name": "Podpora zahraniční spolupráce a pomoci",
       "title": "ČR by měla více finančně podporovat zahraniční rozvojovou spolupráci a humanitární pomoc.",
       "gist": "ČR dala v roce 2021 na rozvojovou spolupráci a humanitární pomoc v zahraničí zhruba 7,8 miliard Kč. V poměru k HDP je pomoc Česka dlouhodobě jedna z nejnižších ze zemí OECD a činí zhruba třetinu očekávaného cíle zemí EU.",
@@ -259,7 +261,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-79-question-32",
+      "id": "senatni-2022-global-q-32",
       "name": "Ohled na rozvojové země",
       "title": "ČR by měla při přijímání zákonů brát ohled i na rozvojové země (např. v oblasti změn klimatu).",
       "gist": "Některé zákony přijímané v ČR mají nepřímý dopad i na další země. Např. globální zvyšování hladiny moří dnes probíhá rychlostí asi 1 cm za 3 roky. Zároveň zhruba 1/4 miliardy lidí žije na místech ve výšce méně jak 2 metry nad mořem, kde je riziko, že se budou muset přestěhovat/migrovat.",
@@ -267,7 +269,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-79-question-33",
+      "id": "senatni-2022-global-q-33",
       "name": "Snazší azyl v ČR",
       "title": "Udělení azylu v ČR by se mělo usnadnit.",
       "gist": "Do února 2022 byl počet uprchlíků v Česku v mezinárodním srovnání mimořádně nízký, stejně jako úspěšnost získání azylu (20 %, např. v Rakousku 50 %). Za první dva měsíce od ruské invaze udělila ČR speciální vízum více než 300 tisícům obyvatel Ukrajiny. Jde zhruba o trojnásobek počtu všech žadatelů (úspěšných i neúspěšných) o azyl od roku1993.",
@@ -275,7 +277,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-79-question-34",
+      "id": "senatni-2022-global-q-34",
       "name": "ČR v Schengenu",
       "title": "ČR by měla zůstat v Schengenském prostoru s volným pohybem občanů EU.",
       "gist": "Tzv. Schengenský prostor zahrnuje 22 zemí EU a 4 další země. Obyvatelé nemusí při překročení hranic procházet hraniční kontrolou.",
@@ -283,7 +285,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-79-question-35",
+      "id": "senatni-2022-global-q-35",
       "name": "Více peněz na armádu",
       "title": "ČR by měla dávat více peněz na armádu.",
       "gist": "V roce 2022 dává ČR na obranu cca 88 miliard Kč, což odpovídá asi 1,35 % hrubého domácího produktu (HDP). ČR se zavázala na setkání NATO v roce 2014, že do 10 let bude vydávat na obranu 2 % HDP; průměr v NATO je zhruba 1,7 %.",
@@ -291,7 +293,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-79-question-36",
+      "id": "senatni-2022-global-q-36",
       "name": "Volba pohlaví dítěte",
       "title": "Rodiče v ČR by při umělém oplodnění měli mít možnost si vybrat pohlaví dítěte.",
       "gist": "ČR podepsala tzv. Oviedskou smlouvu o lidských právech a biomedicíně. Tato mezinárodní smlouva mj. zakazuje výběr pohlaví dítěte při umělém oplodnění (s výjimkou některých prokazatelných dědičných poruch). Výběr pohlaví dítěte je nelegální ve většině světa, výjimkou jsou např. USA.",
@@ -299,7 +301,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-79-question-37",
+      "id": "senatni-2022-global-q-37",
       "name": "Zavedení soukromého zdravotního pojištění",
       "title": "Měla by být zavedena možnost soukromého připojištění ke zdravotnímu pojištění.",
       "gist": "Soukromě připojistit lze v některých státech např. finančně nákladnější postup léčby, nadstandard v nemocnicích nebo doplatky za léky. V ČR to dnes není možné. Rozdělení na standardní a nadstandardní léčbu v roce 2013 zrušil Ústavní soud.",
@@ -307,7 +309,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-79-question-38",
+      "id": "senatni-2022-global-q-38",
       "name": "Centralizace specializované lékařské péče",
       "title": "Specializovaná lékařská péče v ČR se má více centralizovat.",
       "gist": "V ČR je dnes podporována centralizace specializované péče (např. onkologická, hematologická, cerebrovaskulární, traumatologická atd.) do několika velkých nemocnic, zejména fakultních. Důvodem jsou vysoké náklady na náležité vybavení ve více zdravotnických zařízeních.",
@@ -315,7 +317,7 @@
       "tags": ["zdravotnictví"]
     },
     {
-      "id": "senatni-2022-79-question-39",
+      "id": "senatni-2022-global-q-39",
       "name": "Zákaz glyfosátu",
       "title": "Používání glyfosátu (např. Roundup) by mělo být zakázáno.",
       "gist": "Mezinárodní agentura pro výzkum rakoviny zařadila glyfosát mezi tzv. pravděpodobné karcinogeny pro člověka. Výrobce nyní čelí tisícovkám žalob kvůli možným zdravotním dopadům. Plánovaný plošný zákaz v ČR ministerstvo zemědělství v roce 2018 podstatně zmírnilo; platí pouze na plodiny pro potravinářské využití. Licence přípravku v EU končí v roce 2022.",
@@ -323,7 +325,7 @@
       "tags": ["zemědělství"]
     },
     {
-      "id": "senatni-2022-79-question-40",
+      "id": "senatni-2022-global-q-40",
       "name": "Stop automatickým systémům kontroly",
       "title": "Mělo by se zastavit používání automatických systémů měření rychlosti a následného vybírání pokut od řidičů.",
       "gist": "Radar s kamerou změří rychlost, umělá inteligence rozpozná z fotografie SPZ auta, systém zašle pokutu. Lidský dohled nad celým procesem je spíše formální. Systém nerozlišuje společenskou nebezpečnost (např. překročení rychlosti ráno v okolí školy nebo naopak v noci mimo obydlenou část obce). Zastánci systému naopak ukazují na jeho nízké náklady.",
@@ -331,7 +333,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-79-question-41",
+      "id": "senatni-2022-global-q-41",
       "name": "Zákaz automatického rozpoznávání obličeje",
       "title": "Používání systémů automatického rozpoznávání obličeje na veřejných místech by mělo být zakázáno.",
       "gist": "Systémy rozpoznávání obličeje pomocí umělé inteligence dokáží mj. sledovat jednotlivé lidi na veřejnosti prostřednictvím kamer. Dnes má takové systémy v ČR zakoupené policie, která usiluje o jejich nasazení.",
@@ -339,7 +341,7 @@
       "tags": ["AI"]
     },
     {
-      "id": "senatni-2022-79-question-42",
+      "id": "senatni-2022-global-q-42",
       "name": "Vstup Ukrajiny do EU",
       "title": "Ukrajina by měla vstoupit do EU.",
       "gist": "Podle zastánců Ukrajina do EU politicky i geograficky patří. Odpůrci namítají, že by šlo o provokaci Ruska, příp. že Ukrajina nesplňuje tzv. kodaňská kritéria (má např. jednu z nejvyšších měr korupce) nebo že se rovnováha sil v EU posune na východ, kde některé země v posledních letech ustupují v otázkách právního státu. Senát vydal v červnu 2022 usnesení, v němž apeluje na státy EU, aby udělily Ukrajině status kandidátské země.",
@@ -347,7 +349,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-79-question-43",
+      "id": "senatni-2022-global-q-43",
       "name": "Vstup Ukrajiny do NATO",
       "title": "Ukrajina by měla vstoupit do NATO.",
       "gist": "Podle kritiků je příliš nebezpečné, aby aliance sahala až k ruské hranici – Ukrajina má zůstat neutrální. Zastánci říkají, že členské země NATO (Estonsko, Lotyšsko a Norsko) s Ruskem sousedí už nyní a že Ukrajina jako svobodný a suverénní stát nemá Rusku ustupovat. To ji vojensky napadlo a chce mj. zabránit jejímu vstupu do NATO.",
@@ -355,7 +357,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-79-question-44",
+      "id": "senatni-2022-global-q-44",
       "name": "Zastropování cen ruského plynu",
       "title": "EU by měla zastropovat ceny ruského plynu.",
       "gist": "Zastánci tak chtějí zmírnit dopady manipulace trhem ze strany ruského prezidenta Vladimira Putina. Odpůrci zmiňují riziko, že Rusko přestane plyn do EU dodávat.",
@@ -363,7 +365,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-79-question-45",
+      "id": "senatni-2022-global-q-45",
       "name": "Činnost současného ombudsmana",
       "title": "Jste spokojeni s dosavadní prací současného veřejného ochránce práv?",
       "gist": "Kritici poukazují, že názory současného ombudsmana neodpovídají poslání, které úřad má. Mohou podle nich odrazovat oběti vyhledávat pomoc právě v rámci působení ochránce. Podle senátního stanoviska se některé výroky staly předmětem veřejných kontroverzí a silné kritiky ze strany institucí a osob zabývajících se ochranou lidských práv. Ombudsman se hájí právem vyjadřovat se.",
@@ -371,7 +373,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-79-question-46",
+      "id": "senatni-2022-global-q-46",
       "name": "Sankce vůči Rusku",
       "title": "Podporujete, aby Rusko neslo následky za rozpoutání války na Ukrajině?",
       "gist": "Senát nedávno odhlasoval usnesení, že Rusko musí nést následky za rozpoutání války proti Ukrajině včetně platby reparací a ruští představitelé, kteří jsou odpovědní za válečné zločiny, musí být postavení před soud a potrestáni.",
@@ -379,7 +381,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-79-question-47",
+      "id": "senatni-2022-global-q-47",
       "name": "Vyjednávání se zástupci Ruska na Krymu",
       "title": "Souhlasíte s tím, aby čeští zákonodárci vyjednávali s ruskou administrativou na Krymu?",
       "gist": "Rusko obsadilo ukrajinský Krym roku 2014 a od února vede proti Ukrajině válku.",
@@ -387,7 +389,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-79-question-48",
+      "id": "senatni-2022-global-q-48",
       "name": "Ratifikace Istanbulské úmluvy",
       "title": "Podpořili byste směrnici EU o potírání násilí vůči ženám a domácího násilí?",
       "gist": "Cílem směrnice je účinně potírat násilí vůči ženám a domácí násilí v celé EU a převzít do českého práva navrhovanou definici násilí na ženách a zavést trestný čin kybernetické pronásledování, obtěžování nebo neodsouhlasené sdílení intimního materiálu například na sociálních sítích. Kritici chtějí otázky trestní odpovědnosti ponechat v rukou členských států EU.",
@@ -395,7 +397,7 @@
       "tags": ["lidská práva"]
     },
     {
-      "id": "senatni-2022-79-question-49",
+      "id": "senatni-2022-global-q-49",
       "name": "Konec spalování uhlí",
       "title": "Má podle vás ČR ukončit spalování uhlí dříve než v roce 2033?",
       "gist": "Ekologové navrhují odklon od spalování uhlí při výrobě energií v roce 2030. K tomu se zavázaly např. Španělsko či Finsko; Spojené království už do roku 2025. Uhelná komise v ČR navrhovala rok 2038. Kvůli současné nejistotě ohledně dodávek plynu energetici připouštějí, že bude v nejbližší době potřeba více uhlí, ovšem krátkodobě.",
@@ -403,7 +405,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-79-question-50",
+      "id": "senatni-2022-global-q-50",
       "name": "Green Deal",
       "title": "Podporuji, aby se EU do roku 2050 stala klimaticky neutrální.",
       "gist": "Podle tzv. Zelené dohody se má v EU do roku 2050 snížit rozdíl mezi vyprodukovanými a spotřebovanými skleníkovými plyny na nulu.",
@@ -411,7 +413,7 @@
       "tags": ["ekologie"]
     },
     {
-      "id": "senatni-2022-79-question-51",
+      "id": "senatni-2022-global-q-51",
       "name": "Krym součást Ruska",
       "title": "ČR by měla uznat Krym jako součást Ruska",
       "gist": "Rusko obsadilo ukrajinský Krym v roce 2014.",
@@ -419,7 +421,7 @@
       "tags": ["zahraničí"]
     },
     {
-      "id": "senatni-2022-79-question-52",
+      "id": "senatni-2022-global-q-52",
       "name": "Dvoustranné jednání s Ruskem",
       "title": "ČR by měla o nákupech plynu jednat s Ruskem samostatně.",
       "gist": "ČR jedná o nákupech plynu z Ruska nyní koordinovaně s většinou EU.",
@@ -427,7 +429,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-79-question-53",
+      "id": "senatni-2022-global-q-53",
       "name": "Rozšíření NATO o Finsko a Švédsko",
       "title": "Souhlasím, aby se NATO rozšířilo o Finsko a Švédsko.",
       "gist": "Dosud neutrální Finsko a Švédsko požádaly o vstup do aliance kvůli ruské invazi na Ukrajinu. Přístupové dokumenty musí ratifikovat všech 30 aliančních států. Rozšíření schválily obě komory Parlamentu ČR a podepsal prezident.",
@@ -435,7 +437,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-79-question-54",
+      "id": "senatni-2022-global-q-54",
       "name": "Zemědělské dotace",
       "title": "Zemědělské dotace by měly být hlavně pro malé farmy.",
       "gist": "Nejvyšší kontrolní úřad poukazuje, že rozdělování dotací je v ČR špatně cílené a že dotace inkasují spíše velké koncerny namísto malých a středních podniků. Koncerny se hájí, že mají stejné podmínky jako všichni ostatní. V ČR se zemědělská výroba koncentruje více do velkých firem. V celé EU je průměrná velikost farmy 18 hektarů, v ČR je to 130 hektarů.",
@@ -443,7 +445,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-79-question-55",
+      "id": "senatni-2022-global-q-55",
       "name": "Menstruační chudoba",
       "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
       "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
@@ -451,7 +453,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-79-question-56",
+      "id": "senatni-2022-global-q-56",
       "name": "Dostupnost bydlení",
       "title": "Měl by vzniknout Státní bytový fond, který by nakupoval a pronajímal byty?",
       "gist": "Zastánci tvrdí, že krize bydlení se nevyřeší jen tím, že se bude víc stavět. Měl by do toho vstoupit stát a začít na trhu skupovat byty, stavět nové, opravovat zničené budovy, revitalizovat brownfieldy. Odpůrci říkají, že nájemní bydlení by měly nadále pořizovat obce a města nebo soukromníci a že by stát měl zajistit co nejjednodušší převod svých pozemků.",
@@ -459,7 +461,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-79-question-57",
+      "id": "senatni-2022-global-q-57",
       "name": "Ukrajina - vzdát se uzemí",
       "title": "Má se Ruskem napadená Ukrajina vzdát okupovaných území a posunout svou hranici?",
       "gist": "Podle zastánců by to mohlo být teoretické východisko k ukončení války. Odpůrci se odvolávají na suverenitu a územní celistvost Ukrajiny a říkají, že Rusku se nesmí ustoupit.",
@@ -467,7 +469,7 @@
       "tags": [""]
     },
     {
-      "id": "senatni-2022-79-question-58",
+      "id": "senatni-2022-global-q-58",
       "name": "Zastavování bezvýsledných exekucí",
       "title": "Dlouhodobě bezvýsledné exekuce se mají zastavovat.",
       "gist": "",
@@ -477,16 +479,16 @@
   ],
   "candidates": [
     {
-      "id": "senatni-2022-79-candidate-228951",
+      "id": "senatni-2022-79-c-228951",
       "name": "Antonín Kuchař",
-      "type": "party",
+      "type": "person",
       "description": "Antonín Kuchař - DESCRIPTION",
       "contacts": {
         "web": []
       },
       "parties": [
         {
-          "id": "senatni-2022-79-228951-party",
+          "id": "senatni-2022-79-c-228951-p",
           "name": "Antonín Kuchař",
           "description": "Antonín Kuchař - DESCRIPTION",
           "contacts": {
@@ -497,9 +499,9 @@
       ]
     },
     {
-      "id": "senatni-2022-79-candidate-231466",
+      "id": "senatni-2022-79-c-231466",
       "name": "Eva Rajchmanová",
-      "type": "party",
+      "type": "person",
       "description": "Eva Rajchmanová - DESCRIPTION",
       "contacts": {
         "web": [
@@ -520,7 +522,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-79-231466-party",
+          "id": "senatni-2022-79-c-231466-p",
           "name": "Eva Rajchmanová",
           "description": "Eva Rajchmanová - DESCRIPTION",
           "contacts": {
@@ -545,9 +547,9 @@
       ]
     },
     {
-      "id": "senatni-2022-79-candidate-623931",
+      "id": "senatni-2022-79-c-623931",
       "name": "Ladislava Brančíková",
-      "type": "party",
+      "type": "person",
       "description": "Ladislava Brančíková - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -555,7 +557,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-79-623931-party",
+          "id": "senatni-2022-79-c-623931-p",
           "name": "Ladislava Brančíková",
           "description": "Ladislava Brančíková - DESCRIPTION",
           "contacts": {
@@ -567,9 +569,9 @@
       ]
     },
     {
-      "id": "senatni-2022-79-candidate-410558",
+      "id": "senatni-2022-79-c-410558",
       "name": "Lenka Ingrová",
-      "type": "party",
+      "type": "person",
       "description": "Lenka Ingrová - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -577,7 +579,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-79-410558-party",
+          "id": "senatni-2022-79-c-410558-p",
           "name": "Lenka Ingrová",
           "description": "Lenka Ingrová - DESCRIPTION",
           "contacts": {
@@ -589,9 +591,9 @@
       ]
     },
     {
-      "id": "senatni-2022-79-candidate-771797",
+      "id": "senatni-2022-79-c-771797",
       "name": "Ivo Vašíček",
-      "type": "party",
+      "type": "person",
       "description": "Ivo Vašíček - DESCRIPTION",
       "contacts": {
         "web": [
@@ -608,7 +610,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-79-771797-party",
+          "id": "senatni-2022-79-c-771797-p",
           "name": "Ivo Vašíček",
           "description": "Ivo Vašíček - DESCRIPTION",
           "contacts": {
@@ -629,9 +631,9 @@
       ]
     },
     {
-      "id": "senatni-2022-79-candidate-266442",
+      "id": "senatni-2022-79-c-266442",
       "name": "Vítězslav Krabička",
-      "type": "party",
+      "type": "person",
       "description": "Vítězslav Krabička - DESCRIPTION",
       "contacts": {
         "web": [],
@@ -639,7 +641,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-79-266442-party",
+          "id": "senatni-2022-79-c-266442-p",
           "name": "Vítězslav Krabička",
           "description": "Vítězslav Krabička - DESCRIPTION",
           "contacts": {
@@ -651,9 +653,9 @@
       ]
     },
     {
-      "id": "senatni-2022-79-candidate-811606",
+      "id": "senatni-2022-79-c-811606",
       "name": "Zbyněk Pastyřík",
-      "type": "party",
+      "type": "person",
       "description": "Zbyněk Pastyřík - DESCRIPTION",
       "contacts": {
         "web": [
@@ -666,7 +668,7 @@
       },
       "parties": [
         {
-          "id": "senatni-2022-79-811606-party",
+          "id": "senatni-2022-79-c-811606-p",
           "name": "Zbyněk Pastyřík",
           "description": "Zbyněk Pastyřík - DESCRIPTION",
           "contacts": {
@@ -683,5 +685,1410 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-2"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-14"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-20"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-47"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-51"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-55"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-57"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-79-c-771797",
+      "question_id": "senatni-2022-79-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-1",
+      "answer": "yes",
+      "comment": "Je třeba ale definovat, co to je ,,dlouhodobě\" - měsíce, roky a jak to a kdo to zjistí a co se myslí pod pojmem - ,,prázdný byt\"."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-3",
+      "answer": "yes",
+      "comment": "Rozhodování občanů přímo - referendem - je zakotveno v Ústavě České republiky."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-4",
+      "comment": "Mám za to, že by mělo být postupováno v souladu s celospolečenským zájmem a ne podle síly té, které betonové lobby."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-5",
+      "answer": "no",
+      "comment": "Naopak, měla by se přehodnotit současná věková hranice odchodu do důchodu a v první fázi stanovit nižší věkovou hranici odchodu do důchodu u profesí s vysokou fyzickou             \n i psychickou zátěží."
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-7",
+      "comment": "Názory i odborníků se různí a to vzhledem k náročnosti sběru zálohových PET lahví                \ni náročnosti dalšího použití."
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-8",
+      "answer": "yes",
+      "comment": "Je to nejen o solidaritě ,,bohatých\" s ,,chudými\", ale i o tom, že podíl ,,bohatých\" na využívání veřejných prostředků je zpravidla svojí mírou vyšší."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-9"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-12"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-16"
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-17"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-21"
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-22",
+      "answer": "no",
+      "comment": "Pokud je to otázka míněna vážně, tak u mne vyvolává - 🙂."
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-23",
+      "answer": "no",
+      "comment": "Touto formou nelze zajistit dodržení základních atributů volby - zejména tajnost volebního aktu a zaručit, že takto volí skutečně zapsaný volič."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-24",
+      "answer": "yes",
+      "comment": "Souhlasím, ale bez dovětku ,,než jiné obory\"."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-25",
+      "comment": "Vždy by měla zůstat možnost individuální volby ze stanovených podmínek."
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-26",
+      "answer": "no",
+      "comment": "Inkluze ve školách je jeden velký omyl. "
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-27",
+      "answer": "yes",
+      "comment": "A to zavčas!"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-29",
+      "answer": "yes",
+      "comment": "ČR by neměla být členem žádného vojenského bloku."
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-31",
+      "comment": "Nejsem proti adresné a konkrétní humanitární pomoci, ale zásadně nesouhlasím s ,,humanitární pomocí\" dodávkami zbraní a vojenské výstroje do oblastí vojenských konfliktů."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-32"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-33",
+      "answer": "no",
+      "comment": "Naopak, mělo by se zpřísnit."
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-34"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-35",
+      "answer": "no",
+      "comment": "Pro mne jsou přednější a důležitější výdaje na sociální zabezpečení a na rozvoj společnosti."
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-36",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-37",
+      "answer": "no",
+      "comment": "Se zavedením soukromého připojištění se i výkony rozdělí na ,,standardní a nestandardní\"    \na tím nutně dojde k omezení rozsahu zdravotní péče z veřejných prostředků."
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-38",
+      "comment": "To by mohlo vést, spolu s další úpravou, ke snížení dostupnosti péče pro standardně zdravotně pojištěné občany. "
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-40"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-41",
+      "comment": "Nedá se zcela vyloučit zneužití."
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-42",
+      "answer": "no",
+      "comment": "Pokud by z EU Česká republika vystoupila, bylo by na orgánech a zemích EU, koho si do EU přijmou."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-43",
+      "answer": "no",
+      "comment": "NATO by mělo být rozpuštěno, obdobně jako Varšavská smlouva."
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-44",
+      "answer": "no",
+      "comment": ",,Zastropovat\" ceny všech energií by měla především Česká republika, bez ohledu na to, zda se v EU dohodnou a jak "
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-45",
+      "answer": "yes",
+      "comment": "Dle veřejných informací."
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-46",
+      "comment": "Jde o sugestivní a zkratkovou otázku, není jeden viník tohoto stavu, včetně pokračování konfliktu."
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-49",
+      "answer": "no",
+      "comment": "S ohledem na dopady Zelené dohody by mělo dojít co nejdříve k její revizi."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-50",
+      "answer": "no",
+      "comment": "Nelze řešit ,,zelenou politiku\" Evropy bez souběžného řešení na ostatních kontinentech, zejména Asie a Ameriky."
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-52",
+      "answer": "yes",
+      "comment": "Stejně jako Slovensko, Maďarsko i Německo a další země."
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-53",
+      "answer": "no",
+      "comment": "Jak jsem uvedla shora, požaduji rozpuštění NATO."
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-54",
+      "answer": "no",
+      "comment": "Zemědělské dotace by s ohledem na mezinárodní konkurenci měly být poskytovány, tak aby zajistili soběstačnost v zemědělské výrobě České republiky v úrovni 80 %."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-55"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-57",
+      "comment": "To není otázka pro české občany a ani zákonodárce. Rozhodovat o tom budou jiní a jinde..."
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-79-c-410558",
+      "question_id": "senatni-2022-79-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-3",
+      "answer": "yes",
+      "comment": "Ano, ale s přesně definovanými podmínkami referenda."
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-6",
+      "answer": "yes",
+      "comment": "Souhlasím, ovšem za podmínky předchozího pečlivě provedeného průzkumu nezbytnosti."
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-9",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-16",
+      "answer": "no",
+      "comment": "Nikomu neupírám jeho práva, ale pouze svazek muže a ženy je manželství."
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-21",
+      "answer": "yes",
+      "comment": "Pokud to pomůže dobré věci, zcela jednoznačně ano."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-22"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-23",
+      "answer": "yes",
+      "comment": "Ano, pokud bude zajištěna 100% nezneužitelnost."
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-24",
+      "answer": "yes",
+      "comment": "Z důvodu nedostatku řemesel."
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-31"
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-36"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-39",
+      "answer": "no",
+      "comment": "Ne zákaz, ale omezení používání."
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-42",
+      "answer": "yes",
+      "comment": "Ano, za splnění vstupních podmínek."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-43"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-49",
+      "answer": "no",
+      "comment": "Za současné energetické krize ne."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-56",
+      "answer": "no",
+      "comment": "Tato provomoc by měla zůstat v kompetenci obcí a měst."
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-79-c-228951",
+      "question_id": "senatni-2022-79-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-4",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-1",
+      "answer": "no",
+      "comment": "Definujme pojem \"dlouhodobě prázdný byt\" a jak by se posuzoval, když nás státním systém neeviduje tzv. přechodné pobyty."
+    },
+    {
+      "id": "senatni-2022-global-a-7",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-2",
+      "answer": "no",
+      "comment": "Nikoliv, ale naopak by ČR přijmout nástroje rozšíření bytové nabídky a zlepšení dostupnosti bydlení, zejména výstavbou a pronájmem státních, obecních a družstevních bytů, tak jako tomu je například ve Vídni."
+    },
+    {
+      "id": "senatni-2022-global-a-10",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-3"
+    },
+    {
+      "id": "senatni-2022-global-a-13",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-4",
+      "comment": "Výstavba liniových staveb silniční a železniční povahy je stejně důležitá, nejdůležitější je však infrastruktura pro energetiku."
+    },
+    {
+      "id": "senatni-2022-global-a-16",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-19",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-22",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-7",
+      "answer": "no",
+      "comment": "Protože zálohování pouze upravuje problematiku třídění odpadů, avšak třídění odpadů je u nás velmi dobré, problémem je následná recyklace vytříděných odpadů, což zálohování stejně neřeší a odčerpává zdroje finančních prostředků z oblasti odpadového hospodářství."
+    },
+    {
+      "id": "senatni-2022-global-a-25",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-8",
+      "answer": "yes",
+      "comment": "Spíše ano, vzhledem k současné ekonomické situaci."
+    },
+    {
+      "id": "senatni-2022-global-a-28",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-9"
+    },
+    {
+      "id": "senatni-2022-global-a-31",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-10"
+    },
+    {
+      "id": "senatni-2022-global-a-34",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-11",
+      "comment": "Spíše ano."
+    },
+    {
+      "id": "senatni-2022-global-a-37",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-12",
+      "answer": "no",
+      "comment": "Zodpovědní mají být především uživatelé a to jak \"publikující\" tak \"sledující.\" "
+    },
+    {
+      "id": "senatni-2022-global-a-40",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-13",
+      "comment": "Kdo o tom bude rozhodovat, co je \"pravda.\" ? nějaký nejvyšší úřad pseudocenzora? "
+    },
+    {
+      "id": "senatni-2022-global-a-43",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-14",
+      "answer": "no",
+      "comment": "Avšak pozor, veřejnoprávní média by měla hospodařit zodpovědněji."
+    },
+    {
+      "id": "senatni-2022-global-a-46",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-49",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-16",
+      "answer": "no",
+      "comment": "Otázka je nepřesná. Manželství je svazek muže a ženy. "
+    },
+    {
+      "id": "senatni-2022-global-a-52",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-17",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-55",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-58",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-19",
+      "comment": "Definujme nejprve co je \"sociální byt\" když například z hlediska snížení sazby DPH je již dnes většina bytů sociálním bydlením."
+    },
+    {
+      "id": "senatni-2022-global-a-61",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-20"
+    },
+    {
+      "id": "senatni-2022-global-a-64",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-21",
+      "answer": "yes",
+      "comment": "Ale to je zavádějící otázka. Hlavně potřebuje decentralizaci a reformu veřejné správy v čele s obnovením země Moravskoslezské."
+    },
+    {
+      "id": "senatni-2022-global-a-67",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-22"
+    },
+    {
+      "id": "senatni-2022-global-a-70",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-73",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-76",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-79",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-26"
+    },
+    {
+      "id": "senatni-2022-global-a-82",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-27",
+      "answer": "no",
+      "comment": "Ovšem EU se musí reformovat. Zachovat suverenitu členských států a odstranit snahy o většinovém hlasování s odstraněním \"práva veta.\""
+    },
+    {
+      "id": "senatni-2022-global-a-85",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-28",
+      "comment": "Ano, ovšem nyní ani v nadcházejících pár letech nikoliv. Naše ekonomika na to není ještě připravena."
+    },
+    {
+      "id": "senatni-2022-global-a-88",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-91",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-30",
+      "comment": "Místo ČR je především uprostřed Střední Evropy, v rámci V4."
+    },
+    {
+      "id": "senatni-2022-global-a-94",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-31",
+      "answer": "no",
+      "comment": "Tuto součanou pomoc našeho státu považuji za dostatečnou. Nezapomínejme na pomoc našim ohroženým či zranitelným občanům."
+    },
+    {
+      "id": "senatni-2022-global-a-97",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-32",
+      "answer": "no",
+      "comment": "Velmi divná otázka. "
+    },
+    {
+      "id": "senatni-2022-global-a-100",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-103",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-34",
+      "answer": "yes",
+      "comment": "Ano, ale za podmínky důrazné a funkční ochrany vnější hranice Schengenu."
+    },
+    {
+      "id": "senatni-2022-global-a-106",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-109",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-112",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-115",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-118",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-39"
+    },
+    {
+      "id": "senatni-2022-global-a-121",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-124",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-41"
+    },
+    {
+      "id": "senatni-2022-global-a-127",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-42",
+      "comment": "Velmi ale velmi předčasná otázka. Ano, možná někdy v budoucnu po splnění všech podmínek přístupových rozhovorů."
+    },
+    {
+      "id": "senatni-2022-global-a-130",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-133",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-44",
+      "answer": "yes",
+      "comment": "Ale vlastně proč, když EU nechce odebírat Ruský plyn."
+    },
+    {
+      "id": "senatni-2022-global-a-136",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-45"
+    },
+    {
+      "id": "senatni-2022-global-a-139",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-142",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-47"
+    },
+    {
+      "id": "senatni-2022-global-a-145",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-48",
+      "comment": "Přiznávám, že v této oblasti musím nejprve načerpat hlubší informace."
+    },
+    {
+      "id": "senatni-2022-global-a-148",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-49",
+      "answer": "no",
+      "comment": "A hlavně, staré technologie (spalování uhlí) mají být nahrazovány novými technologiemi na základě principu tržního hospodářství a efektivity novějších technologií při jejich provozním zlevnění apod."
+    },
+    {
+      "id": "senatni-2022-global-a-151",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-50"
+    },
+    {
+      "id": "senatni-2022-global-a-154",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-51"
+    },
+    {
+      "id": "senatni-2022-global-a-157",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-52"
+    },
+    {
+      "id": "senatni-2022-global-a-160",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-global-a-163",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-54",
+      "answer": "no",
+      "comment": "Dnes je bohužel v EU nastavena zemědělská politika pro naše zemědělství tak špatně, že není možné dotovat jen některé malé farmy."
+    },
+    {
+      "id": "senatni-2022-global-a-166",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-169",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-global-a-172",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-57"
+    },
+    {
+      "id": "senatni-2022-global-a-175",
+      "candidate_id": "senatni-2022-79-c-811606",
+      "question_id": "senatni-2022-79-q-58",
+      "answer": "no"
+    }
+  ]
 }


### PR DESCRIPTION
Now question/answer ids are stable - based on question number.

It was generated with `make run-converter`