### PR TITLE
add color: inherit to IconButton & Button

### DIFF
--- a/frontend/src/components/design-system/input/ButtonComponent.vue
+++ b/frontend/src/components/design-system/input/ButtonComponent.vue
@@ -69,6 +69,7 @@ const computedSize = computed(() =>
   background-color: transparent;
   text-decoration: none;
   touch-action: manipulation;
+  color: inherit;
 
   &:disabled {
     cursor: not-allowed;

--- a/frontend/src/components/design-system/input/IconButton.vue
+++ b/frontend/src/components/design-system/input/IconButton.vue
@@ -16,6 +16,7 @@
   border-radius: 50%;
   border: none;
   cursor: pointer;
+  color: inherit;
 
   &:disabled {
     color: rgb(var(--color-neutral-fg-disabled));


### PR DESCRIPTION
Turned out that if a button that wraps the svg doesn't have an explicit color, iOS tends to make it default iOS blue. Simple color: inherit fixed this.