### PR TITLE
VK-201: Make generation dummy

### DIFF
--- a/backend/converter.py
+++ b/backend/converter.py
@@ -163,6 +163,9 @@ class Election:
     def answers(self) -> dict[District, dict[str, CandidateAnswers]]:
         return self._answers
 
+    def __str__(self) -> str:
+        return f"Election(id='{self.id}', key='{self.key}', name='{self.name}')"
+
 
 def gen_district_id(election: Election, code: str) -> str:
     return f"{election.key}-{code}"

--- a/data/kalkulacka/calculators.json
+++ b/data/kalkulacka/calculators.json
@@ -252,14 +252,6 @@
     },
     {
       "election_id": "komunalni-2022",
-      "district_code": "554821",
-      "name": "Ostrava",
-      "description": "Ostrava",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
       "district_code": "554791",
       "name": "Plzeň",
       "description": "Plzeň",
@@ -271,22 +263,6 @@
       "district_code": "563889",
       "name": "Liberec",
       "description": "Liberec",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "500496",
-      "name": "Olomouc",
-      "description": "Olomouc",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "544256",
-      "name": "České Budějovice",
-      "description": "České Budějovice",
       "on_hp_from": "2022-09-01T00:00:00",
       "on_hp_to": "2022-09-30T14:00:00"
     },
@@ -316,62 +292,6 @@
     },
     {
       "election_id": "komunalni-2022",
-      "district_code": "585068",
-      "name": "Zlín",
-      "description": "Zlín",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "555088",
-      "name": "Havířov",
-      "description": "Havířov",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "532053",
-      "name": "Kladno",
-      "description": "Kladno",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "567027",
-      "name": "Most",
-      "description": "Most",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "505927",
-      "name": "Opava",
-      "description": "Opava",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "598003",
-      "name": "Frýdek-Místek",
-      "description": "Frýdek-Místek",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "586846",
-      "name": "Jihlava",
-      "description": "Jihlava",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
       "district_code": "598917",
       "name": "Karviná",
       "description": "Karviná",
@@ -380,137 +300,9 @@
     },
     {
       "election_id": "komunalni-2022",
-      "district_code": "567442",
-      "name": "Teplice",
-      "description": "Teplice",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "562971",
-      "name": "Chomutov",
-      "description": "Chomutov",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "554961",
-      "name": "Karlovy Vary",
-      "description": "Karlovy Vary",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "562335",
-      "name": "Děčín",
-      "description": "Děčín",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "563510",
-      "name": "Jablonec nad Nisou",
-      "description": "Jablonec nad Nisou",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "535419",
-      "name": "Mladá Boleslav",
-      "description": "Mladá Boleslav",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "589250",
-      "name": "Prostějov",
-      "description": "Prostějov",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "511382",
-      "name": "Přerov",
-      "description": "Přerov",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "561380",
-      "name": "Česká Lípa",
-      "description": "Česká Lípa",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
       "district_code": "590266",
       "name": "Třebíč",
       "description": "Třebíč",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "598810",
-      "name": "Třinec",
-      "description": "Třinec",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "552046",
-      "name": "Tábor",
-      "description": "Tábor",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "593711",
-      "name": "Znojmo",
-      "description": "Znojmo",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "533165",
-      "name": "Kolín",
-      "description": "Kolín",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "539911",
-      "name": "Příbram",
-      "description": "Příbram",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "554481",
-      "name": "Cheb",
-      "description": "Cheb",
-      "on_hp_from": "2022-09-01T00:00:00",
-      "on_hp_to": "2022-09-30T14:00:00"
-    },
-    {
-      "election_id": "komunalni-2022",
-      "district_code": "549240",
-      "name": "Písek",
-      "description": "Písek",
       "on_hp_from": "2022-09-01T00:00:00",
       "on_hp_to": "2022-09-30T14:00:00"
     }

--- a/data/kalkulacka/komunalni-2022/554782.json
+++ b/data/kalkulacka/komunalni-2022/554782.json
@@ -514,7 +514,7 @@
       "id": "komunalni-2022-554782-c-540309",
       "name": "Svobodní",
       "type": "party",
-      "description": "Svobodní - DESCRIPTION",
+      "description": "Svobodní",
       "img_url": "svobodní",
       "contacts": {
         "web": []
@@ -523,7 +523,7 @@
         {
           "id": "komunalni-2022-554782-c-540309-p",
           "name": "Svobodní",
-          "description": "Svobodní - DESCRIPTION",
+          "description": "Svobodní",
           "contacts": {
             "web": []
           },
@@ -535,7 +535,7 @@
       "id": "komunalni-2022-554782-c-254716",
       "name": "PRAHA NÁŠ DOMOV",
       "type": "party",
-      "description": "PRAHA NÁŠ DOMOV - DESCRIPTION",
+      "description": "PRAHA NÁŠ DOMOV",
       "img_url": "rozum-suver-dom",
       "contacts": {
         "web": [
@@ -550,7 +550,7 @@
         {
           "id": "komunalni-2022-554782-c-254716-p",
           "name": "PRAHA NÁŠ DOMOV",
-          "description": "PRAHA NÁŠ DOMOV - DESCRIPTION",
+          "description": "PRAHA NÁŠ DOMOV",
           "contacts": {
             "web": [
               {
@@ -568,7 +568,7 @@
       "id": "komunalni-2022-554782-c-856015",
       "name": "Praha bez chaosu",
       "type": "party",
-      "description": "Praha bez chaosu - DESCRIPTION",
+      "description": "Praha bez chaosu",
       "img_url": "p bez chaosu-nk",
       "contacts": {
         "web": [],
@@ -579,7 +579,7 @@
         {
           "id": "komunalni-2022-554782-c-856015-p",
           "name": "Praha bez chaosu",
-          "description": "Praha bez chaosu - DESCRIPTION",
+          "description": "Praha bez chaosu",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/pbch.cz",
@@ -593,7 +593,7 @@
       "id": "komunalni-2022-554782-c-550372",
       "name": "PRAHA SOBĚ",
       "type": "party",
-      "description": "PRAHA SOBĚ - DESCRIPTION",
+      "description": "PRAHA SOBĚ",
       "img_url": "praha sobě-nk",
       "contacts": {
         "web": [
@@ -618,7 +618,7 @@
         {
           "id": "komunalni-2022-554782-c-550372-p",
           "name": "PRAHA SOBĚ",
-          "description": "PRAHA SOBĚ - DESCRIPTION",
+          "description": "PRAHA SOBĚ",
           "contacts": {
             "web": [
               {
@@ -646,7 +646,7 @@
       "id": "komunalni-2022-554782-c-917016",
       "name": "LEPŠÍ PRAHA PRO PRAŽANY – snížení daně z nemovitých věcí o 50%, městská hromadná doprava zdarma, internet zdarma…",
       "type": "party",
-      "description": "LEPŠÍ PRAHA PRO PRAŽANY – snížení daně z nemovitých věcí o 50%, městská hromadná doprava zdarma, internet zdarma… - DESCRIPTION",
+      "description": "LEPŠÍ PRAHA PRO PRAŽANY – snížení daně z nemovitých věcí o 50%, městská hromadná doprava zdarma, internet zdarma…",
       "img_url": "nd-ans",
       "contacts": {
         "web": [
@@ -661,7 +661,7 @@
         {
           "id": "komunalni-2022-554782-c-917016-p",
           "name": "LEPŠÍ PRAHA PRO PRAŽANY – snížení daně z nemovitých věcí o 50%, městská hromadná doprava zdarma, internet zdarma…",
-          "description": "LEPŠÍ PRAHA PRO PRAŽANY – snížení daně z nemovitých věcí o 50%, městská hromadná doprava zdarma, internet zdarma… - DESCRIPTION",
+          "description": "LEPŠÍ PRAHA PRO PRAŽANY – snížení daně z nemovitých věcí o 50%, městská hromadná doprava zdarma, internet zdarma…",
           "contacts": {
             "web": [
               {
@@ -679,7 +679,7 @@
       "id": "komunalni-2022-554782-c-528817",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
-      "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "description": "STAROSTOVÉ A NEZÁVISLÍ",
       "img_url": "stan",
       "contacts": {
         "web": [
@@ -696,7 +696,7 @@
         {
           "id": "komunalni-2022-554782-c-528817-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
-          "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+          "description": "STAROSTOVÉ A NEZÁVISLÍ",
           "contacts": {
             "web": [
               {
@@ -716,7 +716,7 @@
       "id": "komunalni-2022-554782-c-684523",
       "name": "Volte Pravý Blok - stranu za ODVOLATELNOST politiků a státních úředníků PŘÍMO OBČANY",
       "type": "party",
-      "description": "Volte Pravý Blok - stranu za ODVOLATELNOST politiků a státních úředníků PŘÍMO OBČANY - DESCRIPTION",
+      "description": "Volte Pravý Blok - stranu za ODVOLATELNOST politiků a státních úředníků PŘÍMO OBČANY",
       "img_url": "pb",
       "contacts": {
         "web": []
@@ -725,7 +725,7 @@
         {
           "id": "komunalni-2022-554782-c-684523-p",
           "name": "Volte Pravý Blok - stranu za ODVOLATELNOST politiků a státních úředníků PŘÍMO OBČANY",
-          "description": "Volte Pravý Blok - stranu za ODVOLATELNOST politiků a státních úředníků PŘÍMO OBČANY - DESCRIPTION",
+          "description": "Volte Pravý Blok - stranu za ODVOLATELNOST politiků a státních úředníků PŘÍMO OBČANY",
           "contacts": {
             "web": []
           },
@@ -737,7 +737,7 @@
       "id": "komunalni-2022-554782-c-738486",
       "name": "Česká pirátská strana",
       "type": "party",
-      "description": "Česká pirátská strana - DESCRIPTION",
+      "description": "Česká pirátská strana",
       "img_url": "piráti",
       "contacts": {
         "web": [
@@ -757,7 +757,7 @@
         {
           "id": "komunalni-2022-554782-c-738486-p",
           "name": "Česká pirátská strana",
-          "description": "Česká pirátská strana - DESCRIPTION",
+          "description": "Česká pirátská strana",
           "contacts": {
             "web": [
               {
@@ -780,7 +780,7 @@
       "id": "komunalni-2022-554782-c-401009",
       "name": "Motoristé sobě",
       "type": "party",
-      "description": "Motoristé sobě - DESCRIPTION",
+      "description": "Motoristé sobě",
       "img_url": "auto",
       "contacts": {
         "web": [
@@ -799,7 +799,7 @@
         {
           "id": "komunalni-2022-554782-c-401009-p",
           "name": "Motoristé sobě",
-          "description": "Motoristé sobě - DESCRIPTION",
+          "description": "Motoristé sobě",
           "contacts": {
             "web": [
               {
@@ -821,7 +821,7 @@
       "id": "komunalni-2022-554782-c-305273",
       "name": "Přísaha s Patrioty",
       "type": "party",
-      "description": "Přísaha s Patrioty - DESCRIPTION",
+      "description": "Přísaha s Patrioty",
       "img_url": "patrčr-přísaha",
       "contacts": {
         "web": [
@@ -836,7 +836,7 @@
         {
           "id": "komunalni-2022-554782-c-305273-p",
           "name": "Přísaha s Patrioty",
-          "description": "Přísaha s Patrioty - DESCRIPTION",
+          "description": "Přísaha s Patrioty",
           "contacts": {
             "web": [
               {
@@ -854,7 +854,7 @@
       "id": "komunalni-2022-554782-c-532713",
       "name": "Za bezpečné ulice v Praze",
       "type": "party",
-      "description": "Za bezpečné ulice v Praze - DESCRIPTION",
+      "description": "Za bezpečné ulice v Praze",
       "img_url": "dsss-bez-ul",
       "contacts": {
         "web": []
@@ -863,7 +863,7 @@
         {
           "id": "komunalni-2022-554782-c-532713-p",
           "name": "Za bezpečné ulice v Praze",
-          "description": "Za bezpečné ulice v Praze - DESCRIPTION",
+          "description": "Za bezpečné ulice v Praze",
           "contacts": {
             "web": []
           },
@@ -875,7 +875,7 @@
       "id": "komunalni-2022-554782-c-476009",
       "name": "Urza.cz: Nechceme vaše hlasy; ke svobodě se nelze provolit... Máme jinou vizi. Jdeme jinou cestou.",
       "type": "party",
-      "description": "Urza.cz: Nechceme vaše hlasy; ke svobodě se nelze provolit... Máme jinou vizi. Jdeme jinou cestou. - DESCRIPTION",
+      "description": "Urza.cz: Nechceme vaše hlasy; ke svobodě se nelze provolit... Máme jinou vizi. Jdeme jinou cestou.",
       "img_url": "nevolte urza.cz",
       "contacts": {
         "web": []
@@ -884,7 +884,7 @@
         {
           "id": "komunalni-2022-554782-c-476009-p",
           "name": "Urza.cz: Nechceme vaše hlasy; ke svobodě se nelze provolit... Máme jinou vizi. Jdeme jinou cestou.",
-          "description": "Urza.cz: Nechceme vaše hlasy; ke svobodě se nelze provolit... Máme jinou vizi. Jdeme jinou cestou. - DESCRIPTION",
+          "description": "Urza.cz: Nechceme vaše hlasy; ke svobodě se nelze provolit... Máme jinou vizi. Jdeme jinou cestou.",
           "contacts": {
             "web": []
           },
@@ -896,7 +896,7 @@
       "id": "komunalni-2022-554782-c-595054",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
-      "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "description": "Komunistická strana Čech a Moravy",
       "img_url": "ksčm",
       "contacts": {
         "web": [
@@ -911,7 +911,7 @@
         {
           "id": "komunalni-2022-554782-c-595054-p",
           "name": "Komunistická strana Čech a Moravy",
-          "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+          "description": "Komunistická strana Čech a Moravy",
           "contacts": {
             "web": [
               {
@@ -929,7 +929,7 @@
       "id": "komunalni-2022-554782-c-304346",
       "name": "SPOLU pro Prahu (ODS, TOP 09, KDU-ČSL)",
       "type": "party",
-      "description": "SPOLU pro Prahu (ODS, TOP 09, KDU-ČSL) - DESCRIPTION",
+      "description": "SPOLU pro Prahu (ODS, TOP 09, KDU-ČSL)",
       "img_url": "kdu-ods-top 09",
       "contacts": {
         "web": [
@@ -950,7 +950,7 @@
         {
           "id": "komunalni-2022-554782-c-304346-p",
           "name": "SPOLU pro Prahu (ODS, TOP 09, KDU-ČSL)",
-          "description": "SPOLU pro Prahu (ODS, TOP 09, KDU-ČSL) - DESCRIPTION",
+          "description": "SPOLU pro Prahu (ODS, TOP 09, KDU-ČSL)",
           "contacts": {
             "web": [
               {
@@ -974,7 +974,7 @@
       "id": "komunalni-2022-554782-c-834158",
       "name": "Solidarita – koalice ČSSD, Zelených, Budoucnosti a Idealistů",
       "type": "party",
-      "description": "Solidarita – koalice ČSSD, Zelených, Budoucnosti a Idealistů - DESCRIPTION",
+      "description": "Solidarita – koalice ČSSD, Zelených, Budoucnosti a Idealistů",
       "img_url": "ze-čssd-bud-ide",
       "contacts": {
         "web": [
@@ -999,7 +999,7 @@
         {
           "id": "komunalni-2022-554782-c-834158-p",
           "name": "Solidarita – koalice ČSSD, Zelených, Budoucnosti a Idealistů",
-          "description": "Solidarita – koalice ČSSD, Zelených, Budoucnosti a Idealistů - DESCRIPTION",
+          "description": "Solidarita – koalice ČSSD, Zelených, Budoucnosti a Idealistů",
           "contacts": {
             "web": [
               {
@@ -1027,7 +1027,7 @@
       "id": "komunalni-2022-554782-c-514272",
       "name": "SPD, Trikolora, Hnutí PES a nezávislí společně pro Prahu",
       "type": "party",
-      "description": "SPD, Trikolora, Hnutí PES a nezávislí společně pro Prahu - DESCRIPTION",
+      "description": "SPD, Trikolora, Hnutí PES a nezávislí společně pro Prahu",
       "img_url": "spd-trik-pes-nk",
       "contacts": {
         "web": []
@@ -1036,7 +1036,7 @@
         {
           "id": "komunalni-2022-554782-c-514272-p",
           "name": "SPD, Trikolora, Hnutí PES a nezávislí společně pro Prahu",
-          "description": "SPD, Trikolora, Hnutí PES a nezávislí společně pro Prahu - DESCRIPTION",
+          "description": "SPD, Trikolora, Hnutí PES a nezávislí společně pro Prahu",
           "contacts": {
             "web": []
           },
@@ -1048,7 +1048,7 @@
       "id": "komunalni-2022-554782-c-393428",
       "name": "Společnost proti developerské výstavbě v Prokopském údolí",
       "type": "party",
-      "description": "Společnost proti developerské výstavbě v Prokopském údolí - DESCRIPTION",
+      "description": "Společnost proti developerské výstavbě v Prokopském údolí",
       "img_url": "spdv",
       "contacts": {
         "web": []
@@ -1057,7 +1057,7 @@
         {
           "id": "komunalni-2022-554782-c-393428-p",
           "name": "Společnost proti developerské výstavbě v Prokopském údolí",
-          "description": "Společnost proti developerské výstavbě v Prokopském údolí - DESCRIPTION",
+          "description": "Společnost proti developerské výstavbě v Prokopském údolí",
           "contacts": {
             "web": []
           },
@@ -1069,7 +1069,7 @@
       "id": "komunalni-2022-554782-c-174835",
       "name": "Volt",
       "type": "party",
-      "description": "Volt - DESCRIPTION",
+      "description": "Volt",
       "img_url": "včr",
       "contacts": {
         "web": [
@@ -1086,7 +1086,7 @@
         {
           "id": "komunalni-2022-554782-c-174835-p",
           "name": "Volt",
-          "description": "Volt - DESCRIPTION",
+          "description": "Volt",
           "contacts": {
             "web": [
               {
@@ -1106,7 +1106,7 @@
       "id": "komunalni-2022-554782-c-318069",
       "name": "DOST",
       "type": "party",
-      "description": "DOST - DESCRIPTION",
+      "description": "DOST",
       "img_url": "dost",
       "contacts": {
         "web": []
@@ -1115,7 +1115,7 @@
         {
           "id": "komunalni-2022-554782-c-318069-p",
           "name": "DOST",
-          "description": "DOST - DESCRIPTION",
+          "description": "DOST",
           "contacts": {
             "web": []
           },
@@ -1127,7 +1127,7 @@
       "id": "komunalni-2022-554782-c-464824",
       "name": "S.O.S. ZA PRÁVA ZVÍŘAT — Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
       "type": "party",
-      "description": "S.O.S. ZA PRÁVA ZVÍŘAT — Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+      "description": "S.O.S. ZA PRÁVA ZVÍŘAT — Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
       "img_url": "dsz-nk",
       "contacts": {
         "web": []
@@ -1136,7 +1136,7 @@
         {
           "id": "komunalni-2022-554782-c-464824-p",
           "name": "S.O.S. ZA PRÁVA ZVÍŘAT — Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
-          "description": "S.O.S. ZA PRÁVA ZVÍŘAT — Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+          "description": "S.O.S. ZA PRÁVA ZVÍŘAT — Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
           "contacts": {
             "web": []
           },
@@ -1148,7 +1148,7 @@
       "id": "komunalni-2022-554782-c-662662",
       "name": "ANO 2011",
       "type": "party",
-      "description": "ANO 2011 - DESCRIPTION",
+      "description": "ANO 2011",
       "img_url": "ano",
       "contacts": {
         "web": [],
@@ -1159,7 +1159,7 @@
         {
           "id": "komunalni-2022-554782-c-662662-p",
           "name": "ANO 2011",
-          "description": "ANO 2011 - DESCRIPTION",
+          "description": "ANO 2011",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/ANOPraha/",
@@ -1173,7 +1173,7 @@
       "id": "komunalni-2022-554782-c-568122",
       "name": "Strana soukromníků ČR, Koruna Česká (monarch. strana Čech, Moravy a Slezska), Konzervat. strana, Klub angaž. nestraníků",
       "type": "party",
-      "description": "Strana soukromníků ČR, Koruna Česká (monarch. strana Čech, Moravy a Slezska), Konzervat. strana, Klub angaž. nestraníků - DESCRIPTION",
+      "description": "Strana soukromníků ČR, Koruna Česká (monarch. strana Čech, Moravy a Slezska), Konzervat. strana, Klub angaž. nestraníků",
       "img_url": "konskanmonsoukr",
       "contacts": {
         "web": [
@@ -1187,7 +1187,7 @@
         {
           "id": "komunalni-2022-554782-c-568122-p",
           "name": "Strana soukromníků ČR, Koruna Česká (monarch. strana Čech, Moravy a Slezska), Konzervat. strana, Klub angaž. nestraníků",
-          "description": "Strana soukromníků ČR, Koruna Česká (monarch. strana Čech, Moravy a Slezska), Konzervat. strana, Klub angaž. nestraníků - DESCRIPTION",
+          "description": "Strana soukromníků ČR, Koruna Česká (monarch. strana Čech, Moravy a Slezska), Konzervat. strana, Klub angaž. nestraníků",
           "contacts": {
             "web": [
               {
@@ -6645,6 +6645,766 @@
     {
       "id": "komunalni-2022-554782-a-514272-62",
       "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-62",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-1",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "no",
+      "comment": "Praha je pro všechny Pražany"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-2",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-2",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-3",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no",
+      "comment": "Problém je v tom, že Praha nebude mít plyn na vytápění obecně"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-4",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-4",
+      "answer": "no",
+      "comment": "Průjezdnost Prahy se musí řešit jinak!"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-5",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-6",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-6",
+      "answer": "yes",
+      "comment": "Bezpečnost je důležitá"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-7",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-8",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-9",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-10",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-11",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-12",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-12",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-13",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-13",
+      "answer": "yes",
+      "comment": "Pokud město nezajistí dostatek plynu, bude i v těchto budovách chladno"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-14",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-14",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-15",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-15",
+      "answer": "no",
+      "comment": "Otázka řeší následek, ne příčinu. Praha musí zajistit dostatek energie!"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-16",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-17",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-18",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-19",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-20",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-20",
+      "answer": "yes",
+      "comment": "Praha by měla začít více stavět dostupné bydlení"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-21",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-21",
+      "answer": "yes",
+      "comment": "Bude to nutnost"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-22",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-23",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-24",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-24",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-25",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-25",
+      "answer": "yes",
+      "comment": "Současný chaos v zónách městských částí je nutné zastavit"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-26",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-27",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-27",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-28",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes",
+      "comment": "Je to praxe velkých evropských měst, například Vídně"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-29",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-29",
+      "answer": "no",
+      "comment": "Město má řešit dopravu jako celek"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-30",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-30",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-31",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-32",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-32",
+      "answer": "dont_know",
+      "comment": "Na druhou stranu, vzhledem k trendům ve výrobě vozidel, to bude zřejmě nutnost"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-33",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-34",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-34",
+      "answer": "yes",
+      "comment": "Resp. děti mají mít výhody pro cestování MHD"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-35",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-36",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-37",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-38",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-39",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-40",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-40",
+      "answer": "no",
+      "comment": "Jak to dopadá vidíme již dnes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-41",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-42",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-43",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-44",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-44",
+      "answer": "no",
+      "comment": "Praha nemá vhodný terénní reliéf"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-45",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-45",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-46",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-47",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-47",
+      "answer": "yes",
+      "comment": "Cíleně, ne plošně"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-48",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-49",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-50",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-51",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-52",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-53",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-53",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-54",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-55",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-55",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-56",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-57",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-57",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-58",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-59",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-60",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-60",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-61",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-62",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-62",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-1",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-2",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-3",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-4",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-5",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-6",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-7",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-8",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-9",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-10",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-11",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-12",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-13",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-14",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-15",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-16",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-17",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-18",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-19",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-20",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-21",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-22",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-23",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-24",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-25",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-26",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-27",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-28",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-29",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-30",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-31",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-32",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-33",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-34",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-35",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-36",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-37",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-38",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-39",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-40",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-41",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-42",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-43",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-44",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-45",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-46",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-47",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-48",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-49",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-50",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-51",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-52",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-53",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-53",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-54",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-55",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-56",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-57",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-57",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-58",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-59",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-60",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-60",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-61",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-62",
+      "candidate_id": "komunalni-2022-554782-c-305273",
       "question_id": "komunalni-2022-554782-q-62",
       "answer": "yes"
     }

--- a/data/kalkulacka/komunalni-2022/554791.json
+++ b/data/kalkulacka/komunalni-2022/554791.json
@@ -442,7 +442,7 @@
       "id": "komunalni-2022-554791-c-952782",
       "name": "PRO PLZEŇ",
       "type": "party",
-      "description": "PRO PLZEŇ - DESCRIPTION",
+      "description": "PRO PLZEŇ",
       "img_url": "pro plzeň",
       "contacts": {
         "web": [
@@ -461,7 +461,7 @@
         {
           "id": "komunalni-2022-554791-c-952782-p",
           "name": "PRO PLZEŇ",
-          "description": "PRO PLZEŇ - DESCRIPTION",
+          "description": "PRO PLZEŇ",
           "contacts": {
             "web": [
               {
@@ -483,7 +483,7 @@
       "id": "komunalni-2022-554791-c-524664",
       "name": "SPOLU – ODS, KDU-ČSL, TOP 09",
       "type": "party",
-      "description": "SPOLU – ODS, KDU-ČSL, TOP 09 - DESCRIPTION",
+      "description": "SPOLU – ODS, KDU-ČSL, TOP 09",
       "img_url": "kdu-ods-top 09",
       "contacts": {
         "web": []
@@ -492,7 +492,7 @@
         {
           "id": "komunalni-2022-554791-c-524664-p",
           "name": "SPOLU – ODS, KDU-ČSL, TOP 09",
-          "description": "SPOLU – ODS, KDU-ČSL, TOP 09 - DESCRIPTION",
+          "description": "SPOLU – ODS, KDU-ČSL, TOP 09",
           "contacts": {
             "web": []
           },
@@ -505,7 +505,7 @@
       "id": "komunalni-2022-554791-c-314551",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
-      "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "description": "Komunistická strana Čech a Moravy",
       "img_url": "ksčm",
       "contacts": {
         "web": []
@@ -514,19 +514,20 @@
         {
           "id": "komunalni-2022-554791-c-314551-p",
           "name": "Komunistická strana Čech a Moravy",
-          "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+          "description": "Komunistická strana Čech a Moravy",
           "contacts": {
             "web": []
           },
           "abbreviation": "KSČM"
         }
-      ]
+      ],
+      "motto": "Jsme stranou s jasnou vizí a programem pro většinu lidí."
     },
     {
       "id": "komunalni-2022-554791-c-995503",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
-      "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "description": "STAROSTOVÉ A NEZÁVISLÍ",
       "img_url": "stan",
       "contacts": {
         "web": [
@@ -545,7 +546,7 @@
         {
           "id": "komunalni-2022-554791-c-995503-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
-          "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+          "description": "STAROSTOVÉ A NEZÁVISLÍ",
           "contacts": {
             "web": [
               {
@@ -568,7 +569,7 @@
       "id": "komunalni-2022-554791-c-400852",
       "name": "Česká pirátská strana",
       "type": "party",
-      "description": "Česká pirátská strana - DESCRIPTION",
+      "description": "Česká pirátská strana",
       "img_url": "piráti",
       "contacts": {
         "web": []
@@ -577,7 +578,7 @@
         {
           "id": "komunalni-2022-554791-c-400852-p",
           "name": "Česká pirátská strana",
-          "description": "Česká pirátská strana - DESCRIPTION",
+          "description": "Česká pirátská strana",
           "contacts": {
             "web": []
           },
@@ -590,7 +591,7 @@
       "id": "komunalni-2022-554791-c-286601",
       "name": "Koruna Česká (monarchistická strana Čech, Moravy a Slezska)",
       "type": "party",
-      "description": "Koruna Česká (monarchistická strana Čech, Moravy a Slezska) - DESCRIPTION",
+      "description": "Koruna Česká (monarchistická strana Čech, Moravy a Slezska)",
       "img_url": "monarchiste.cz",
       "contacts": {
         "web": []
@@ -599,7 +600,7 @@
         {
           "id": "komunalni-2022-554791-c-286601-p",
           "name": "Koruna Česká (monarchistická strana Čech, Moravy a Slezska)",
-          "description": "Koruna Česká (monarchistická strana Čech, Moravy a Slezska) - DESCRIPTION",
+          "description": "Koruna Česká (monarchistická strana Čech, Moravy a Slezska)",
           "contacts": {
             "web": []
           },
@@ -611,7 +612,7 @@
       "id": "komunalni-2022-554791-c-893550",
       "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
       "type": "party",
-      "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+      "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
       "img_url": "dsz-nk",
       "contacts": {
         "web": []
@@ -620,7 +621,7 @@
         {
           "id": "komunalni-2022-554791-c-893550-p",
           "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
-          "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+          "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT — sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
           "contacts": {
             "web": []
           },
@@ -632,7 +633,7 @@
       "id": "komunalni-2022-554791-c-133857",
       "name": "ČESKÁ PLZEŇ A BEZPEČNÉ ULICE",
       "type": "party",
-      "description": "ČESKÁ PLZEŇ A BEZPEČNÉ ULICE - DESCRIPTION",
+      "description": "ČESKÁ PLZEŇ A BEZPEČNÉ ULICE",
       "img_url": "dsss-bez-ul",
       "contacts": {
         "web": []
@@ -641,7 +642,7 @@
         {
           "id": "komunalni-2022-554791-c-133857-p",
           "name": "ČESKÁ PLZEŇ A BEZPEČNÉ ULICE",
-          "description": "ČESKÁ PLZEŇ A BEZPEČNÉ ULICE - DESCRIPTION",
+          "description": "ČESKÁ PLZEŇ A BEZPEČNÉ ULICE",
           "contacts": {
             "web": []
           },
@@ -654,7 +655,7 @@
       "id": "komunalni-2022-554791-c-591389",
       "name": "Právo Respekt Odbornost",
       "type": "party",
-      "description": "Právo Respekt Odbornost - DESCRIPTION",
+      "description": "Právo Respekt Odbornost",
       "img_url": "pro 2022",
       "contacts": {
         "web": []
@@ -663,7 +664,7 @@
         {
           "id": "komunalni-2022-554791-c-591389-p",
           "name": "Právo Respekt Odbornost",
-          "description": "Právo Respekt Odbornost - DESCRIPTION",
+          "description": "Právo Respekt Odbornost",
           "contacts": {
             "web": []
           },
@@ -675,7 +676,7 @@
       "id": "komunalni-2022-554791-c-455134",
       "name": "ANO 2011 a nezávislí",
       "type": "party",
-      "description": "ANO 2011 a nezávislí - DESCRIPTION",
+      "description": "ANO 2011 a nezávislí",
       "img_url": "ano-nk",
       "contacts": {
         "web": []
@@ -684,7 +685,7 @@
         {
           "id": "komunalni-2022-554791-c-455134-p",
           "name": "ANO 2011 a nezávislí",
-          "description": "ANO 2011 a nezávislí - DESCRIPTION",
+          "description": "ANO 2011 a nezávislí",
           "contacts": {
             "web": []
           },
@@ -697,7 +698,7 @@
       "id": "komunalni-2022-554791-c-187608",
       "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
       "type": "party",
-      "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
+      "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
       "img_url": "přísaha",
       "contacts": {
         "web": [
@@ -715,7 +716,7 @@
         {
           "id": "komunalni-2022-554791-c-187608-p",
           "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
-          "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
+          "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
           "contacts": {
             "web": [
               {
@@ -737,7 +738,7 @@
       "id": "komunalni-2022-554791-c-733929",
       "name": "Plzeň v srdci - ČSSD a nezávislí kandidáti",
       "type": "party",
-      "description": "Plzeň v srdci - ČSSD a nezávislí kandidáti - DESCRIPTION",
+      "description": "Plzeň v srdci - ČSSD a nezávislí kandidáti",
       "img_url": "čssd-nk",
       "contacts": {
         "web": [
@@ -751,7 +752,7 @@
         {
           "id": "komunalni-2022-554791-c-733929-p",
           "name": "Plzeň v srdci - ČSSD a nezávislí kandidáti",
-          "description": "Plzeň v srdci - ČSSD a nezávislí kandidáti - DESCRIPTION",
+          "description": "Plzeň v srdci - ČSSD a nezávislí kandidáti",
           "contacts": {
             "web": [
               {
@@ -769,7 +770,7 @@
       "id": "komunalni-2022-554791-c-657721",
       "name": "Ta Pravá Plzeň",
       "type": "party",
-      "description": "Ta Pravá Plzeň - DESCRIPTION",
+      "description": "Ta Pravá Plzeň",
       "img_url": "soukromníci-nk",
       "contacts": {
         "web": []
@@ -778,7 +779,7 @@
         {
           "id": "komunalni-2022-554791-c-657721-p",
           "name": "Ta Pravá Plzeň",
-          "description": "Ta Pravá Plzeň - DESCRIPTION",
+          "description": "Ta Pravá Plzeň",
           "contacts": {
             "web": []
           },
@@ -790,7 +791,7 @@
       "id": "komunalni-2022-554791-c-809330",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
-      "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "description": "Svoboda a přímá demokracie (SPD)",
       "img_url": "spd",
       "contacts": {
         "web": []
@@ -799,7 +800,7 @@
         {
           "id": "komunalni-2022-554791-c-809330-p",
           "name": "Svoboda a přímá demokracie (SPD)",
-          "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+          "description": "Svoboda a přímá demokracie (SPD)",
           "contacts": {
             "web": []
           },
@@ -3203,6 +3204,324 @@
       "question_id": "komunalni-2022-554791-q-53",
       "answer": "yes",
       "comment": "Ano. Lze to spojit s výstavbou nových sídlišt a participaci ze strany developerů."
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-1",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-2",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-3",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-4",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-4",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-5",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-6",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-7",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-7",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-8",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-9",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-10",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-11",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-12",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-13",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-13",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-14",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-14",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-15",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-16",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-17",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-17",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-18",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-19",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-20",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-21",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-22",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-23",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-24",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-25",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-26",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-27",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-28",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-29",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-30",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-31",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-32",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-33",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-34",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-34",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-35",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-36",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-37",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-37",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-38",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-39",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-39",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-40",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-40",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-41",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-42",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-43",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-43",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-44",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-45",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-46",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-47",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-48",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-49",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-50",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-51",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-52",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554791-a-314551-53",
+      "candidate_id": "komunalni-2022-554791-c-314551",
+      "question_id": "komunalni-2022-554791-q-53",
+      "answer": "yes"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/554804.json
+++ b/data/kalkulacka/komunalni-2022/554804.json
@@ -410,7 +410,7 @@
       "id": "komunalni-2022-554804-c-415562",
       "name": "ÚSTECKÉ FÓRUM OBČANŮ",
       "type": "party",
-      "description": "ÚSTECKÉ FÓRUM OBČANŮ - DESCRIPTION",
+      "description": "ÚSTECKÉ FÓRUM OBČANŮ",
       "img_url": "ufo",
       "contacts": {
         "web": [
@@ -424,7 +424,7 @@
         {
           "id": "komunalni-2022-554804-c-415562-p",
           "name": "ÚSTECKÉ FÓRUM OBČANŮ",
-          "description": "ÚSTECKÉ FÓRUM OBČANŮ - DESCRIPTION",
+          "description": "ÚSTECKÉ FÓRUM OBČANŮ",
           "contacts": {
             "web": [
               {
@@ -442,7 +442,7 @@
       "id": "komunalni-2022-554804-c-606320",
       "name": "Vaše Ústí",
       "type": "party",
-      "description": "Vaše Ústí - DESCRIPTION",
+      "description": "Vaše Ústí",
       "img_url": "vú",
       "contacts": {
         "web": [
@@ -457,7 +457,7 @@
         {
           "id": "komunalni-2022-554804-c-606320-p",
           "name": "Vaše Ústí",
-          "description": "Vaše Ústí - DESCRIPTION",
+          "description": "Vaše Ústí",
           "contacts": {
             "web": [
               {
@@ -476,7 +476,7 @@
       "id": "komunalni-2022-554804-c-265108",
       "name": "Občanská demokratická strana",
       "type": "party",
-      "description": "Občanská demokratická strana - DESCRIPTION",
+      "description": "Občanská demokratická strana",
       "img_url": "ods",
       "contacts": {
         "web": []
@@ -485,7 +485,7 @@
         {
           "id": "komunalni-2022-554804-c-265108-p",
           "name": "Občanská demokratická strana",
-          "description": "Občanská demokratická strana - DESCRIPTION",
+          "description": "Občanská demokratická strana",
           "contacts": {
             "web": []
           },
@@ -498,7 +498,7 @@
       "id": "komunalni-2022-554804-c-986225",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
-      "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "description": "STAROSTOVÉ A NEZÁVISLÍ",
       "img_url": "stan",
       "contacts": {
         "web": [
@@ -512,7 +512,7 @@
         {
           "id": "komunalni-2022-554804-c-986225-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
-          "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+          "description": "STAROSTOVÉ A NEZÁVISLÍ",
           "contacts": {
             "web": [
               {
@@ -530,7 +530,7 @@
       "id": "komunalni-2022-554804-c-287190",
       "name": "Aliance pro Ústí",
       "type": "party",
-      "description": "Aliance pro Ústí - DESCRIPTION",
+      "description": "Aliance pro Ústí",
       "img_url": "manifest.cz-nk",
       "contacts": {
         "web": []
@@ -539,7 +539,7 @@
         {
           "id": "komunalni-2022-554804-c-287190-p",
           "name": "Aliance pro Ústí",
-          "description": "Aliance pro Ústí - DESCRIPTION",
+          "description": "Aliance pro Ústí",
           "contacts": {
             "web": []
           },
@@ -551,7 +551,7 @@
       "id": "komunalni-2022-554804-c-554883",
       "name": "ANO 2011",
       "type": "party",
-      "description": "ANO 2011 - DESCRIPTION",
+      "description": "ANO 2011",
       "img_url": "ano",
       "contacts": {
         "web": []
@@ -560,7 +560,7 @@
         {
           "id": "komunalni-2022-554804-c-554883-p",
           "name": "ANO 2011",
-          "description": "ANO 2011 - DESCRIPTION",
+          "description": "ANO 2011",
           "contacts": {
             "web": []
           },
@@ -573,7 +573,7 @@
       "id": "komunalni-2022-554804-c-118556",
       "name": "Zdraví Sport Prosperita",
       "type": "party",
-      "description": "Zdraví Sport Prosperita - DESCRIPTION",
+      "description": "Zdraví Sport Prosperita",
       "img_url": "pro zdraví",
       "contacts": {
         "web": []
@@ -582,7 +582,7 @@
         {
           "id": "komunalni-2022-554804-c-118556-p",
           "name": "Zdraví Sport Prosperita",
-          "description": "Zdraví Sport Prosperita - DESCRIPTION",
+          "description": "Zdraví Sport Prosperita",
           "contacts": {
             "web": []
           },
@@ -595,7 +595,7 @@
       "id": "komunalni-2022-554804-c-862129",
       "name": "Svoboda a přímá demokracie (SPD) s podporou politické strany Trikolora",
       "type": "party",
-      "description": "Svoboda a přímá demokracie (SPD) s podporou politické strany Trikolora - DESCRIPTION",
+      "description": "Svoboda a přímá demokracie (SPD) s podporou politické strany Trikolora",
       "img_url": "spd-trikolóra",
       "contacts": {
         "web": []
@@ -604,7 +604,7 @@
         {
           "id": "komunalni-2022-554804-c-862129-p",
           "name": "Svoboda a přímá demokracie (SPD) s podporou politické strany Trikolora",
-          "description": "Svoboda a přímá demokracie (SPD) s podporou politické strany Trikolora - DESCRIPTION",
+          "description": "Svoboda a přímá demokracie (SPD) s podporou politické strany Trikolora",
           "contacts": {
             "web": []
           },
@@ -617,7 +617,7 @@
       "id": "komunalni-2022-554804-c-320927",
       "name": "Za lepší Střekov",
       "type": "party",
-      "description": "Za lepší Střekov - DESCRIPTION",
+      "description": "Za lepší Střekov",
       "img_url": "zls",
       "contacts": {
         "web": [
@@ -631,7 +631,7 @@
         {
           "id": "komunalni-2022-554804-c-320927-p",
           "name": "Za lepší Střekov",
-          "description": "Za lepší Střekov - DESCRIPTION",
+          "description": "Za lepší Střekov",
           "contacts": {
             "web": [
               {
@@ -648,7 +648,7 @@
       "id": "komunalni-2022-554804-c-418969",
       "name": "PRO! Ústí",
       "type": "party",
-      "description": "PRO! Ústí - DESCRIPTION",
+      "description": "PRO! Ústí",
       "img_url": "zel.-piráti-nk",
       "contacts": {
         "web": [
@@ -663,7 +663,7 @@
         {
           "id": "komunalni-2022-554804-c-418969-p",
           "name": "PRO! Ústí",
-          "description": "PRO! Ústí - DESCRIPTION",
+          "description": "PRO! Ústí",
           "contacts": {
             "web": [
               {
@@ -682,7 +682,7 @@
       "id": "komunalni-2022-554804-c-627274",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
-      "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "description": "Komunistická strana Čech a Moravy",
       "img_url": "ksčm",
       "contacts": {
         "web": []
@@ -691,7 +691,7 @@
         {
           "id": "komunalni-2022-554804-c-627274-p",
           "name": "Komunistická strana Čech a Moravy",
-          "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+          "description": "Komunistická strana Čech a Moravy",
           "contacts": {
             "web": []
           },
@@ -703,7 +703,7 @@
       "id": "komunalni-2022-554804-c-894961",
       "name": "SPOLEČNĚ Ústí nad Labem",
       "type": "party",
-      "description": "SPOLEČNĚ Ústí nad Labem - DESCRIPTION",
+      "description": "SPOLEČNĚ Ústí nad Labem",
       "img_url": "kdučsl-top09-nk",
       "contacts": {
         "web": [
@@ -723,7 +723,7 @@
         {
           "id": "komunalni-2022-554804-c-894961-p",
           "name": "SPOLEČNĚ Ústí nad Labem",
-          "description": "SPOLEČNĚ Ústí nad Labem - DESCRIPTION",
+          "description": "SPOLEČNĚ Ústí nad Labem",
           "contacts": {
             "web": [
               {
@@ -747,7 +747,7 @@
       "id": "komunalni-2022-554804-c-775234",
       "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
       "type": "party",
-      "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
+      "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
       "img_url": "přísaha",
       "contacts": {
         "web": [
@@ -762,7 +762,7 @@
         {
           "id": "komunalni-2022-554804-c-775234-p",
           "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
-          "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
+          "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
           "contacts": {
             "web": [
               {

--- a/data/kalkulacka/komunalni-2022/555134.json
+++ b/data/kalkulacka/komunalni-2022/555134.json
@@ -402,7 +402,7 @@
       "id": "komunalni-2022-555134-c-915355",
       "name": "SPOLU (ODS, KDU-ČSL, TOP 09)",
       "type": "party",
-      "description": "SPOLU (ODS, KDU-ČSL, TOP 09) - DESCRIPTION",
+      "description": "SPOLU (ODS, KDU-ČSL, TOP 09)",
       "img_url": "kdu-ods-top 09",
       "contacts": {
         "web": [
@@ -422,7 +422,7 @@
         {
           "id": "komunalni-2022-555134-c-915355-p",
           "name": "SPOLU (ODS, KDU-ČSL, TOP 09)",
-          "description": "SPOLU (ODS, KDU-ČSL, TOP 09) - DESCRIPTION",
+          "description": "SPOLU (ODS, KDU-ČSL, TOP 09)",
           "contacts": {
             "web": [
               {
@@ -446,7 +446,7 @@
       "id": "komunalni-2022-555134-c-349076",
       "name": "Piráti: 42projektu.cz",
       "type": "party",
-      "description": "Piráti: 42projektu.cz - DESCRIPTION",
+      "description": "Piráti: 42projektu.cz",
       "img_url": "zelení-piráti",
       "contacts": {
         "web": [
@@ -465,7 +465,7 @@
         {
           "id": "komunalni-2022-555134-c-349076-p",
           "name": "Piráti: 42projektu.cz",
-          "description": "Piráti: 42projektu.cz - DESCRIPTION",
+          "description": "Piráti: 42projektu.cz",
           "contacts": {
             "web": [
               {
@@ -488,7 +488,7 @@
       "id": "komunalni-2022-555134-c-280020",
       "name": "Žijeme Pardubice",
       "type": "party",
-      "description": "Žijeme Pardubice - DESCRIPTION",
+      "description": "Žijeme Pardubice",
       "img_url": "čssd-pp21-nk",
       "contacts": {
         "web": [
@@ -504,7 +504,7 @@
         {
           "id": "komunalni-2022-555134-c-280020-p",
           "name": "Žijeme Pardubice",
-          "description": "Žijeme Pardubice - DESCRIPTION",
+          "description": "Žijeme Pardubice",
           "contacts": {
             "web": [
               {
@@ -523,7 +523,7 @@
       "id": "komunalni-2022-555134-c-343643",
       "name": "NAŠE PARDUBICE - \"Nechme město rozkvést\"",
       "type": "party",
-      "description": "NAŠE PARDUBICE - \"Nechme město rozkvést\" - DESCRIPTION",
+      "description": "NAŠE PARDUBICE - \"Nechme město rozkvést\"",
       "img_url": "spdv-nk",
       "contacts": {
         "web": [
@@ -538,7 +538,7 @@
         {
           "id": "komunalni-2022-555134-c-343643-p",
           "name": "NAŠE PARDUBICE - \"Nechme město rozkvést\"",
-          "description": "NAŠE PARDUBICE - \"Nechme město rozkvést\" - DESCRIPTION",
+          "description": "NAŠE PARDUBICE - \"Nechme město rozkvést\"",
           "contacts": {
             "web": [
               {
@@ -557,7 +557,7 @@
       "id": "komunalni-2022-555134-c-694313",
       "name": "ANO 2011",
       "type": "party",
-      "description": "ANO 2011 - DESCRIPTION",
+      "description": "ANO 2011",
       "img_url": "ano",
       "contacts": {
         "web": [
@@ -572,7 +572,7 @@
         {
           "id": "komunalni-2022-555134-c-694313-p",
           "name": "ANO 2011",
-          "description": "ANO 2011 - DESCRIPTION",
+          "description": "ANO 2011",
           "contacts": {
             "web": [
               {
@@ -591,7 +591,7 @@
       "id": "komunalni-2022-555134-c-193762",
       "name": "SPD a nezávislí s podporou Trikolory",
       "type": "party",
-      "description": "SPD a nezávislí s podporou Trikolory - DESCRIPTION",
+      "description": "SPD a nezávislí s podporou Trikolory",
       "img_url": "spd-trikol-nk",
       "contacts": {
         "web": []
@@ -600,7 +600,7 @@
         {
           "id": "komunalni-2022-555134-c-193762-p",
           "name": "SPD a nezávislí s podporou Trikolory",
-          "description": "SPD a nezávislí s podporou Trikolory - DESCRIPTION",
+          "description": "SPD a nezávislí s podporou Trikolory",
           "contacts": {
             "web": []
           },
@@ -613,7 +613,7 @@
       "id": "komunalni-2022-555134-c-812723",
       "name": "SPOLEČNĚ PRO PARDUBICE (Pardubáci společně, Sdružení pro Pardubice, Pardubice pro lidi)",
       "type": "party",
-      "description": "SPOLEČNĚ PRO PARDUBICE (Pardubáci společně, Sdružení pro Pardubice, Pardubice pro lidi) - DESCRIPTION",
+      "description": "SPOLEČNĚ PRO PARDUBICE (Pardubáci společně, Sdružení pro Pardubice, Pardubice pro lidi)",
       "img_url": "snk ed-vč-ppl",
       "contacts": {
         "web": [
@@ -632,7 +632,7 @@
         {
           "id": "komunalni-2022-555134-c-812723-p",
           "name": "SPOLEČNĚ PRO PARDUBICE (Pardubáci společně, Sdružení pro Pardubice, Pardubice pro lidi)",
-          "description": "SPOLEČNĚ PRO PARDUBICE (Pardubáci společně, Sdružení pro Pardubice, Pardubice pro lidi) - DESCRIPTION",
+          "description": "SPOLEČNĚ PRO PARDUBICE (Pardubáci společně, Sdružení pro Pardubice, Pardubice pro lidi)",
           "contacts": {
             "web": [
               {
@@ -648,13 +648,14 @@
           },
           "abbreviation": "SNK ED+VČ+PPL"
         }
-      ]
+      ],
+      "motto": "Jsme jediné ryze pardubické uskupení."
     },
     {
       "id": "komunalni-2022-555134-c-918217",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
-      "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "description": "Komunistická strana Čech a Moravy",
       "img_url": "ksčm",
       "contacts": {
         "web": []
@@ -663,7 +664,7 @@
         {
           "id": "komunalni-2022-555134-c-918217-p",
           "name": "Komunistická strana Čech a Moravy",
-          "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+          "description": "Komunistická strana Čech a Moravy",
           "contacts": {
             "web": []
           },
@@ -675,7 +676,7 @@
       "id": "komunalni-2022-555134-c-188831",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
-      "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "description": "STAROSTOVÉ A NEZÁVISLÍ",
       "img_url": "stan",
       "contacts": {
         "web": [
@@ -690,7 +691,7 @@
         {
           "id": "komunalni-2022-555134-c-188831-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
-          "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+          "description": "STAROSTOVÉ A NEZÁVISLÍ",
           "contacts": {
             "web": [
               {
@@ -2572,6 +2573,294 @@
       "question_id": "komunalni-2022-555134-q-48",
       "answer": "yes",
       "comment": "Je potřeba ulevit rodičům, kteří chtějí jít do práce. Což ale znamená zahájit činnost speciálních školek. "
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-1",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-2",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-3",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-4",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-5",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-6",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-7",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-8",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-9",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-10",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-11",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-12",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-13",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-14",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-15",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-16",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-17",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-18",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-19",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-20",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-21",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-22",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-23",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-24",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-25",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-26",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-27",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-28",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-29",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-30",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-31",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-32",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-33",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-34",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-34",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-35",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-36",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-37",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-38",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-39",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-40",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-41",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-42",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-43",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-44",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-45",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-46",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-47",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-812723-48",
+      "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-48",
+      "answer": "yes"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/563889.json
+++ b/data/kalkulacka/komunalni-2022/563889.json
@@ -434,7 +434,7 @@
       "id": "komunalni-2022-563889-c-709264",
       "name": "Trikolora a Soukromníci",
       "type": "party",
-      "description": "Trikolora a Soukromníci - DESCRIPTION",
+      "description": "Trikolora a Soukromníci",
       "img_url": "trikol-soukrom",
       "contacts": {
         "web": []
@@ -443,7 +443,7 @@
         {
           "id": "komunalni-2022-563889-c-709264-p",
           "name": "Trikolora a Soukromníci",
-          "description": "Trikolora a Soukromníci - DESCRIPTION",
+          "description": "Trikolora a Soukromníci",
           "contacts": {
             "web": []
           },
@@ -455,7 +455,7 @@
       "id": "komunalni-2022-563889-c-434921",
       "name": "ANO 2011",
       "type": "party",
-      "description": "ANO 2011 - DESCRIPTION",
+      "description": "ANO 2011",
       "img_url": "ano",
       "contacts": {
         "web": [
@@ -469,7 +469,7 @@
         {
           "id": "komunalni-2022-563889-c-434921-p",
           "name": "ANO 2011",
-          "description": "ANO 2011 - DESCRIPTION",
+          "description": "ANO 2011",
           "contacts": {
             "web": [
               {
@@ -487,7 +487,7 @@
       "id": "komunalni-2022-563889-c-184949",
       "name": "Česká pirátská strana",
       "type": "party",
-      "description": "Česká pirátská strana - DESCRIPTION",
+      "description": "Česká pirátská strana",
       "img_url": "piráti",
       "contacts": {
         "web": [
@@ -503,7 +503,7 @@
         {
           "id": "komunalni-2022-563889-c-184949-p",
           "name": "Česká pirátská strana",
-          "description": "Česká pirátská strana - DESCRIPTION",
+          "description": "Česká pirátská strana",
           "contacts": {
             "web": [
               {
@@ -523,7 +523,7 @@
       "id": "komunalni-2022-563889-c-282146",
       "name": "Starostové pro Liberecký kraj společně s TOP 09 a KDU-ČSL",
       "type": "party",
-      "description": "Starostové pro Liberecký kraj společně s TOP 09 a KDU-ČSL - DESCRIPTION",
+      "description": "Starostové pro Liberecký kraj společně s TOP 09 a KDU-ČSL",
       "img_url": "kdu-čsl-slk-top",
       "contacts": {
         "web": [
@@ -542,7 +542,7 @@
         {
           "id": "komunalni-2022-563889-c-282146-p",
           "name": "Starostové pro Liberecký kraj společně s TOP 09 a KDU-ČSL",
-          "description": "Starostové pro Liberecký kraj společně s TOP 09 a KDU-ČSL - DESCRIPTION",
+          "description": "Starostové pro Liberecký kraj společně s TOP 09 a KDU-ČSL",
           "contacts": {
             "web": [
               {
@@ -565,7 +565,7 @@
       "id": "komunalni-2022-563889-c-188908",
       "name": "Liberec otevřený lidem",
       "type": "party",
-      "description": "Liberec otevřený lidem - DESCRIPTION",
+      "description": "Liberec otevřený lidem",
       "img_url": "zelení-nk",
       "contacts": {
         "web": [
@@ -581,7 +581,7 @@
         {
           "id": "komunalni-2022-563889-c-188908-p",
           "name": "Liberec otevřený lidem",
-          "description": "Liberec otevřený lidem - DESCRIPTION",
+          "description": "Liberec otevřený lidem",
           "contacts": {
             "web": [
               {
@@ -601,7 +601,7 @@
       "id": "komunalni-2022-563889-c-230742",
       "name": "ODS společně se Sportovci",
       "type": "party",
-      "description": "ODS společně se Sportovci - DESCRIPTION",
+      "description": "ODS společně se Sportovci",
       "img_url": "ods-usz-nk",
       "contacts": {
         "web": [
@@ -620,7 +620,7 @@
         {
           "id": "komunalni-2022-563889-c-230742-p",
           "name": "ODS společně se Sportovci",
-          "description": "ODS společně se Sportovci - DESCRIPTION",
+          "description": "ODS společně se Sportovci",
           "contacts": {
             "web": [
               {
@@ -642,7 +642,7 @@
       "id": "komunalni-2022-563889-c-843854",
       "name": "Právo Respekt Odbornost",
       "type": "party",
-      "description": "Právo Respekt Odbornost - DESCRIPTION",
+      "description": "Právo Respekt Odbornost",
       "img_url": "pro 2022",
       "contacts": {
         "web": []
@@ -651,7 +651,7 @@
         {
           "id": "komunalni-2022-563889-c-843854-p",
           "name": "Právo Respekt Odbornost",
-          "description": "Právo Respekt Odbornost - DESCRIPTION",
+          "description": "Právo Respekt Odbornost",
           "contacts": {
             "web": []
           },
@@ -664,7 +664,7 @@
       "id": "komunalni-2022-563889-c-401265",
       "name": "Komunistická strana Čech a Moravy a Podještědská levice",
       "type": "party",
-      "description": "Komunistická strana Čech a Moravy a Podještědská levice - DESCRIPTION",
+      "description": "Komunistická strana Čech a Moravy a Podještědská levice",
       "img_url": "ksčm-nk",
       "contacts": {
         "web": []
@@ -673,7 +673,7 @@
         {
           "id": "komunalni-2022-563889-c-401265-p",
           "name": "Komunistická strana Čech a Moravy a Podještědská levice",
-          "description": "Komunistická strana Čech a Moravy a Podještědská levice - DESCRIPTION",
+          "description": "Komunistická strana Čech a Moravy a Podještědská levice",
           "contacts": {
             "web": []
           },
@@ -686,7 +686,7 @@
       "id": "komunalni-2022-563889-c-323656",
       "name": "Česká strana sociálně demokratická",
       "type": "party",
-      "description": "Česká strana sociálně demokratická - DESCRIPTION",
+      "description": "Česká strana sociálně demokratická",
       "img_url": "čssd",
       "contacts": {
         "web": []
@@ -695,7 +695,7 @@
         {
           "id": "komunalni-2022-563889-c-323656-p",
           "name": "Česká strana sociálně demokratická",
-          "description": "Česká strana sociálně demokratická - DESCRIPTION",
+          "description": "Česká strana sociálně demokratická",
           "contacts": {
             "web": []
           },
@@ -708,7 +708,7 @@
       "id": "komunalni-2022-563889-c-690485",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
-      "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "description": "Svoboda a přímá demokracie (SPD)",
       "img_url": "spd",
       "contacts": {
         "web": [
@@ -723,7 +723,7 @@
         {
           "id": "komunalni-2022-563889-c-690485-p",
           "name": "Svoboda a přímá demokracie (SPD)",
-          "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+          "description": "Svoboda a přímá demokracie (SPD)",
           "contacts": {
             "web": [
               {

--- a/data/kalkulacka/komunalni-2022/569810.json
+++ b/data/kalkulacka/komunalni-2022/569810.json
@@ -442,7 +442,7 @@
       "id": "komunalni-2022-569810-c-760916",
       "name": "HRADEC ROZUMEM",
       "type": "party",
-      "description": "HRADEC ROZUMEM - DESCRIPTION",
+      "description": "HRADEC ROZUMEM",
       "img_url": "svob-pro2022-nk",
       "contacts": {
         "web": []
@@ -451,7 +451,7 @@
         {
           "id": "komunalni-2022-569810-c-760916-p",
           "name": "HRADEC ROZUMEM",
-          "description": "HRADEC ROZUMEM - DESCRIPTION",
+          "description": "HRADEC ROZUMEM",
           "contacts": {
             "web": []
           },
@@ -463,7 +463,7 @@
       "id": "komunalni-2022-569810-c-244511",
       "name": "Česká strana sociálně demokratická s podporou nezávislých",
       "type": "party",
-      "description": "Česká strana sociálně demokratická s podporou nezávislých - DESCRIPTION",
+      "description": "Česká strana sociálně demokratická s podporou nezávislých",
       "img_url": "čssd-nk",
       "contacts": {
         "web": []
@@ -472,7 +472,7 @@
         {
           "id": "komunalni-2022-569810-c-244511-p",
           "name": "Česká strana sociálně demokratická s podporou nezávislých",
-          "description": "Česká strana sociálně demokratická s podporou nezávislých - DESCRIPTION",
+          "description": "Česká strana sociálně demokratická s podporou nezávislých",
           "contacts": {
             "web": []
           },
@@ -485,7 +485,7 @@
       "id": "komunalni-2022-569810-c-515530",
       "name": "ROMA LUMA",
       "type": "party",
-      "description": "ROMA LUMA - DESCRIPTION",
+      "description": "ROMA LUMA",
       "img_url": "luma",
       "contacts": {
         "web": []
@@ -494,7 +494,7 @@
         {
           "id": "komunalni-2022-569810-c-515530-p",
           "name": "ROMA LUMA",
-          "description": "ROMA LUMA - DESCRIPTION",
+          "description": "ROMA LUMA",
           "contacts": {
             "web": []
           },
@@ -507,7 +507,7 @@
       "id": "komunalni-2022-569810-c-748887",
       "name": "HRADEČÁCI",
       "type": "party",
-      "description": "HRADEČÁCI - DESCRIPTION",
+      "description": "HRADEČÁCI",
       "img_url": "hk",
       "contacts": {
         "web": []
@@ -516,7 +516,7 @@
         {
           "id": "komunalni-2022-569810-c-748887-p",
           "name": "HRADEČÁCI",
-          "description": "HRADEČÁCI - DESCRIPTION",
+          "description": "HRADEČÁCI",
           "contacts": {
             "web": []
           },
@@ -528,7 +528,7 @@
       "id": "komunalni-2022-569810-c-841188",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
-      "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "description": "Svoboda a přímá demokracie (SPD)",
       "img_url": "spd",
       "contacts": {
         "web": []
@@ -537,7 +537,7 @@
         {
           "id": "komunalni-2022-569810-c-841188-p",
           "name": "Svoboda a přímá demokracie (SPD)",
-          "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+          "description": "Svoboda a přímá demokracie (SPD)",
           "contacts": {
             "web": []
           },
@@ -550,7 +550,7 @@
       "id": "komunalni-2022-569810-c-813906",
       "name": "Hradečtí kantoři a Nestraníci",
       "type": "party",
-      "description": "Hradečtí kantoři a Nestraníci - DESCRIPTION",
+      "description": "Hradečtí kantoři a Nestraníci",
       "img_url": "nestraníci-nk",
       "contacts": {
         "web": []
@@ -559,7 +559,7 @@
         {
           "id": "komunalni-2022-569810-c-813906-p",
           "name": "Hradečtí kantoři a Nestraníci",
-          "description": "Hradečtí kantoři a Nestraníci - DESCRIPTION",
+          "description": "Hradečtí kantoři a Nestraníci",
           "contacts": {
             "web": []
           },
@@ -572,7 +572,7 @@
       "id": "komunalni-2022-569810-c-938535",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
-      "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "description": "STAROSTOVÉ A NEZÁVISLÍ",
       "img_url": "stan",
       "contacts": {
         "web": [
@@ -593,7 +593,7 @@
         {
           "id": "komunalni-2022-569810-c-938535-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
-          "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+          "description": "STAROSTOVÉ A NEZÁVISLÍ",
           "contacts": {
             "web": [
               {
@@ -618,7 +618,7 @@
       "id": "komunalni-2022-569810-c-707699",
       "name": "Hradecký demokratický klub a TOP 09 s podporou Hradeckých patriotů a LES",
       "type": "party",
-      "description": "Hradecký demokratický klub a TOP 09 s podporou Hradeckých patriotů a LES - DESCRIPTION",
+      "description": "Hradecký demokratický klub a TOP 09 s podporou Hradeckých patriotů a LES",
       "img_url": "top-les-hp-hdk",
       "contacts": {
         "web": [
@@ -638,7 +638,7 @@
         {
           "id": "komunalni-2022-569810-c-707699-p",
           "name": "Hradecký demokratický klub a TOP 09 s podporou Hradeckých patriotů a LES",
-          "description": "Hradecký demokratický klub a TOP 09 s podporou Hradeckých patriotů a LES - DESCRIPTION",
+          "description": "Hradecký demokratický klub a TOP 09 s podporou Hradeckých patriotů a LES",
           "contacts": {
             "web": [
               {
@@ -662,7 +662,7 @@
       "id": "komunalni-2022-569810-c-956549",
       "name": "Změna pro Hradec a Zelení",
       "type": "party",
-      "description": "Změna pro Hradec a Zelení - DESCRIPTION",
+      "description": "Změna pro Hradec a Zelení",
       "img_url": "zelení-nk",
       "contacts": {
         "web": [
@@ -677,7 +677,7 @@
         {
           "id": "komunalni-2022-569810-c-956549-p",
           "name": "Změna pro Hradec a Zelení",
-          "description": "Změna pro Hradec a Zelení - DESCRIPTION",
+          "description": "Změna pro Hradec a Zelení",
           "contacts": {
             "web": [
               {
@@ -696,7 +696,7 @@
       "id": "komunalni-2022-569810-c-589869",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
-      "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "description": "Komunistická strana Čech a Moravy",
       "img_url": "ksčm",
       "contacts": {
         "web": []
@@ -705,7 +705,7 @@
         {
           "id": "komunalni-2022-569810-c-589869-p",
           "name": "Komunistická strana Čech a Moravy",
-          "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+          "description": "Komunistická strana Čech a Moravy",
           "contacts": {
             "web": []
           },
@@ -717,7 +717,7 @@
       "id": "komunalni-2022-569810-c-601843",
       "name": "ANO 2011",
       "type": "party",
-      "description": "ANO 2011 - DESCRIPTION",
+      "description": "ANO 2011",
       "img_url": "ano",
       "contacts": {
         "web": []
@@ -726,7 +726,7 @@
         {
           "id": "komunalni-2022-569810-c-601843-p",
           "name": "ANO 2011",
-          "description": "ANO 2011 - DESCRIPTION",
+          "description": "ANO 2011",
           "contacts": {
             "web": []
           },
@@ -738,7 +738,7 @@
       "id": "komunalni-2022-569810-c-655604",
       "name": "Občanská demokratická strana",
       "type": "party",
-      "description": "Občanská demokratická strana - DESCRIPTION",
+      "description": "Občanská demokratická strana",
       "img_url": "ods",
       "contacts": {
         "web": []
@@ -747,7 +747,7 @@
         {
           "id": "komunalni-2022-569810-c-655604-p",
           "name": "Občanská demokratická strana",
-          "description": "Občanská demokratická strana - DESCRIPTION",
+          "description": "Občanská demokratická strana",
           "contacts": {
             "web": []
           },
@@ -759,7 +759,7 @@
       "id": "komunalni-2022-569810-c-803953",
       "name": "ROZVÍJÍME HRADEC - NOVÁ HRADECKÁ OBČANSKÁ KANDIDÁTKA",
       "type": "party",
-      "description": "ROZVÍJÍME HRADEC - NOVÁ HRADECKÁ OBČANSKÁ KANDIDÁTKA - DESCRIPTION",
+      "description": "ROZVÍJÍME HRADEC - NOVÁ HRADECKÁ OBČANSKÁ KANDIDÁTKA",
       "img_url": "rh-nk",
       "contacts": {
         "web": [
@@ -774,7 +774,7 @@
         {
           "id": "komunalni-2022-569810-c-803953-p",
           "name": "ROZVÍJÍME HRADEC - NOVÁ HRADECKÁ OBČANSKÁ KANDIDÁTKA",
-          "description": "ROZVÍJÍME HRADEC - NOVÁ HRADECKÁ OBČANSKÁ KANDIDÁTKA - DESCRIPTION",
+          "description": "ROZVÍJÍME HRADEC - NOVÁ HRADECKÁ OBČANSKÁ KANDIDÁTKA",
           "contacts": {
             "web": [
               {
@@ -792,7 +792,7 @@
       "id": "komunalni-2022-569810-c-982677",
       "name": "Česká pirátská strana",
       "type": "party",
-      "description": "Česká pirátská strana - DESCRIPTION",
+      "description": "Česká pirátská strana",
       "img_url": "piráti",
       "contacts": {
         "web": []
@@ -801,7 +801,7 @@
         {
           "id": "komunalni-2022-569810-c-982677-p",
           "name": "Česká pirátská strana",
-          "description": "Česká pirátská strana - DESCRIPTION",
+          "description": "Česká pirátská strana",
           "contacts": {
             "web": []
           },
@@ -814,7 +814,7 @@
       "id": "komunalni-2022-569810-c-278614",
       "name": "Koalice pro Hradec",
       "type": "party",
-      "description": "Koalice pro Hradec - DESCRIPTION",
+      "description": "Koalice pro Hradec",
       "img_url": "kdu-čsl-nk",
       "contacts": {
         "web": [],
@@ -824,7 +824,7 @@
         {
           "id": "komunalni-2022-569810-c-278614-p",
           "name": "Koalice pro Hradec",
-          "description": "Koalice pro Hradec - DESCRIPTION",
+          "description": "Koalice pro Hradec",
           "contacts": {
             "web": [],
             "twitter": "https://twitter.com/koaliceHK"

--- a/data/kalkulacka/komunalni-2022/582786.json
+++ b/data/kalkulacka/komunalni-2022/582786.json
@@ -498,7 +498,7 @@
       "id": "komunalni-2022-582786-c-895801",
       "name": "ČSSD VAŠI STAROSTOVÉ",
       "type": "party",
-      "description": "ČSSD VAŠI STAROSTOVÉ - DESCRIPTION",
+      "description": "ČSSD VAŠI STAROSTOVÉ",
       "img_url": "čssd-nk",
       "contacts": {
         "web": [
@@ -517,7 +517,7 @@
         {
           "id": "komunalni-2022-582786-c-895801-p",
           "name": "ČSSD VAŠI STAROSTOVÉ",
-          "description": "ČSSD VAŠI STAROSTOVÉ - DESCRIPTION",
+          "description": "ČSSD VAŠI STAROSTOVÉ",
           "contacts": {
             "web": [
               {
@@ -540,7 +540,7 @@
       "id": "komunalni-2022-582786-c-380850",
       "name": "Brno Brňankám a Brňanům! (B3!)",
       "type": "party",
-      "description": "Brno Brňankám a Brňanům! (B3!) - DESCRIPTION",
+      "description": "Brno Brňankám a Brňanům! (B3!)",
       "img_url": "levice-nk",
       "contacts": {
         "web": [
@@ -560,7 +560,7 @@
         {
           "id": "komunalni-2022-582786-c-380850-p",
           "name": "Brno Brňankám a Brňanům! (B3!)",
-          "description": "Brno Brňankám a Brňanům! (B3!) - DESCRIPTION",
+          "description": "Brno Brňankám a Brňanům! (B3!)",
           "contacts": {
             "web": [
               {
@@ -584,7 +584,7 @@
       "id": "komunalni-2022-582786-c-395398",
       "name": "Česká pirátská strana",
       "type": "party",
-      "description": "Česká pirátská strana - DESCRIPTION",
+      "description": "Česká pirátská strana",
       "img_url": "piráti",
       "contacts": {
         "web": [],
@@ -594,7 +594,7 @@
         {
           "id": "komunalni-2022-582786-c-395398-p",
           "name": "Česká pirátská strana",
-          "description": "Česká pirátská strana - DESCRIPTION",
+          "description": "Česká pirátská strana",
           "contacts": {
             "web": [],
             "twitter": "https://twitter.com/MarekLahoda"
@@ -608,7 +608,7 @@
       "id": "komunalni-2022-582786-c-658413",
       "name": "Zelení a Žít Brno s podporou Idealistů",
       "type": "party",
-      "description": "Zelení a Žít Brno s podporou Idealistů - DESCRIPTION",
+      "description": "Zelení a Žít Brno s podporou Idealistů",
       "img_url": "zelen-žtb-ideal",
       "contacts": {
         "web": [],
@@ -619,7 +619,7 @@
         {
           "id": "komunalni-2022-582786-c-658413-p",
           "name": "Zelení a Žít Brno s podporou Idealistů",
-          "description": "Zelení a Žít Brno s podporou Idealistů - DESCRIPTION",
+          "description": "Zelení a Žít Brno s podporou Idealistů",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/idealistehnuti",
@@ -634,7 +634,7 @@
       "id": "komunalni-2022-582786-c-968366",
       "name": "Lidovci a Starostové (KDU-ČSL + Starostové a nezávislí)",
       "type": "party",
-      "description": "Lidovci a Starostové (KDU-ČSL + Starostové a nezávislí) - DESCRIPTION",
+      "description": "Lidovci a Starostové (KDU-ČSL + Starostové a nezávislí)",
       "img_url": "kdu-čsl-stan",
       "contacts": {
         "web": [
@@ -648,7 +648,7 @@
         {
           "id": "komunalni-2022-582786-c-968366-p",
           "name": "Lidovci a Starostové (KDU-ČSL + Starostové a nezávislí)",
-          "description": "Lidovci a Starostové (KDU-ČSL + Starostové a nezávislí) - DESCRIPTION",
+          "description": "Lidovci a Starostové (KDU-ČSL + Starostové a nezávislí)",
           "contacts": {
             "web": [
               {
@@ -666,7 +666,7 @@
       "id": "komunalni-2022-582786-c-778616",
       "name": "Brno Plus a Svobodní",
       "type": "party",
-      "description": "Brno Plus a Svobodní - DESCRIPTION",
+      "description": "Brno Plus a Svobodní",
       "img_url": "svobodní-brno-",
       "contacts": {
         "web": [
@@ -687,7 +687,7 @@
         {
           "id": "komunalni-2022-582786-c-778616-p",
           "name": "Brno Plus a Svobodní",
-          "description": "Brno Plus a Svobodní - DESCRIPTION",
+          "description": "Brno Plus a Svobodní",
           "contacts": {
             "web": [
               {
@@ -712,7 +712,7 @@
       "id": "komunalni-2022-582786-c-197622",
       "name": "SPD, TRIKOLORA, MORAVANÉ a nezávislí",
       "type": "party",
-      "description": "SPD, TRIKOLORA, MORAVANÉ a nezávislí - DESCRIPTION",
+      "description": "SPD, TRIKOLORA, MORAVANÉ a nezávislí",
       "img_url": "mor-spd-trik-nk",
       "contacts": {
         "web": []
@@ -721,7 +721,7 @@
         {
           "id": "komunalni-2022-582786-c-197622-p",
           "name": "SPD, TRIKOLORA, MORAVANÉ a nezávislí",
-          "description": "SPD, TRIKOLORA, MORAVANÉ a nezávislí - DESCRIPTION",
+          "description": "SPD, TRIKOLORA, MORAVANÉ a nezávislí",
           "contacts": {
             "web": []
           },
@@ -734,7 +734,7 @@
       "id": "komunalni-2022-582786-c-475575",
       "name": "ANO 2011",
       "type": "party",
-      "description": "ANO 2011 - DESCRIPTION",
+      "description": "ANO 2011",
       "img_url": "ano",
       "contacts": {
         "web": [
@@ -752,7 +752,7 @@
         {
           "id": "komunalni-2022-582786-c-475575-p",
           "name": "ANO 2011",
-          "description": "ANO 2011 - DESCRIPTION",
+          "description": "ANO 2011",
           "contacts": {
             "web": [
               {
@@ -774,7 +774,7 @@
       "id": "komunalni-2022-582786-c-119941",
       "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
       "type": "party",
-      "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
+      "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
       "img_url": "přísaha",
       "contacts": {
         "web": [
@@ -792,7 +792,7 @@
         {
           "id": "komunalni-2022-582786-c-119941-p",
           "name": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
-          "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty - DESCRIPTION",
+          "description": "PŘÍSAHA - občanské hnutí Roberta Šlachty",
           "contacts": {
             "web": [
               {
@@ -813,7 +813,7 @@
       "id": "komunalni-2022-582786-c-467949",
       "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT – sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
       "type": "party",
-      "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT – sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+      "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT – sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
       "img_url": "dsz-nk",
       "contacts": {
         "web": []
@@ -822,7 +822,7 @@
         {
           "id": "komunalni-2022-582786-c-467949-p",
           "name": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT – sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
-          "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT – sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK - DESCRIPTION",
+          "description": "Demokratická strana zelených - ZA PRÁVA ZVÍŘAT – sdružení DSZ - ZA PRÁVA ZVÍŘAT a NK",
           "contacts": {
             "web": []
           },
@@ -834,7 +834,7 @@
       "id": "komunalni-2022-582786-c-524545",
       "name": "SPOLEČNĚ - ODS a TOP 09",
       "type": "party",
-      "description": "SPOLEČNĚ - ODS a TOP 09 - DESCRIPTION",
+      "description": "SPOLEČNĚ - ODS a TOP 09",
       "img_url": "ods-top 09",
       "contacts": {
         "web": [
@@ -852,7 +852,7 @@
         {
           "id": "komunalni-2022-582786-c-524545-p",
           "name": "SPOLEČNĚ - ODS a TOP 09",
-          "description": "SPOLEČNĚ - ODS a TOP 09 - DESCRIPTION",
+          "description": "SPOLEČNĚ - ODS a TOP 09",
           "contacts": {
             "web": [
               {
@@ -874,7 +874,7 @@
       "id": "komunalni-2022-582786-c-726436",
       "name": "RESTART PRO BRNO",
       "type": "party",
-      "description": "RESTART PRO BRNO - DESCRIPTION",
+      "description": "RESTART PRO BRNO",
       "img_url": "ksčmspozsuvdom",
       "contacts": {
         "web": [],
@@ -884,7 +884,7 @@
         {
           "id": "komunalni-2022-582786-c-726436-p",
           "name": "RESTART PRO BRNO",
-          "description": "RESTART PRO BRNO - DESCRIPTION",
+          "description": "RESTART PRO BRNO",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/Restart-pro-Brno-103632592357718/"
@@ -897,7 +897,7 @@
       "id": "komunalni-2022-582786-c-625869",
       "name": "JSI PRO? Jistota Solidarita Investice pro budoucnost",
       "type": "party",
-      "description": "JSI PRO? Jistota Solidarita Investice pro budoucnost - DESCRIPTION",
+      "description": "JSI PRO? Jistota Solidarita Investice pro budoucnost",
       "img_url": "jsi pro?",
       "contacts": {
         "web": []
@@ -906,7 +906,7 @@
         {
           "id": "komunalni-2022-582786-c-625869-p",
           "name": "JSI PRO? Jistota Solidarita Investice pro budoucnost",
-          "description": "JSI PRO? Jistota Solidarita Investice pro budoucnost - DESCRIPTION",
+          "description": "JSI PRO? Jistota Solidarita Investice pro budoucnost",
           "contacts": {
             "web": []
           },
@@ -918,7 +918,7 @@
       "id": "komunalni-2022-582786-c-919557",
       "name": "Fakt Brno",
       "type": "party",
-      "description": "Fakt Brno - DESCRIPTION",
+      "description": "Fakt Brno",
       "img_url": "fakt brno",
       "contacts": {
         "web": [
@@ -939,7 +939,7 @@
         {
           "id": "komunalni-2022-582786-c-919557-p",
           "name": "Fakt Brno",
-          "description": "Fakt Brno - DESCRIPTION",
+          "description": "Fakt Brno",
           "contacts": {
             "web": [
               {

--- a/data/kalkulacka/komunalni-2022/590266.json
+++ b/data/kalkulacka/komunalni-2022/590266.json
@@ -402,7 +402,7 @@
       "id": "komunalni-2022-590266-c-860344",
       "name": "Třebíč můj domov",
       "type": "party",
-      "description": "Třebíč můj domov - DESCRIPTION",
+      "description": "Třebíč můj domov",
       "img_url": "snk ed-nk",
       "contacts": {
         "web": []
@@ -411,7 +411,7 @@
         {
           "id": "komunalni-2022-590266-c-860344-p",
           "name": "Třebíč můj domov",
-          "description": "Třebíč můj domov - DESCRIPTION",
+          "description": "Třebíč můj domov",
           "contacts": {
             "web": []
           },
@@ -424,7 +424,7 @@
       "id": "komunalni-2022-590266-c-378973",
       "name": "Třebíč Občanům!",
       "type": "party",
-      "description": "Třebíč Občanům! - DESCRIPTION",
+      "description": "Třebíč Občanům!",
       "img_url": "kan-nk",
       "contacts": {
         "web": [
@@ -445,7 +445,7 @@
         {
           "id": "komunalni-2022-590266-c-378973-p",
           "name": "Třebíč Občanům!",
-          "description": "Třebíč Občanům! - DESCRIPTION",
+          "description": "Třebíč Občanům!",
           "contacts": {
             "web": [
               {
@@ -470,7 +470,7 @@
       "id": "komunalni-2022-590266-c-505803",
       "name": "ANO 2011",
       "type": "party",
-      "description": "ANO 2011 - DESCRIPTION",
+      "description": "ANO 2011",
       "img_url": "ano",
       "contacts": {
         "web": []
@@ -479,7 +479,7 @@
         {
           "id": "komunalni-2022-590266-c-505803-p",
           "name": "ANO 2011",
-          "description": "ANO 2011 - DESCRIPTION",
+          "description": "ANO 2011",
           "contacts": {
             "web": []
           },
@@ -491,7 +491,7 @@
       "id": "komunalni-2022-590266-c-238616",
       "name": "Občané patrioti",
       "type": "party",
-      "description": "Občané patrioti - DESCRIPTION",
+      "description": "Občané patrioti",
       "img_url": "opat",
       "contacts": {
         "web": []
@@ -500,7 +500,7 @@
         {
           "id": "komunalni-2022-590266-c-238616-p",
           "name": "Občané patrioti",
-          "description": "Občané patrioti - DESCRIPTION",
+          "description": "Občané patrioti",
           "contacts": {
             "web": []
           },
@@ -513,7 +513,7 @@
       "id": "komunalni-2022-590266-c-543213",
       "name": "PIRÁTI A NEZÁVISLÍ",
       "type": "party",
-      "description": "PIRÁTI A NEZÁVISLÍ - DESCRIPTION",
+      "description": "PIRÁTI A NEZÁVISLÍ",
       "img_url": "piráti-nk",
       "contacts": {
         "web": []
@@ -522,7 +522,7 @@
         {
           "id": "komunalni-2022-590266-c-543213-p",
           "name": "PIRÁTI A NEZÁVISLÍ",
-          "description": "PIRÁTI A NEZÁVISLÍ - DESCRIPTION",
+          "description": "PIRÁTI A NEZÁVISLÍ",
           "contacts": {
             "web": []
           },
@@ -535,7 +535,7 @@
       "id": "komunalni-2022-590266-c-763579",
       "name": "KDU-ČSL",
       "type": "party",
-      "description": "KDU-ČSL - DESCRIPTION",
+      "description": "KDU-ČSL",
       "img_url": "kdu-čsl",
       "contacts": {
         "web": []
@@ -544,7 +544,7 @@
         {
           "id": "komunalni-2022-590266-c-763579-p",
           "name": "KDU-ČSL",
-          "description": "KDU-ČSL - DESCRIPTION",
+          "description": "KDU-ČSL",
           "contacts": {
             "web": []
           },
@@ -556,7 +556,7 @@
       "id": "komunalni-2022-590266-c-160320",
       "name": "TSD - Třebíč sociálně demokratická",
       "type": "party",
-      "description": "TSD - Třebíč sociálně demokratická - DESCRIPTION",
+      "description": "TSD - Třebíč sociálně demokratická",
       "img_url": "čssd-nk",
       "contacts": {
         "web": []
@@ -565,7 +565,7 @@
         {
           "id": "komunalni-2022-590266-c-160320-p",
           "name": "TSD - Třebíč sociálně demokratická",
-          "description": "TSD - Třebíč sociálně demokratická - DESCRIPTION",
+          "description": "TSD - Třebíč sociálně demokratická",
           "contacts": {
             "web": []
           },
@@ -577,7 +577,7 @@
       "id": "komunalni-2022-590266-c-875906",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
-      "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "description": "Komunistická strana Čech a Moravy",
       "img_url": "ksčm",
       "contacts": {
         "web": []
@@ -586,7 +586,7 @@
         {
           "id": "komunalni-2022-590266-c-875906-p",
           "name": "Komunistická strana Čech a Moravy",
-          "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+          "description": "Komunistická strana Čech a Moravy",
           "contacts": {
             "web": []
           },
@@ -598,7 +598,7 @@
       "id": "komunalni-2022-590266-c-900395",
       "name": "Domov pro Třebíč",
       "type": "party",
-      "description": "Domov pro Třebíč - DESCRIPTION",
+      "description": "Domov pro Třebíč",
       "img_url": "domov-nk",
       "contacts": {
         "web": []
@@ -607,7 +607,7 @@
         {
           "id": "komunalni-2022-590266-c-900395-p",
           "name": "Domov pro Třebíč",
-          "description": "Domov pro Třebíč - DESCRIPTION",
+          "description": "Domov pro Třebíč",
           "contacts": {
             "web": []
           },
@@ -620,7 +620,7 @@
       "id": "komunalni-2022-590266-c-711663",
       "name": "TOP 09",
       "type": "party",
-      "description": "TOP 09 - DESCRIPTION",
+      "description": "TOP 09",
       "img_url": "top 09",
       "contacts": {
         "web": []
@@ -629,7 +629,7 @@
         {
           "id": "komunalni-2022-590266-c-711663-p",
           "name": "TOP 09",
-          "description": "TOP 09 - DESCRIPTION",
+          "description": "TOP 09",
           "contacts": {
             "web": []
           },
@@ -642,7 +642,7 @@
       "id": "komunalni-2022-590266-c-166431",
       "name": "Svoboda a přímá demokracie (SPD) s podporou Trikolory",
       "type": "party",
-      "description": "Svoboda a přímá demokracie (SPD) s podporou Trikolory - DESCRIPTION",
+      "description": "Svoboda a přímá demokracie (SPD) s podporou Trikolory",
       "img_url": "spd-trikolora",
       "contacts": {
         "web": []
@@ -651,7 +651,7 @@
         {
           "id": "komunalni-2022-590266-c-166431-p",
           "name": "Svoboda a přímá demokracie (SPD) s podporou Trikolory",
-          "description": "Svoboda a přímá demokracie (SPD) s podporou Trikolory - DESCRIPTION",
+          "description": "Svoboda a přímá demokracie (SPD) s podporou Trikolory",
           "contacts": {
             "web": []
           },
@@ -664,7 +664,7 @@
       "id": "komunalni-2022-590266-c-180898",
       "name": "PRO TŘEBÍČ",
       "type": "party",
-      "description": "PRO TŘEBÍČ - DESCRIPTION",
+      "description": "PRO TŘEBÍČ",
       "img_url": "stan-nk",
       "contacts": {
         "web": []
@@ -673,7 +673,7 @@
         {
           "id": "komunalni-2022-590266-c-180898-p",
           "name": "PRO TŘEBÍČ",
-          "description": "PRO TŘEBÍČ - DESCRIPTION",
+          "description": "PRO TŘEBÍČ",
           "contacts": {
             "web": []
           },
@@ -686,7 +686,7 @@
       "id": "komunalni-2022-590266-c-934440",
       "name": "Občanská demokratická strana a Ta naše Třebíč",
       "type": "party",
-      "description": "Občanská demokratická strana a Ta naše Třebíč - DESCRIPTION",
+      "description": "Občanská demokratická strana a Ta naše Třebíč",
       "img_url": "ods-tnt",
       "contacts": {
         "web": []
@@ -695,7 +695,7 @@
         {
           "id": "komunalni-2022-590266-c-934440-p",
           "name": "Občanská demokratická strana a Ta naše Třebíč",
-          "description": "Občanská demokratická strana a Ta naše Třebíč - DESCRIPTION",
+          "description": "Občanská demokratická strana a Ta naše Třebíč",
           "contacts": {
             "web": []
           },
@@ -708,7 +708,7 @@
       "id": "komunalni-2022-590266-c-589003",
       "name": "Břehy",
       "type": "party",
-      "description": "Břehy - DESCRIPTION",
+      "description": "Břehy",
       "img_url": "zelení-nk",
       "contacts": {
         "web": []
@@ -717,7 +717,7 @@
         {
           "id": "komunalni-2022-590266-c-589003-p",
           "name": "Břehy",
-          "description": "Břehy - DESCRIPTION",
+          "description": "Břehy",
           "contacts": {
             "web": []
           },

--- a/data/kalkulacka/komunalni-2022/598917.json
+++ b/data/kalkulacka/komunalni-2022/598917.json
@@ -402,7 +402,7 @@
       "id": "komunalni-2022-598917-c-934669",
       "name": "ANO 2011",
       "type": "party",
-      "description": "ANO 2011 - DESCRIPTION",
+      "description": "ANO 2011",
       "img_url": "ano",
       "contacts": {
         "web": []
@@ -411,7 +411,7 @@
         {
           "id": "komunalni-2022-598917-c-934669-p",
           "name": "ANO 2011",
-          "description": "ANO 2011 - DESCRIPTION",
+          "description": "ANO 2011",
           "contacts": {
             "web": []
           },
@@ -423,7 +423,7 @@
       "id": "komunalni-2022-598917-c-410314",
       "name": "Česká pirátská strana",
       "type": "party",
-      "description": "Česká pirátská strana - DESCRIPTION",
+      "description": "Česká pirátská strana",
       "img_url": "piráti",
       "contacts": {
         "web": []
@@ -432,7 +432,7 @@
         {
           "id": "komunalni-2022-598917-c-410314-p",
           "name": "Česká pirátská strana",
-          "description": "Česká pirátská strana - DESCRIPTION",
+          "description": "Česká pirátská strana",
           "contacts": {
             "web": []
           },
@@ -445,7 +445,7 @@
       "id": "komunalni-2022-598917-c-804761",
       "name": "Česká strana sociálně demokratická",
       "type": "party",
-      "description": "Česká strana sociálně demokratická - DESCRIPTION",
+      "description": "Česká strana sociálně demokratická",
       "img_url": "čssd",
       "contacts": {
         "web": []
@@ -454,7 +454,7 @@
         {
           "id": "komunalni-2022-598917-c-804761-p",
           "name": "Česká strana sociálně demokratická",
-          "description": "Česká strana sociálně demokratická - DESCRIPTION",
+          "description": "Česká strana sociálně demokratická",
           "contacts": {
             "web": []
           },
@@ -466,7 +466,7 @@
       "id": "komunalni-2022-598917-c-702950",
       "name": "Komunistická strana Čech a Moravy",
       "type": "party",
-      "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+      "description": "Komunistická strana Čech a Moravy",
       "img_url": "ksčm",
       "contacts": {
         "web": []
@@ -475,7 +475,7 @@
         {
           "id": "komunalni-2022-598917-c-702950-p",
           "name": "Komunistická strana Čech a Moravy",
-          "description": "Komunistická strana Čech a Moravy - DESCRIPTION",
+          "description": "Komunistická strana Čech a Moravy",
           "contacts": {
             "web": []
           },
@@ -488,7 +488,7 @@
       "id": "komunalni-2022-598917-c-687752",
       "name": "Svoboda a přímá demokracie (SPD)",
       "type": "party",
-      "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+      "description": "Svoboda a přímá demokracie (SPD)",
       "img_url": "spd",
       "contacts": {
         "web": []
@@ -497,7 +497,7 @@
         {
           "id": "komunalni-2022-598917-c-687752-p",
           "name": "Svoboda a přímá demokracie (SPD)",
-          "description": "Svoboda a přímá demokracie (SPD) - DESCRIPTION",
+          "description": "Svoboda a přímá demokracie (SPD)",
           "contacts": {
             "web": []
           },
@@ -510,7 +510,7 @@
       "id": "komunalni-2022-598917-c-191723",
       "name": "SPOLU",
       "type": "party",
-      "description": "SPOLU - DESCRIPTION",
+      "description": "SPOLU",
       "img_url": "kdu-ods-top 09",
       "contacts": {
         "web": [
@@ -524,7 +524,7 @@
         {
           "id": "komunalni-2022-598917-c-191723-p",
           "name": "SPOLU",
-          "description": "SPOLU - DESCRIPTION",
+          "description": "SPOLU",
           "contacts": {
             "web": [
               {
@@ -542,7 +542,7 @@
       "id": "komunalni-2022-598917-c-825401",
       "name": "STAROSTOVÉ A NEZÁVISLÍ",
       "type": "party",
-      "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+      "description": "STAROSTOVÉ A NEZÁVISLÍ",
       "img_url": "stan",
       "contacts": {
         "web": [
@@ -557,7 +557,7 @@
         {
           "id": "komunalni-2022-598917-c-825401-p",
           "name": "STAROSTOVÉ A NEZÁVISLÍ",
-          "description": "STAROSTOVÉ A NEZÁVISLÍ - DESCRIPTION",
+          "description": "STAROSTOVÉ A NEZÁVISLÍ",
           "contacts": {
             "web": [
               {

--- a/data/kalkulacka/senatni-2022/1.json
+++ b/data/kalkulacka/senatni-2022/1.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-1-c-965208",
       "name": "Pavel Petričko",
       "type": "person",
-      "description": "Pavel Petričko - DESCRIPTION",
+      "description": "Pavel Petričko",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/pavel.petricko.9",
@@ -492,7 +492,7 @@
         {
           "id": "senatni-2022-1-c-965208-p",
           "name": "Pavel Petričko",
-          "description": "Pavel Petričko - DESCRIPTION",
+          "description": "Pavel Petričko",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/pavel.petricko.9",
@@ -506,7 +506,7 @@
       "id": "senatni-2022-1-c-872946",
       "name": "Eva Chromcová",
       "type": "person",
-      "description": "Eva Chromcová - DESCRIPTION",
+      "description": "Eva Chromcová",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/eva.chromcova"
@@ -515,7 +515,7 @@
         {
           "id": "senatni-2022-1-c-872946-p",
           "name": "Eva Chromcová",
-          "description": "Eva Chromcová - DESCRIPTION",
+          "description": "Eva Chromcová",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/eva.chromcova"
@@ -528,7 +528,7 @@
       "id": "senatni-2022-1-c-107987",
       "name": "Bohdan Vaněk",
       "type": "person",
-      "description": "Bohdan Vaněk - DESCRIPTION",
+      "description": "Bohdan Vaněk",
       "contacts": {
         "web": [
           {
@@ -547,7 +547,7 @@
         {
           "id": "senatni-2022-1-c-107987-p",
           "name": "Bohdan Vaněk",
-          "description": "Bohdan Vaněk - DESCRIPTION",
+          "description": "Bohdan Vaněk",
           "contacts": {
             "web": [
               {
@@ -570,7 +570,7 @@
       "id": "senatni-2022-1-c-578851",
       "name": "Bedřich Šmudla",
       "type": "person",
-      "description": "Bedřich Šmudla - DESCRIPTION",
+      "description": "Bedřich Šmudla",
       "contacts": {
         "web": [],
         "instagram": "https://www.instagram.com/senatorbedrich/"
@@ -579,7 +579,7 @@
         {
           "id": "senatni-2022-1-c-578851-p",
           "name": "Bedřich Šmudla",
-          "description": "Bedřich Šmudla - DESCRIPTION",
+          "description": "Bedřich Šmudla",
           "contacts": {
             "web": [],
             "instagram": "https://www.instagram.com/senatorbedrich/"
@@ -592,7 +592,7 @@
       "id": "senatni-2022-1-c-128673",
       "name": "Věra Procházková",
       "type": "person",
-      "description": "Věra Procházková - DESCRIPTION",
+      "description": "Věra Procházková",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/mudrveraprochazkova",
@@ -602,7 +602,7 @@
         {
           "id": "senatni-2022-1-c-128673-p",
           "name": "Věra Procházková",
-          "description": "Věra Procházková - DESCRIPTION",
+          "description": "Věra Procházková",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/mudrveraprochazkova",
@@ -616,7 +616,7 @@
       "id": "senatni-2022-1-c-329053",
       "name": "Petr Kulhánek",
       "type": "person",
-      "description": "Petr Kulhánek - DESCRIPTION",
+      "description": "Petr Kulhánek",
       "contacts": {
         "web": [
           {
@@ -632,7 +632,7 @@
         {
           "id": "senatni-2022-1-c-329053-p",
           "name": "Petr Kulhánek",
-          "description": "Petr Kulhánek - DESCRIPTION",
+          "description": "Petr Kulhánek",
           "contacts": {
             "web": [
               {
@@ -652,7 +652,7 @@
       "id": "senatni-2022-1-c-200693",
       "name": "Jan Havel",
       "type": "person",
-      "description": "Jan Havel - DESCRIPTION",
+      "description": "Jan Havel",
       "contacts": {
         "web": []
       },
@@ -660,7 +660,7 @@
         {
           "id": "senatni-2022-1-c-200693-p",
           "name": "Jan Havel",
-          "description": "Jan Havel - DESCRIPTION",
+          "description": "Jan Havel",
           "contacts": {
             "web": []
           },
@@ -672,7 +672,7 @@
       "id": "senatni-2022-1-c-174710",
       "name": "Petr Ajšman",
       "type": "person",
-      "description": "Petr Ajšman - DESCRIPTION",
+      "description": "Petr Ajšman",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/petr.ajsman",
@@ -683,7 +683,7 @@
         {
           "id": "senatni-2022-1-c-174710-p",
           "name": "Petr Ajšman",
-          "description": "Petr Ajšman - DESCRIPTION",
+          "description": "Petr Ajšman",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/petr.ajsman",
@@ -698,7 +698,7 @@
       "id": "senatni-2022-1-c-755869",
       "name": "Martin Maleček",
       "type": "person",
-      "description": "Martin Maleček - DESCRIPTION",
+      "description": "Martin Maleček",
       "contacts": {
         "web": [
           {
@@ -712,7 +712,7 @@
         {
           "id": "senatni-2022-1-c-755869-p",
           "name": "Martin Maleček",
-          "description": "Martin Maleček - DESCRIPTION",
+          "description": "Martin Maleček",
           "contacts": {
             "web": [
               {
@@ -730,7 +730,7 @@
       "id": "senatni-2022-1-c-306348",
       "name": "Václav Slavík",
       "type": "person",
-      "description": "Václav Slavík - DESCRIPTION",
+      "description": "Václav Slavík",
       "contacts": {
         "web": [
           {
@@ -754,7 +754,7 @@
         {
           "id": "senatni-2022-1-c-306348-p",
           "name": "Václav Slavík",
-          "description": "Václav Slavík - DESCRIPTION",
+          "description": "Václav Slavík",
           "contacts": {
             "web": [
               {
@@ -782,7 +782,7 @@
       "id": "senatni-2022-1-c-742303",
       "name": "Jan Horník",
       "type": "person",
-      "description": "Jan Horník - DESCRIPTION",
+      "description": "Jan Horník",
       "contacts": {
         "web": [
           {
@@ -802,7 +802,7 @@
         {
           "id": "senatni-2022-1-c-742303-p",
           "name": "Jan Horník",
-          "description": "Jan Horník - DESCRIPTION",
+          "description": "Jan Horník",
           "contacts": {
             "web": [
               {
@@ -827,2979 +827,2979 @@
     {
       "id": "senatni-2022-1-a-329053-1",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-2",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-3",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-4",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Upřednostňovat nikoliv, ale dostat se do vyvážené pozice ve vztahu k další dopravní infrastruktuře jednoznačně ano."
     },
     {
       "id": "senatni-2022-1-a-329053-5",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-6",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "Nikoliv přehrady (až na výjimky, kde jsou ve shodě všichni aktéři), ale soustředit se na drobnější, ale četností masivnější, opatření zadržující vodu v krajině."
     },
     {
       "id": "senatni-2022-1-a-329053-7",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "dont_know",
       "comment": "Proti sobě stojí zatím druhotné využití a ekonomika celého systému"
     },
     {
       "id": "senatni-2022-1-a-329053-8",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-9",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-10",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-11",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-12",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes",
       "comment": "V maximální míře, kde je možné to ovlivnit/regulovat."
     },
     {
       "id": "senatni-2022-1-a-329053-13",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes",
       "comment": "Ale vnímám kolizi s prokazováním a hranicí co ještě není a už je fake news"
     },
     {
       "id": "senatni-2022-1-a-329053-14",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-15",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no",
       "comment": "Ale podrobněji specifikovány a kontrolovány podmínky jejich fungování"
     },
     {
       "id": "senatni-2022-1-a-329053-16",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-17",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-329053-18",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-19",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Myšleno sociálními byty modelu prostupného bydlení, nebo pro potřebné ve složité hmotné, zdravotní, životní situaci."
     },
     {
       "id": "senatni-2022-1-a-329053-20",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Tato sociální práce je primární úloha obcí."
     },
     {
       "id": "senatni-2022-1-a-329053-21",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-22",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-329053-23",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-24",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no",
       "comment": "Tím myslím finanční podporu. Úkol pro stát je najít motivací pro studenty přihlásit se technické obory - argumentace budoucího uplatnění a poptávky po jejich znalostech."
     },
     {
       "id": "senatni-2022-1-a-329053-25",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes",
       "comment": "Pokud nejde o případy, kdy společné studium je nemožné a vyžaduje individuální/skupinové řešení"
     },
     {
       "id": "senatni-2022-1-a-329053-26",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-27",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-28",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-29",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-30",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-31",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-32",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes",
       "comment": "Přiměření velikosti a významu naší země"
     },
     {
       "id": "senatni-2022-1-a-329053-33",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Pokud nelze usnadnit udělení u osob s válečných oblastí, osob pronásledovaných kvůli jejich přesvědčení, názoru, náboženství..."
     },
     {
       "id": "senatni-2022-1-a-329053-34",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-35",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-36",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-329053-37",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-38",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-39",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-329053-40",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-41",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-42",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-43",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-44",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-45",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-329053-46",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-47",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-48",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-49",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-50",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes",
       "comment": "Podporuji, pokud to bude realistické a významně to nepoškodí/nezhorší podmínky v řadě oblastí života"
     },
     {
       "id": "senatni-2022-1-a-329053-51",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-52",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-53",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-329053-54",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "dont_know",
       "comment": "Primární cíl by měl být rovný přístup k podpoře bez ohledu na velikost"
     },
     {
       "id": "senatni-2022-1-a-329053-55",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-56",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-57",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-329053-58",
       "candidate_id": "senatni-2022-1-c-329053",
-      "question_id": "senatni-2022-1-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-578851-1",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Jde o zásah do vlastnických práv. Naopak úlohou státu je zajistit startovací a sociální byty."
     },
     {
       "id": "senatni-2022-1-a-578851-2",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Jde o zásah do vlastnických práv. Naopak úlohou státu je zajistit startovací a sociální byty s adresnou pomocí tam, kde je to nutné."
     },
     {
       "id": "senatni-2022-1-a-578851-3",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Jsem pro osvědčený švýcarský model, tedy 50.000 podpisů pod peticí."
     },
     {
       "id": "senatni-2022-1-a-578851-4",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Jako důležitější téma vidím dálnice a silnice v České republice."
     },
     {
       "id": "senatni-2022-1-a-578851-5",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Odchod do penze by se měl naopak vrátit na 60 let. Navíc pro ženy s odpočtem za počet dětí. Při současných technologiích není nutné věkový limit zvyšovat, vždyť už měla být i kratší pracovní doba."
     },
     {
       "id": "senatni-2022-1-a-578851-6",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes",
       "comment": "Jsme střechou Evropy a pitná voda je strategická surovina již dnes."
     },
     {
       "id": "senatni-2022-1-a-578851-7",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes",
       "comment": "Třídění těchto odpadů konečně dostane nějaký smysl."
     },
     {
       "id": "senatni-2022-1-a-578851-8",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Nevidím jediný důvod, proč by úspěšní měli být trestáni. Statistika za posledních 30 let navíc ukazuje, že pokud jsou daně nižší a jednotné, tak je i výběr daně efektivnější. "
     },
     {
       "id": "senatni-2022-1-a-578851-9",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Konopí je již delší dobu démonizováno."
     },
     {
       "id": "senatni-2022-1-a-578851-10",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Prokázané násilí je nutné potrestat tak, aby výše trestu byla odstrašující."
     },
     {
       "id": "senatni-2022-1-a-578851-11",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Pokud generují zisk na území České republiky, musí mít stejné podmínky jako ostatní."
     },
     {
       "id": "senatni-2022-1-a-578851-12",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Tyto sítě mají naopak umožnit názorovou pestrost. Pokud někdo porušuje zákon, má jednat Policie."
     },
     {
       "id": "senatni-2022-1-a-578851-13",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "Již třetím rokem vymazávají tzv. \"ověřovatelé faktů\" zprávy a to je obyčejná cenzura."
     },
     {
       "id": "senatni-2022-1-a-578851-14",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes",
       "comment": "Třetím rokem předvádí \"veřejnopráví média\", že slouží pouze vládě. Tedy zrušme koncesionářské poplatky a navažme jejich rozpočty na ten státní."
     },
     {
       "id": "senatni-2022-1-a-578851-15",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no",
       "comment": "Takřka všechny regulace ze strany státu proti soukromé sféře křiví trh, konkurenceschopnost a v konečné fázi i ceny."
     },
     {
       "id": "senatni-2022-1-a-578851-16",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Manželství je vztah ženy a muže. Partnerství je vztah stejnopohlavních párů. Zákonné právo např. na dědění nebo osvojení dítěte by však mělo být stejné. Dnešní přívlastek \"registrované\" je dehonestující."
     },
     {
       "id": "senatni-2022-1-a-578851-17",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes",
       "comment": "Produktivita není zakázané slovo ani pro exekutory, navíc se odstraní i jiné náklady."
     },
     {
       "id": "senatni-2022-1-a-578851-18",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes",
       "comment": "Jednoznačně, protože dnes se lidé ztrácí pod jejich množstvím. Forma losu zajistí rovné příležitosti pro všechny exekutory."
     },
     {
       "id": "senatni-2022-1-a-578851-19",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Je to jedna ze zásadních úloh státu."
     },
     {
       "id": "senatni-2022-1-a-578851-20",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Pravidla by měla být natolik jednoduchá a dostatečně veřejná, aby ten kdo má oprávněný nárok se o něj mohl přihlásit sám. "
     },
     {
       "id": "senatni-2022-1-a-578851-21",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "Zamezí se centralismu a přinese to nová pracovní místa i možnost pro mladou generaci uplatnit se ve svém regionu."
     },
     {
       "id": "senatni-2022-1-a-578851-22",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no",
       "comment": "Nejdřív se postarejme o důstojný život všech našich občanů a poté se zapisujme do světových dějin vědy."
     },
     {
       "id": "senatni-2022-1-a-578851-23",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Při současných možnostech ovlivnění elektronických dat to není ten správný způsob volby. Jednou za čtyři až šest let může k volbám osobně dojít každý. "
     },
     {
       "id": "senatni-2022-1-a-578851-24",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "Položte si otázku. Je pro Vás důležitější např. funkční automobil nebo názor na jakýkoliv politický směr. Za mne je to technika, Byla, je a bude vždy pokrokem lidstva."
     },
     {
       "id": "senatni-2022-1-a-578851-25",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Stát by měl zajistit speciální školy pro ty, kteří to potřebují. "
     },
     {
       "id": "senatni-2022-1-a-578851-26",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no",
       "comment": "Při současném stavu vzdělávání je tzv. inkluze pouze líbivé politické rozhodnutí."
     },
     {
       "id": "senatni-2022-1-a-578851-27",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "yes",
       "comment": "EU již není tím útvarem, který hájí národní zájmy svých členů. Evropa byla, je a doufám i bude nadále unikátní světadíl. "
     },
     {
       "id": "senatni-2022-1-a-578851-28",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "Euro je pouze politické rozhodnutí velkých států k ovládnutí těch malých."
     },
     {
       "id": "senatni-2022-1-a-578851-29",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes",
       "comment": "Je to spolek, který vedl a vede války na celém světě pro získání surovin jen pro vyvolené. "
     },
     {
       "id": "senatni-2022-1-a-578851-30",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no",
       "comment": "Společná armáda? Společná policie? Děkuji nemám zájem."
     },
     {
       "id": "senatni-2022-1-a-578851-31",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes",
       "comment": "Protože jsme všichni lidé a každý někdy potřebuje pomoc."
     },
     {
       "id": "senatni-2022-1-a-578851-32",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no",
       "comment": "Změna klimatu je jenom strašák k ovládání lidstva."
     },
     {
       "id": "senatni-2022-1-a-578851-33",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know",
       "comment": "Nemám dostatečné informace pro jednoznačné stanovisko."
     },
     {
       "id": "senatni-2022-1-a-578851-34",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes",
       "comment": "I jako nečlenský stát můžeme být tou pátou zemí, která má zaručený volný pohyb."
     },
     {
       "id": "senatni-2022-1-a-578851-35",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no",
       "comment": "Měli bychom se soustředit na odstranění ekonomických dopadů z posledních tří let."
     },
     {
       "id": "senatni-2022-1-a-578851-36",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Dítě není věc, ale lidská bytost."
     },
     {
       "id": "senatni-2022-1-a-578851-37",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "dont_know",
       "comment": "Nemám dostatečné informace pro jednoznačný názor."
     },
     {
       "id": "senatni-2022-1-a-578851-38",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes",
       "comment": "Souhlasím s centry ve fakultních nemocnicích v krajích. Jejich rozložení po krajích zajistí kvatitní a dostupnou zdravotní péči."
     },
     {
       "id": "senatni-2022-1-a-578851-39",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-578851-40",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Systém by měl ale rozlišovat tzv. společenskou nebezpečnost."
     },
     {
       "id": "senatni-2022-1-a-578851-41",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes",
       "comment": "Je to jenom další systém k ovládání a perzekuci lidí."
     },
     {
       "id": "senatni-2022-1-a-578851-42",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no",
       "comment": "Ukrajina nesplňuje zásadní kriteria (zejména korupcí a definicí právního státu) a navíc by to byl předstupeň pro její vstup do NATO."
     },
     {
       "id": "senatni-2022-1-a-578851-43",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "Hranice mezi západem a východem se již nesmí posouvat."
     },
     {
       "id": "senatni-2022-1-a-578851-44",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes",
       "comment": "Až na hranici nákupu Německa, tedy jeho přímého nákupu z Ruska. Dnešní poměr je 1:13 v neprospěch České republiky."
     },
     {
       "id": "senatni-2022-1-a-578851-45",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know",
       "comment": "Nemám dostatek informací pro jednoznačnou odpověď."
     },
     {
       "id": "senatni-2022-1-a-578851-46",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "no",
       "comment": "Jak se ukazuje, tak následky tzv. restrikcí proti Rusku nesou řadoví občané členských států EU."
     },
     {
       "id": "senatni-2022-1-a-578851-47",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no",
       "comment": "Čeští zákonodárci by měli sloužit českým občanům a zajistit jim důstojný život na úrovni roku 2022."
     },
     {
       "id": "senatni-2022-1-a-578851-48",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know",
       "comment": "Nemám dostatečné informace pro jednoznačné stanovisko. Obecně jsem pro zvýšení trestů za násilí proti ženám."
     },
     {
       "id": "senatni-2022-1-a-578851-49",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Dnes mají uhelné elektrárny taková technická řešení, že zátěž je minimální. A ta se do budoucna opět sníží."
     },
     {
       "id": "senatni-2022-1-a-578851-50",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "Tzv. \"Zelený úděl\" je světová mantra pro ovládání lidí."
     },
     {
       "id": "senatni-2022-1-a-578851-51",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "yes",
       "comment": "Podle mezinárodních úmluv je jakékoliv území oprávněno rozhodnout o své samostatnosti. Obyvatelé Krymu se svobodně v referendu rozhodli pro přičlenění k Rusku."
     },
     {
       "id": "senatni-2022-1-a-578851-52",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Přímý nákup ropy i plynu z Ruska je pro nás strategicky důležilý. Ostatně Německo udělalo to samé. "
     },
     {
       "id": "senatni-2022-1-a-578851-53",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "no",
       "comment": "Hranice mezi NATO a RF se již nesmí posouvat."
     },
     {
       "id": "senatni-2022-1-a-578851-54",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes",
       "comment": "Současná situace likviduje naše drobné a střední zemědělce a tím si likvidujeme i vlastní potravinovou soběstačnost."
     },
     {
       "id": "senatni-2022-1-a-578851-55",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "Úlohou státu je zajistit adresnou pomoc těm, kteří to potřebují."
     },
     {
       "id": "senatni-2022-1-a-578851-56",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes",
       "comment": "Navíc by měl i pořizovat startovní a sociální byty, aby lidé měli kde bydlet."
     },
     {
       "id": "senatni-2022-1-a-578851-57",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know",
       "comment": "Nemám dostatečné informace pro jednoznačnou odpověď. Nevím zda se jedná o území Ukrajiny, když po rozpadu Sovětského svazu o uznání svých hranic nikdy nepožádala."
     },
     {
       "id": "senatni-2022-1-a-578851-58",
       "candidate_id": "senatni-2022-1-c-578851",
-      "question_id": "senatni-2022-1-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "dont_know",
       "comment": "Nemám dostatečné informace pro jednoznačnou odpověď. Nevím, co znamená termín bezvýsledná exekuce."
     },
     {
       "id": "senatni-2022-1-a-755869-1",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-755869-2",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes",
       "comment": "V případě čerpání sociálního příspěvku na bydlení nutno zavést regionální cenové mapy obvyklé výše nájemného."
     },
     {
       "id": "senatni-2022-1-a-755869-3",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-755869-4",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-5",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-6",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know",
       "comment": "Nutno řešit s odborníky v oblasti vodohospodářství."
     },
     {
       "id": "senatni-2022-1-a-755869-7",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-755869-8",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Každý z občanů by měl mít nastavené stejné podmínky. Výše odvodu je závislá na výši výdělku."
     },
     {
       "id": "senatni-2022-1-a-755869-9",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-755869-10",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-755869-11",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-12",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-755869-13",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-755869-14",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-15",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-755869-16",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know",
       "comment": "Souhlasím s novelizací Zákona o registrovaném partnerství vzhledem k majetkoprávním vztahům, děditství a výchovy dětí."
     },
     {
       "id": "senatni-2022-1-a-755869-17",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-755869-18",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-755869-19",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "Tuto otázku ponechat na obcích a městech. Více podpořit obce při výstavbě nájemních bytů."
     },
     {
       "id": "senatni-2022-1-a-755869-20",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "dont_know",
       "comment": "Tuto problematiku musí přesně vymezit Ministerstvo práce a sociálních věcí."
     },
     {
       "id": "senatni-2022-1-a-755869-21",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-755869-22",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-23",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "S využítím datové schránky z důvodu identifikace voliče."
     },
     {
       "id": "senatni-2022-1-a-755869-24",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-755869-25",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Nemám problém se vzděláváním na víceletých gymnáziích, ale s větším nárokem na přijímací řízení za podmínek stanovených Ministerstvem školství."
     },
     {
       "id": "senatni-2022-1-a-755869-26",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-755869-27",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-28",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-29",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-30",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "dont_know",
       "comment": "Nesmí být potlačovány zásadní národní zájmy České republiky. Je potřeba více a razantněji tyto zájmy v rámci legitimních procesů Evropské unie prosazovat."
     },
     {
       "id": "senatni-2022-1-a-755869-31",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know",
       "comment": "Současná ekonomická situace nám to moc nedovoluje. Abychom mohli více pomáhat mimo hranice naší republiky, musí být zajištěna přijatelná životní úroveň našich občanů."
     },
     {
       "id": "senatni-2022-1-a-755869-32",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know",
       "comment": "Toto téma musí byt podrobeno široké diskuzi nejen v oblasti ochrany životního prostředí, ale i zajištění energetických služeb pro hospodářství a domácnosti. Nemůžou rozhodovat laici, ale odborníci."
     },
     {
       "id": "senatni-2022-1-a-755869-33",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Současný právní systém si myslím je dostačující."
     },
     {
       "id": "senatni-2022-1-a-755869-34",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-755869-35",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-755869-36",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-755869-37",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-755869-38",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-39",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-755869-40",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Vzhledem k regulaci rychlosti v obcích na rizikových úsecích s uvedeným systémem souhlasím."
     },
     {
       "id": "senatni-2022-1-a-755869-41",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-755869-42",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no",
       "comment": "V současné době nesplňuje podmínky. Již mnoho let čekají na vstup balkánské země bývalé Jugoslávie a určitě jsou lépe připraveni."
     },
     {
       "id": "senatni-2022-1-a-755869-43",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-44",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-755869-45",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-755869-46",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-755869-47",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-48",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-755869-49",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-50",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-755869-51",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-52",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-755869-53",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-755869-54",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-55",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-56",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-755869-57",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-755869-58",
       "candidate_id": "senatni-2022-1-c-755869",
-      "question_id": "senatni-2022-1-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-1",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-2",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-3",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-4",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-5",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-6",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-7",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-8",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-9",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-10",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-11",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-12",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-13",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-14",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-15",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-16",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-17",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-18",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-19",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-20",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-21",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-22",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-23",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-24",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-25",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-26",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-27",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-28",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-29",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-30",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-31",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-32",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-33",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-34",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-35",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-36",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-37",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-38",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-39",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-40",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-41",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-42",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-43",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-44",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-45",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-46",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-47",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-48",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-49",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-50",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-51",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-52",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-53",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-54",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-55",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-306348-56",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-306348-57",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-306348-58",
       "candidate_id": "senatni-2022-1-c-306348",
-      "question_id": "senatni-2022-1-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-1",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-2",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-3",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-4",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-5",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "yes",
       "comment": "Do 67 let, ale s výjimkou"
     },
     {
       "id": "senatni-2022-1-a-742303-6",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-742303-7",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-8",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-9",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-10",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-11",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-12",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-13",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-14",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-15",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-16",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-742303-17",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-18",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-19",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-20",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-21",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-22",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-23",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-24",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-25",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-26",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-27",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-28",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-29",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-30",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-31",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-742303-32",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes",
       "comment": "Ale, pokud tak učiní i ostatní země"
     },
     {
       "id": "senatni-2022-1-a-742303-33",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know",
       "comment": "Je to případ od případu"
     },
     {
       "id": "senatni-2022-1-a-742303-34",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-35",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-36",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-37",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-742303-38",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-742303-39",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-40",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-41",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-42",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes",
       "comment": "Ale bude to dlouhodobý proces"
     },
     {
       "id": "senatni-2022-1-a-742303-43",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-742303-44",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-45",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-46",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-47",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-48",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-49",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "dont_know",
       "comment": "V probíhající energetické krizi na otázku nejde jednoznačně odpovědět"
     },
     {
       "id": "senatni-2022-1-a-742303-50",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-51",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-52",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-53",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-54",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-742303-55",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-56",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-57",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-742303-58",
       "candidate_id": "senatni-2022-1-c-742303",
-      "question_id": "senatni-2022-1-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-107987-1",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes",
       "comment": "Jde spíše o daňové zvýhodnění bytů užívaných k trvalému bydlení. K tomu byty mají sloužit především. K uložení peněz slouži jiné instrumenty. Prázdné bytové domy jsou drahé i pro město - musí platit infrastrukturu lidem, kteří bydlí jinde."
     },
     {
       "id": "senatni-2022-1-a-107987-2",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Stát není dobrý regulátor něčeho, co se liší v různých částech země. Na druhou stranu je na obcích jaké nájemné si stanoví pro nájemce ve svých bytech s přihlédnutím k jejich individuální situaci. Proto má smysl, aby obce byly vybaveny bytovým fondem."
     },
     {
       "id": "senatni-2022-1-a-107987-3",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Jde o možnost. Už samotná možnost kultivuje politické prostředí. A na nastavení parametrů je, aby omezily možnost zneužití."
     },
     {
       "id": "senatni-2022-1-a-107987-4",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Nemělo by se tak dít na úkor ostatní důležité dopravní infrastruktury. Spolu s výstavbou sítě VRT je možné vybudovat další relevantní sítě pro maximální využití kapacit tak, aby se stavělo promyšleně, efektivně a v logických celcích."
     },
     {
       "id": "senatni-2022-1-a-107987-5",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Spíše je vhodné odměňovat ty, co se dobrovolně rozhodnou přesluhovat nebo pracovat i v důchodu, protože to je výhodné pro stát i seniory. "
     },
     {
       "id": "senatni-2022-1-a-107987-6",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "Toto je důležité posuzovat v širších souvislostech a z hlediska dlouhodobých dopadů. Je přínosné využití geografických možností, ale nepovažuji za vhodné stavět přehrady na každém využitelném místě. "
     },
     {
       "id": "senatni-2022-1-a-107987-7",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no",
       "comment": "Domnívám se, že povinné zálohování PET lahví a plechovek by nyní nepřineslo významné zlepšení v třídění a recyklaci odpadu. S vývojem nových technologií se to může změnit."
     },
     {
       "id": "senatni-2022-1-a-107987-8",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes",
       "comment": "Jsem spíše pro daňové zvýhodnění osob s nižšími příjmy."
     },
     {
       "id": "senatni-2022-1-a-107987-9",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Je důležité zavést regulaci dosud černého trhu. To omezí organizovaný zločin, přinese nové příjmy do státního rozpočtu a zároveň přispěje k ochraně dětí a mladistvých."
     },
     {
       "id": "senatni-2022-1-a-107987-10",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Nejde ani tak o rozsah trestů vymezených zákonem, ale skutečnou výši udělovaných trestů v trestním řízení. Je potřeba napravit definici znásilnění tak, aby zahrnovala i situace, kdy oběť nedokáže projevit odpor, nebo zažívá paralýzu. Zároveň je třeba změnit přístup k obětem, které druhotně trpí i při následném vyšetřování. "
     },
     {
       "id": "senatni-2022-1-a-107987-11",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Podporuji zavedení globální minimální daně, která odstraní nerovné postavení vedle \"daňových rájů\". "
     },
     {
       "id": "senatni-2022-1-a-107987-12",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Obecná právní odpovědnost sociálních sítí za obsah jejich uživatelů by vedla nejen k nepřiměřenému omezování svobody slova, ale i k enormní právní nejistotě. Postačují povinnosti odstranění nežádoucího obsahu na příkaz odpovědné osoby."
     },
     {
       "id": "senatni-2022-1-a-107987-13",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "Stát má občany chránit před nebezpečím, ne před nesmysly na internetu. Pokud ovšem někdo využívá dezinformace k šíření nenávistného projevu, jehož důsledkem mohou být další zločiny z nenávisti, tak proti těmto producentům stát musí zasáhnout."
     },
     {
       "id": "senatni-2022-1-a-107987-14",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Je třeba zajistit stabilní financování veřejnoprávních médií, která jsou v naší společnosti důležitým článkem objektivního zpravodajství. Zároveň je nutné zajistit, aby jejich hospodaření podléhalo náležité veřejné kontrole. "
     },
     {
       "id": "senatni-2022-1-a-107987-15",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no",
       "comment": "Problémem není pracovní agentura jako taková, ale nelegální agentury, které nedodržují pravidla.  "
     },
     {
       "id": "senatni-2022-1-a-107987-16",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes",
       "comment": "Rovné manželství pomůže tisícům párů a jejich dětem, neohrozí nikoho. Současný stav, kdy mezi registrovaným manželstvím a partnerstvím existuje řada rozdílů, je nespravedlivý. V sekulárním státě, kde všichni platí daně a mají stejné povinnosti, mají mít i rovná práva."
     },
     {
       "id": "senatni-2022-1-a-107987-17",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes",
       "comment": "Zavedením místní příslušnosti se zvýší dohled krajského soudu nad jednotlivými exekutory a tím se zajistí co největší přezkoumatelnost činnosti exekutorů, zvýší se efektivita vymáhání dluhů a zajistí se sjednocený přístup exekutorů v celé ČR."
     },
     {
       "id": "senatni-2022-1-a-107987-18",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes",
       "comment": "Mělo by docházet ke slučování dluhů všech exekucí dlužníka pod jednoho exekutora. "
     },
     {
       "id": "senatni-2022-1-a-107987-19",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "Sociální bydlení by mělo být navázáno potřebu v konkrétní lokalitě a rozhodovat o něm by si měly municipality. Důležité je mít dostatek bytů, kterými budou obce disponovat. Množství sociálního bydlení pak již závisí na místní situaci. "
     },
     {
       "id": "senatni-2022-1-a-107987-20",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Stát má zlepšit informovanost o možnostech podpory, snažit se dostat jasné, přehledné, srozumitelné informace k lidem. A zároveň umožnit potřebným tyto možnosti snadno využít. Ale není reálně v moci státu se aktivně starat o každého jednotlivce. "
     },
     {
       "id": "senatni-2022-1-a-107987-21",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know",
       "comment": "Podporuji myšlenku omezit centralizaci všech institucí z důvodu vyrovnávání atraktivity regionů, na druhou stranu není žádoucí, aby to vedlo ke snížení efektivity jejich fungování. Toto je ke zvážení pro konkrétní státní instituce jednotlivě."
     },
     {
       "id": "senatni-2022-1-a-107987-22",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "yes",
       "comment": "Zapojení do mezinárodních vesmírných programů včetně kolonizace Marsu je důležitým prvkem pro udržení konkurenceschopnosti průmyslu i vysoké úrovně vědeckého bádání."
     },
     {
       "id": "senatni-2022-1-a-107987-23",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Zcela zásadní je zde bezpečnost a spolehlivost technické realizace elektronických voleb."
     },
     {
       "id": "senatni-2022-1-a-107987-24",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no",
       "comment": "Zásadní je dostupnost informací o vzdělávací nabídce, perspektivě budoucího uplatnění a kariérové poradenství. Ale není zdaleka zřejmé, že nynější technické vzdělávání je přínosné pro životní dráhu současných studentů více než jiné obory."
     },
     {
       "id": "senatni-2022-1-a-107987-25",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Svobodu vzdělávání považuji za důležitou. Podporuji alternativní možnosti vzdělávání jako je individuální vzdělávání, homeschooling nebo unschooling. Podstatný je zde cíl, stanovení toho, co od základního vzdělávání očekáváme, ne tak samotná cesta."
     },
     {
       "id": "senatni-2022-1-a-107987-26",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "Samotná inkluze je přínosná, protože spojuje společnost. Nicméně nastavení u nás je vhodné přehodnotit a poskytnout školám náležitou podporu, aby inkluzí nedocházelo ke snížení hodnoty vzdělávání."
     },
     {
       "id": "senatni-2022-1-a-107987-27",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no",
       "comment": "EU je pro nás jednoznačně přínosná, jak politicky, tak ekonomicky. Má smysl přemýšlet o zlepšení jejího fungování, ale ne o vystoupení."
     },
     {
       "id": "senatni-2022-1-a-107987-28",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "Z dlouhodobého hlediska je společná měna jednoznačně přínosná jak hospodářsky tak psychologicky."
     },
     {
       "id": "senatni-2022-1-a-107987-29",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no",
       "comment": "NATO je zásadním posílením naší vojenské bezpečnosti. Toto nejsme schopni odpovídajícím způsobem nahradit."
     },
     {
       "id": "senatni-2022-1-a-107987-30",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes",
       "comment": "ČR je otevřená ekonomika významně navázaná na ostatní evropské země. Užší integrace je pro nás jednoznačně přínosná."
     },
     {
       "id": "senatni-2022-1-a-107987-31",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes",
       "comment": "Podpora zahraniční rozvojové spolupráce a humanitární pomoci významně zlepšuje naše mezinárodní postavení, posiluje naši bezpečnost a zvyšuje ochotu ostatních s námi spolupracovat."
     },
     {
       "id": "senatni-2022-1-a-107987-32",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes",
       "comment": "Není úplně zřejmé, co se zde myslí, nicméně ohled na ostatní, které svým jednáním na společné planetě ovlivňujeme, je samozřejmý."
     },
     {
       "id": "senatni-2022-1-a-107987-33",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "yes",
       "comment": "Žádost o azyl musí být především zefektivněna tak, abychom byli schopni vyřídit větší množství žádostí o azyl bez vyvolání humanitární krize. Azylové řízení musí samozřejmě nadále splňovat požadavky na bezpečnostní kontrolu příchozích, stejně jako preference sjednocování rodin."
     },
     {
       "id": "senatni-2022-1-a-107987-34",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes",
       "comment": "Volný pohyb ve svobodném světě považuji dnes už za samozřejmost."
     },
     {
       "id": "senatni-2022-1-a-107987-35",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "Na vlastní bezpečnosti bychom se měli podílet poměrem odpovídajícím existujícím rizikům."
     },
     {
       "id": "senatni-2022-1-a-107987-36",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Tuto možnost nepovažuji při současné kulturní úrovni za eticky vhodnou."
     },
     {
       "id": "senatni-2022-1-a-107987-37",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes",
       "comment": "Je to rozšíření svobodného rozhodování, které jiné neomezuje."
     },
     {
       "id": "senatni-2022-1-a-107987-38",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know",
       "comment": "Záleží na míře specializace - počtu dotčených pacientů. Má smysl, aby nejvíce specializovaná péče byla plně centralizovaná. Ale běžná specializovaná péče může být dostupná v každé nemocnici."
     },
     {
       "id": "senatni-2022-1-a-107987-39",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes",
       "comment": "Ano, ale je to vytržený jeden prvek z mnoha. Dává smysl všechny prokázaně škodlivé látky postupně eliminovat. Na druhou stranu to nelze provést naráz a se všemi, protože na to naše zemědělství a průmysl nejsou připraveny."
     },
     {
       "id": "senatni-2022-1-a-107987-40",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Nejedná se o nadbytečné omezování svobody a soukromí. Je ovšem třeba vždy zvážit umístění těchto systémů - zda skutečně přispívají ke zvýšení bezpečnosti, plynulosti provozu, apod., a neslouží jen k šikaně v místech, kde daný rychlostní limit nedává smysl."
     },
     {
       "id": "senatni-2022-1-a-107987-41",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes",
       "comment": "Jedná se nyní o problematickou technologii s vysokým rizikem zneužití. Lze ho jen obtížně veřejně kontrolovat. Bezpečnostní přínosy nepovažuji za dostatečné k vyvážení těchto rizik."
     },
     {
       "id": "senatni-2022-1-a-107987-42",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes",
       "comment": "Je zcela v našem zájmu, aby Ukrajina fungovala za srovnatelných pravidel a hodnot. Ze stability Ukrajiny a užší spolupráce s ní může EU pouze těžit. "
     },
     {
       "id": "senatni-2022-1-a-107987-43",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes",
       "comment": "NATO je bezpečnostní a obranná organizace sdružující státy podobných hodnot, které chtějí společně bránit. Ukrajina sdílí naše hodnoty lidských práv a demokracie, a jako taková by měla být součástí našeho obranného uskupení."
     },
     {
       "id": "senatni-2022-1-a-107987-44",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "dont_know",
       "comment": "Nejsem si jist, jestli je toto nejlepší řešení. Může být přechodné, ale může také přinést jiné komplikace, které samotné zastropování nevyřeší. Doporučuji mít v záloze více cest a možností, mezi kterými budeme moct vybírat podle vývoje situace."
     },
     {
       "id": "senatni-2022-1-a-107987-45",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no",
       "comment": "Ombudsman má chránit práva lidí bez rozdílů, což bohužel dlouhodobě nečiní. Naopak opakovaně šíří předsudky a xenofobii ve společnosti. Stanislav Křeček není schopný vykonávat úřad ombudsmana v souladu se svým slibem, tedy nezávisle a nestranně."
     },
     {
       "id": "senatni-2022-1-a-107987-46",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes",
       "comment": "Jedná se jednoznačně o porušení mezinárodního práva a je v našem zájmu požadovat jeho dodržování."
     },
     {
       "id": "senatni-2022-1-a-107987-47",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no",
       "comment": "Ruská administrativa na okupovaném Krymu není řádným partnerem pro českou stranu."
     },
     {
       "id": "senatni-2022-1-a-107987-48",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Istanbulská úmluva od států vyžaduje lepší ochranu obětí a efektivní stíhání pachatelů. Přijetí úmluvy je symbolem a zároveň závazkem potírat tyto formy násilí."
     },
     {
       "id": "senatni-2022-1-a-107987-49",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "dont_know",
       "comment": "Bylo by to velmi vhodné, nejsem si však jist, zda je to opravdu reálné. Budu podporovat kroky, které ke dřívějšímu ukončení spalování uhlí povedou, ale nikoliv za každou cenu."
     },
     {
       "id": "senatni-2022-1-a-107987-50",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes",
       "comment": "Zásadní snižování emisí skleníkových plynů je nutné a musíme se o něj snažit na všech úrovních. Z dlouhodobého hlediska pouze klimatická neutralita je udržitelná."
     },
     {
       "id": "senatni-2022-1-a-107987-51",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no",
       "comment": "ČR nesmí schvalovat porušování mezinárodních pravidel."
     },
     {
       "id": "senatni-2022-1-a-107987-52",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no",
       "comment": "ČR by tím svoji pozici oslabila a zásadně podlomila mezinárodní důvěryhodnost."
     },
     {
       "id": "senatni-2022-1-a-107987-53",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes",
       "comment": "NATO je bezpečnostní a obranná organizace sdružující státy podobných hodnot, které chtějí společně bránit. Finsko a Švédsko sdílí naše hodnoty lidských práv a demokracie, a jako takové by měly být součástí našeho obranného uskupení."
     },
     {
       "id": "senatni-2022-1-a-107987-54",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes",
       "comment": "Smyslem dotací je napravovat selhání trhu. Podpora malých farem je jednou z obran proti selhání trhu. "
     },
     {
       "id": "senatni-2022-1-a-107987-55",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know",
       "comment": "Nejsem si jist, nakolik je toto tak závažný problém, aby ho bylo nutno řešit zákonem."
     },
     {
       "id": "senatni-2022-1-a-107987-56",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no",
       "comment": "Obce a města mají lepší znalost potřeb bydlení pro své občany a měly by si svou bytovou politiku určovat samy. Stát může zajistit legislativní rámec, metodickou podporu a pomoct efektivnímu fungování trhu."
     },
     {
       "id": "senatni-2022-1-a-107987-57",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no",
       "comment": "Jednoznačně podporuji respektování mezinárodních dohod a pravidel, nikoliv zákon džungle a právo každého dobýt si vojensky, na co stačí."
     },
     {
       "id": "senatni-2022-1-a-107987-58",
       "candidate_id": "senatni-2022-1-c-107987",
-      "question_id": "senatni-2022-1-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Nedává smysl pokračovat v bezvýsledné činnosti, je to zátěž pro obě strany."
     },
     {
       "id": "senatni-2022-1-a-174710-1",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-2",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-3",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-4",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-5",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-6",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-7",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-8",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-9",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-174710-10",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-11",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-12",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-13",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-14",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-15",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-174710-16",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-17",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-18",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-19",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-20",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-21",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-22",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-174710-23",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-24",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-25",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-26",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-27",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-28",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-29",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-30",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-31",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-174710-32",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-174710-33",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-34",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-35",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-174710-36",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-174710-37",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-38",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-174710-39",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-174710-40",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-41",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-174710-42",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-174710-43",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-174710-44",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-45",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-46",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-174710-47",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-48",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-49",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-50",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-174710-51",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-52",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-53",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-54",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-55",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-174710-56",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-174710-57",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-174710-58",
       "candidate_id": "senatni-2022-1-c-174710",
-      "question_id": "senatni-2022-1-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-128673-1",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "dont_know",
       "comment": "Jak zjistíte, že je byt dlouhodobě prázdný. Co to je dlouhodobě?"
     },
     {
       "id": "senatni-2022-1-a-128673-2",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Dle současných zákonů je soukromé vlastnictví nedotknutelné. Byty vlastní i města, obce."
     },
     {
       "id": "senatni-2022-1-a-128673-3",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Petici by mělo pro celostátní referendum podepsat větší množství občanů."
     },
     {
       "id": "senatni-2022-1-a-128673-4",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-128673-5",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Fyzicky náročná zaměstnání i tak někdy nad 65 let těžko zvládají. Řešila bych spíše délku zaměstnání a tím odvodů do sociálního pojištění."
     },
     {
       "id": "senatni-2022-1-a-128673-6",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "Zadržování vody na našem území je velmi důležité. Mělo by se tak ale dít pomocí menších nádrží, například rybníků a podobně."
     },
     {
       "id": "senatni-2022-1-a-128673-7",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes",
       "comment": "Jinde to funguje, je třeba to nastavit."
     },
     {
       "id": "senatni-2022-1-a-128673-8",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Zásadní je ta hranice výše příjmu. Někteří lidé pracují na více místech a díky tomu mají vyšší příjem. Nebylo by spravedlivé je za to trestat. "
     },
     {
       "id": "senatni-2022-1-a-128673-9",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "kdo to bude kontrolovat, že je to jen pro vlastní potřebu? "
     },
     {
       "id": "senatni-2022-1-a-128673-10",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "dont_know",
       "comment": "Pokud tyto tresty zvýšíme, pak se musí zvýšit i tresty za jiné závažné činy , jinak by vznikl nepoměr."
     },
     {
       "id": "senatni-2022-1-a-128673-11",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Daň by měla být sjednocena ve všech státech, kde působí."
     },
     {
       "id": "senatni-2022-1-a-128673-12",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "dont_know",
       "comment": "Bojím se přílišné cenzury, pokud za to budou zodpovědní. "
     },
     {
       "id": "senatni-2022-1-a-128673-13",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "dont_know",
       "comment": "To, že je někdo upozorněn na \"fake news\" ještě neznamená, že je to \"fake news\". Mělo by to být ověřeno alespoň dvěma nezávislými zdroji. I tak je to problematické, nemám ráda příliš omezení. Lidé mají mít na výběr."
     },
     {
       "id": "senatni-2022-1-a-128673-14",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "dont_know",
       "comment": "Nejdřív je ale důležité definovat, co je veřejnoprávní a dodržovat tato pravidla. Radši bych umožnila reklamu i zde, ať mají všechna média stejné konkurenční podmínky. Peníze od občanů by měly jít pouze na jasně definované vysílání. Diskusní pořady,  komentáře a podobně, které vyjadřují politické názory jsou bohužel značně ovlivnitelné. Rada ČT by měla být apolitická. Je to na delší diskusi."
     },
     {
       "id": "senatni-2022-1-a-128673-15",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no",
       "comment": "Spíše by měla být důsledně kontrolována a sankcionována."
     },
     {
       "id": "senatni-2022-1-a-128673-16",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes",
       "comment": "Nikomu to neublíží a jim to pomůže"
     },
     {
       "id": "senatni-2022-1-a-128673-17",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "no",
       "comment": "klient má mít právo si vybrat "
     },
     {
       "id": "senatni-2022-1-a-128673-18",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "no",
       "comment": "Souvisí s předešlou otázkou. Když má někdo více exekucí, kdo bude tím exekutorem? "
     },
     {
       "id": "senatni-2022-1-a-128673-19",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Pokud to opravdu  budou byty pro veřejnost."
     },
     {
       "id": "senatni-2022-1-a-128673-20",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Pravidla nároků mají být jasná a jednoduchá, aby jim rozuměl každý a pak si každý má sám zvolit, zda o sociální dávky požádá."
     },
     {
       "id": "senatni-2022-1-a-128673-21",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no",
       "comment": "Většina státních institucí je zajištěna rovnoměrně/krajské, obecní atd jsou v místě/Ty velké, celostátní potřebují přece jen spolupráci. Pokud bude státní správa plně digitalizována, pak je to možné. "
     },
     {
       "id": "senatni-2022-1-a-128673-22",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-128673-23",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Zatím je zneužitelnost extrémní. Jít k volbám by měla být pro každého důležitým úkonem a ne jen kliknutím na dotazník."
     },
     {
       "id": "senatni-2022-1-a-128673-24",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no",
       "comment": "Všechny obory si jsou rovné. Podporu potřebují všechny. Při nedostatku některých profesí by se měl stát zaměřit na spolupráci s podniky."
     },
     {
       "id": "senatni-2022-1-a-128673-25",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Jsem pro zvýšenou podporu nadaných dětí .Učitelé by měli aktivně pomáhat nadaným dětem a nabízet jim další možnosti navíc. "
     },
     {
       "id": "senatni-2022-1-a-128673-26",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "Jsem pro pomoc slabším žákům, ale individuálně, nepodřizovat jejich podporu omezením ostatních."
     },
     {
       "id": "senatni-2022-1-a-128673-27",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-128673-28",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "Zatím ne"
     },
     {
       "id": "senatni-2022-1-a-128673-29",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-128673-30",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "dont_know",
       "comment": "Co to znamená být v jádru EU?"
     },
     {
       "id": "senatni-2022-1-a-128673-31",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "myslím, že v současné době je podpora na tak malou zemi, jako ČR dostatečná"
     },
     {
       "id": "senatni-2022-1-a-128673-32",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know",
       "comment": "Záleží na druhu zákonu."
     },
     {
       "id": "senatni-2022-1-a-128673-33",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "současné zákony jsou dostačující, je třeba je důsledně dodržovat"
     },
     {
       "id": "senatni-2022-1-a-128673-34",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-1-a-128673-35",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no",
       "comment": "Současné financování je dostatečné. Peníze je potřeba správně zacílit."
     },
     {
       "id": "senatni-2022-1-a-128673-36",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Je to nebezpečné. Procentuální zastoupení pohlaví v přírodě je cca 50/50.Tím je zajištěna reprodukce."
     },
     {
       "id": "senatni-2022-1-a-128673-37",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes",
       "comment": "Částečně to již funguje."
     },
     {
       "id": "senatni-2022-1-a-128673-38",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes",
       "comment": "Je nákladná a odborníků není mnoho. Měla by se zajistit její dostupnost."
     },
     {
       "id": "senatni-2022-1-a-128673-39",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes",
       "comment": "Starý je zakázán, vyrábí se nový, již ekologický."
     },
     {
       "id": "senatni-2022-1-a-128673-40",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-128673-41",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no",
       "comment": "Veřejná prostranství by měla být pod kontrolou kvůli bezpečnosti. kdo nechce být viděn si stejně cestu najde, jak to obejít. Usnadní to práci bezpečnostním složkám, ale nesmí se to zneužívat."
     },
     {
       "id": "senatni-2022-1-a-128673-42",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know",
       "comment": "Myslím, že by měla projít standartním procesem přístupových pravidel. Zatím na to vůbec nemá."
     },
     {
       "id": "senatni-2022-1-a-128673-43",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-128673-44",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "dont_know",
       "comment": "Nejsem ekonom, ale principiálně když stropovat, tak všechen plyn, nejen ruský."
     },
     {
       "id": "senatni-2022-1-a-128673-45",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-128673-46",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "dont_know",
       "comment": "Válka je špatně všude. Následky již nyní nesou všichni."
     },
     {
       "id": "senatni-2022-1-a-128673-47",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "dont_know",
       "comment": "Proč by to dělali? "
     },
     {
       "id": "senatni-2022-1-a-128673-48",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know",
       "comment": "Ještě jsem se s ní v plném znění neseznámila."
     },
     {
       "id": "senatni-2022-1-a-128673-49",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Uhlí v minulém století zachránilo vykácení lesů v Evropě, protože se topilo dřevem. Bojím se, že pokud se nenajdou jiné zdroje, můžeme se toho dočkat nyní. Uhlí je třeba omezovat postupně, dobře ošetřit jeho spalování."
     },
     {
       "id": "senatni-2022-1-a-128673-50",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes",
       "comment": "Ale nevěřím, že to zvládneme."
     },
     {
       "id": "senatni-2022-1-a-128673-51",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "dont_know",
       "comment": "Nechala bych to na rozhodnutí většinové společnosti, která tam žije."
     },
     {
       "id": "senatni-2022-1-a-128673-52",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "dont_know",
       "comment": "Nemáme přímé napojení na ruské plynovody, vždy se budeme muset s někým domluvit."
     },
     {
       "id": "senatni-2022-1-a-128673-53",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes",
       "comment": "Už se tak dávno chovají, je to jen potvrzení status quo."
     },
     {
       "id": "senatni-2022-1-a-128673-54",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "Spravedlivě všem. velké farmy zajišťují produkty, které malé nejsou schopny zajistit. Pak by nám chyběly."
     },
     {
       "id": "senatni-2022-1-a-128673-55",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-128673-56",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-1-a-128673-57",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-1-a-128673-58",
       "candidate_id": "senatni-2022-1-c-128673",
-      "question_id": "senatni-2022-1-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Musí se ale přesně definovat, co je dlouhodobě bezvýsledné a mít s tím souhlas, toho komu dluží. "
     }

--- a/data/kalkulacka/senatni-2022/10.json
+++ b/data/kalkulacka/senatni-2022/10.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-10-c-908666",
       "name": "Robert Huneš",
       "type": "person",
-      "description": "Robert Huneš - DESCRIPTION",
+      "description": "Robert Huneš",
       "contacts": {
         "web": [
           {
@@ -504,7 +504,7 @@
         {
           "id": "senatni-2022-10-c-908666-p",
           "name": "Robert Huneš",
-          "description": "Robert Huneš - DESCRIPTION",
+          "description": "Robert Huneš",
           "contacts": {
             "web": [
               {
@@ -530,7 +530,7 @@
       "id": "senatni-2022-10-c-593117",
       "name": "Tomáš Jirsa",
       "type": "person",
-      "description": "Tomáš Jirsa - DESCRIPTION",
+      "description": "Tomáš Jirsa",
       "contacts": {
         "web": [
           {
@@ -550,7 +550,7 @@
         {
           "id": "senatni-2022-10-c-593117-p",
           "name": "Tomáš Jirsa",
-          "description": "Tomáš Jirsa - DESCRIPTION",
+          "description": "Tomáš Jirsa",
           "contacts": {
             "web": [
               {
@@ -574,7 +574,7 @@
       "id": "senatni-2022-10-c-974997",
       "name": "Dalibor Uhlíř",
       "type": "person",
-      "description": "Dalibor Uhlíř - DESCRIPTION",
+      "description": "Dalibor Uhlíř",
       "contacts": {
         "web": [
           {
@@ -593,7 +593,7 @@
         {
           "id": "senatni-2022-10-c-974997-p",
           "name": "Dalibor Uhlíř",
-          "description": "Dalibor Uhlíř - DESCRIPTION",
+          "description": "Dalibor Uhlíř",
           "contacts": {
             "web": [
               {
@@ -616,7 +616,7 @@
       "id": "senatni-2022-10-c-488789",
       "name": "Miroslav Lorenc",
       "type": "person",
-      "description": "Miroslav Lorenc - DESCRIPTION",
+      "description": "Miroslav Lorenc",
       "contacts": {
         "web": []
       },
@@ -624,7 +624,7 @@
         {
           "id": "senatni-2022-10-c-488789-p",
           "name": "Miroslav Lorenc",
-          "description": "Miroslav Lorenc - DESCRIPTION",
+          "description": "Miroslav Lorenc",
           "contacts": {
             "web": []
           },
@@ -636,7 +636,7 @@
       "id": "senatni-2022-10-c-310539",
       "name": "Václav Mikeš",
       "type": "person",
-      "description": "Václav Mikeš - DESCRIPTION",
+      "description": "Václav Mikeš",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/vaclav.mikes.33"
@@ -645,7 +645,7 @@
         {
           "id": "senatni-2022-10-c-310539-p",
           "name": "Václav Mikeš",
-          "description": "Václav Mikeš - DESCRIPTION",
+          "description": "Václav Mikeš",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/vaclav.mikes.33"
@@ -659,365 +659,365 @@
     {
       "id": "senatni-2022-10-a-974997-1",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-2",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Mělo by se více stavět družstevních a obecních bytů."
     },
     {
       "id": "senatni-2022-10-a-974997-3",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Ale s jasnými pravidly a ne ke každé hlouposti."
     },
     {
       "id": "senatni-2022-10-a-974997-4",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Potřebujeme jak dálniční síť, tak železniční. Obě mají nezastupitelný význam."
     },
     {
       "id": "senatni-2022-10-a-974997-5",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-6",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know",
       "comment": "Otázka pro odborníky na zadržování vody v krajině, ne pro politiky."
     },
     {
       "id": "senatni-2022-10-a-974997-7",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-10-a-974997-8",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-9",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Pro řadu vážně nemocných občanů to může být jediný lék, prostředek zmírnění utrpení."
     },
     {
       "id": "senatni-2022-10-a-974997-10",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "dont_know",
       "comment": "Otázka spíše pro odborníky, ne pro politiky."
     },
     {
       "id": "senatni-2022-10-a-974997-11",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-10-a-974997-12",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-13",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "Jen pokud se jedná o trestný čin nebo šíření poplašné zprávy. Může být jinak lehce zneužitelné pro cenzuru."
     },
     {
       "id": "senatni-2022-10-a-974997-14",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes",
       "comment": "A lépe kontrolovat a komerční obsah přenechat komerčním médiím."
     },
     {
       "id": "senatni-2022-10-a-974997-15",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-16",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-17",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-10-a-974997-18",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-10-a-974997-19",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-20",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-21",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-10-a-974997-22",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-23",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-24",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-10-a-974997-25",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-26",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-27",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "dont_know",
       "comment": "Jsem pro zásadní transformaci nebo jiný model spolupráce, než nabízí současná EU."
     },
     {
       "id": "senatni-2022-10-a-974997-28",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-29",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-30",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-31",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-32",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-33",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-34",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-10-a-974997-35",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-10-a-974997-36",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-37",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-10-a-974997-38",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-39",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-40",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-41",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-10-a-974997-42",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no",
       "comment": "Nesplňuje většinu řádných požadavků. Všem by mělo být měřeno stejným metrem."
     },
     {
       "id": "senatni-2022-10-a-974997-43",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-44",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "Vážně tím riskujeme, že pak nebude proudit plyn žádný."
     },
     {
       "id": "senatni-2022-10-a-974997-45",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-10-a-974997-46",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "dont_know",
       "comment": "Otázka na Mezinárodní tribunál a především světové mocnosti. Každá genocida, každá agrese by měla být potrestána bez rozdílu."
     },
     {
       "id": "senatni-2022-10-a-974997-47",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-48",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Samozřejmě ano, stejně tak vůči mužům. Domácí násilí nemá být vůči nikomu. Záleží na konkrétní formulaci."
     },
     {
       "id": "senatni-2022-10-a-974997-49",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-50",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-51",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no",
       "comment": "Upřednostňuji širší mezinárodní shodu, ne ad hoc rozhodnutí jednotlivých států."
     },
     {
       "id": "senatni-2022-10-a-974997-52",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Bez prostředníků a obchodníků, kteří na tom vydělávají obrovské marže, které zaplatí naši spotřebitelé."
     },
     {
       "id": "senatni-2022-10-a-974997-53",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-10-a-974997-54",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-55",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-56",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-10-a-974997-57",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no",
       "comment": "Musí dojít k jednáním a široké shodě mezinárodního společenství."
     },
     {
       "id": "senatni-2022-10-a-974997-58",
       "candidate_id": "senatni-2022-10-c-974997",
-      "question_id": "senatni-2022-10-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     }
   ]

--- a/data/kalkulacka/senatni-2022/13.json
+++ b/data/kalkulacka/senatni-2022/13.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-13-c-440713",
       "name": "Marek Slabý",
       "type": "person",
-      "description": "Marek Slabý - DESCRIPTION",
+      "description": "Marek Slabý",
       "contacts": {
         "web": [
           {
@@ -497,7 +497,7 @@
         {
           "id": "senatni-2022-13-c-440713-p",
           "name": "Marek Slabý",
-          "description": "Marek Slabý - DESCRIPTION",
+          "description": "Marek Slabý",
           "contacts": {
             "web": [
               {
@@ -516,7 +516,7 @@
       "id": "senatni-2022-13-c-203124",
       "name": "Martin Kákona",
       "type": "person",
-      "description": "Martin Kákona - DESCRIPTION",
+      "description": "Martin Kákona",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/martinkakona",
@@ -526,7 +526,7 @@
         {
           "id": "senatni-2022-13-c-203124-p",
           "name": "Martin Kákona",
-          "description": "Martin Kákona - DESCRIPTION",
+          "description": "Martin Kákona",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/martinkakona",
@@ -540,7 +540,7 @@
       "id": "senatni-2022-13-c-941147",
       "name": "Jaroslav Větrovský",
       "type": "person",
-      "description": "Jaroslav Větrovský - DESCRIPTION",
+      "description": "Jaroslav Větrovský",
       "contacts": {
         "web": [
           {
@@ -553,7 +553,7 @@
         {
           "id": "senatni-2022-13-c-941147-p",
           "name": "Jaroslav Větrovský",
-          "description": "Jaroslav Větrovský - DESCRIPTION",
+          "description": "Jaroslav Větrovský",
           "contacts": {
             "web": [
               {
@@ -570,7 +570,7 @@
       "id": "senatni-2022-13-c-420091",
       "name": "Jiří Machač",
       "type": "person",
-      "description": "Jiří Machač - DESCRIPTION",
+      "description": "Jiří Machač",
       "contacts": {
         "web": [
           {
@@ -590,7 +590,7 @@
         {
           "id": "senatni-2022-13-c-420091-p",
           "name": "Jiří Machač",
-          "description": "Jiří Machač - DESCRIPTION",
+          "description": "Jiří Machač",
           "contacts": {
             "web": [
               {
@@ -614,7 +614,7 @@
       "id": "senatni-2022-13-c-940838",
       "name": "Martin Kupec",
       "type": "person",
-      "description": "Martin Kupec - DESCRIPTION",
+      "description": "Martin Kupec",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/profile.php?id=100010001926506"
@@ -623,7 +623,7 @@
         {
           "id": "senatni-2022-13-c-940838-p",
           "name": "Martin Kupec",
-          "description": "Martin Kupec - DESCRIPTION",
+          "description": "Martin Kupec",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/profile.php?id=100010001926506"
@@ -636,7 +636,7 @@
       "id": "senatni-2022-13-c-338969",
       "name": "Jiří Šimánek",
       "type": "person",
-      "description": "Jiří Šimánek - DESCRIPTION",
+      "description": "Jiří Šimánek",
       "contacts": {
         "web": []
       },
@@ -644,7 +644,7 @@
         {
           "id": "senatni-2022-13-c-338969-p",
           "name": "Jiří Šimánek",
-          "description": "Jiří Šimánek - DESCRIPTION",
+          "description": "Jiří Šimánek",
           "contacts": {
             "web": []
           },
@@ -656,7 +656,7 @@
       "id": "senatni-2022-13-c-459651",
       "name": "Evžen Zadražil",
       "type": "person",
-      "description": "Evžen Zadražil - DESCRIPTION",
+      "description": "Evžen Zadražil",
       "contacts": {
         "web": [
           {
@@ -670,7 +670,7 @@
         {
           "id": "senatni-2022-13-c-459651-p",
           "name": "Evžen Zadražil",
-          "description": "Evžen Zadražil - DESCRIPTION",
+          "description": "Evžen Zadražil",
           "contacts": {
             "web": [
               {
@@ -688,7 +688,7 @@
       "id": "senatni-2022-13-c-267821",
       "name": "Olga Bastlová",
       "type": "person",
-      "description": "Olga Bastlová - DESCRIPTION",
+      "description": "Olga Bastlová",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/olga.bastlova"
@@ -697,7 +697,7 @@
         {
           "id": "senatni-2022-13-c-267821-p",
           "name": "Olga Bastlová",
-          "description": "Olga Bastlová - DESCRIPTION",
+          "description": "Olga Bastlová",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/olga.bastlova"
@@ -710,7 +710,7 @@
       "id": "senatni-2022-13-c-545048",
       "name": "Miloš Zábranský",
       "type": "person",
-      "description": "Miloš Zábranský - DESCRIPTION",
+      "description": "Miloš Zábranský",
       "contacts": {
         "web": []
       },
@@ -718,7 +718,7 @@
         {
           "id": "senatni-2022-13-c-545048-p",
           "name": "Miloš Zábranský",
-          "description": "Miloš Zábranský - DESCRIPTION",
+          "description": "Miloš Zábranský",
           "contacts": {
             "web": []
           },
@@ -731,1483 +731,1835 @@
     {
       "id": "senatni-2022-13-a-941147-1",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-2",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-3",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-4",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-5",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-6",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-7",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-8",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-9",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-941147-10",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-11",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-941147-12",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-13",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-941147-14",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-15",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-16",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-941147-17",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-18",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-19",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-20",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-21",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-22",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-941147-23",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-24",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-25",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-26",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-27",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-28",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "Ano, ale ne v současné době"
     },
     {
       "id": "senatni-2022-13-a-941147-29",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-30",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-31",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-941147-32",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-941147-33",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-34",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-35",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-36",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-941147-37",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-38",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-39",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-941147-40",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-941147-41",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-42",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-43",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-44",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-45",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-46",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-47",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-48",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-49",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-50",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know",
       "comment": "v současné době v podstatě nelze objektivně odpovědět, v době růstu cen energií"
     },
     {
       "id": "senatni-2022-13-a-941147-51",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-52",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-941147-53",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-941147-54",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "zemědělské dotace by měly být pro všechny zemědělce, kteří produkují "
     },
     {
       "id": "senatni-2022-13-a-941147-55",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-56",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-57",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-941147-58",
       "candidate_id": "senatni-2022-13-c-941147",
-      "question_id": "senatni-2022-13-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-459651-1",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-459651-2",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-459651-3",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-459651-4",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "V  našich podmínkách bychom se spíše než na rychlovlaky měli zaměřit na celkovou modernizaci dráhy ale především dostavění rozdělaných silničních spojení, která už měla být dávno postavená."
     },
     {
       "id": "senatni-2022-13-a-459651-5",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-459651-6",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-459651-7",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-459651-8",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Lidé s vyššími příjmy by za ně neměli být trestáni."
     },
     {
       "id": "senatni-2022-13-a-459651-9",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Jsem pro dekriminalizaci konopí"
     },
     {
       "id": "senatni-2022-13-a-459651-10",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Je k smíchu, že je v naší zemi možné, aby za čin tzv. bez oběti, jako je pěstování návykových látek byla stanovena vyšší trestní sazba, než za tak ohavný čin, jakým je znásilnění."
     },
     {
       "id": "senatni-2022-13-a-459651-11",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-459651-12",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Za obsah na sítích, které umožňují uživatelům prezentaci jejich názorů, mají být odpovědní hlavně uživatelé. "
     },
     {
       "id": "senatni-2022-13-a-459651-13",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "Je na dané síti, jaký obsah pustí do světa. Ideální je taková, která necenzuruje nic a nechá uživatele samotného si rozhodnout, co je a co není pravda. Trestat se mají pouze viditelné nenávistné projevy či podněcování k tresným činům. I to může být ale ošemetné. "
     },
     {
       "id": "senatni-2022-13-a-459651-14",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes",
       "comment": "Ano. Zrušme koncesionářské poplatky."
     },
     {
       "id": "senatni-2022-13-a-459651-15",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-459651-16",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-459651-17",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-459651-18",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-459651-19",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "Soukromá určitě ne. Je na soukromém vlastníkovi, jak si své byty zařídí. "
     },
     {
       "id": "senatni-2022-13-a-459651-20",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Je na lidech v nouzi, aby měli sami potřebu tuto nouzi řešit. Náš sociální systém jim pomoc umožňuje. "
     },
     {
       "id": "senatni-2022-13-a-459651-21",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know",
       "comment": "Státní instituce by se měly hlavně decentralizovat. Jejich rozmístění pak nebude takový problém. "
     },
     {
       "id": "senatni-2022-13-a-459651-22",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no",
       "comment": "ČR má teď mnohem větší věci na práci, než řešit kolonizaci Marsu. "
     },
     {
       "id": "senatni-2022-13-a-459651-23",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Náš volební zákon a systém, jakým se k volbám chodí, je v pořádku. Elektronizací se otevírají dvěře pro potenciální volební machinace. "
     },
     {
       "id": "senatni-2022-13-a-459651-24",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no",
       "comment": "Technické vzdělávání je potřeba vylepšit hlavně na úrovni učňovského školství. Vysoké a střední školství by mělo být podporováno rovnoměrně a hlavně kvalitě. "
     },
     {
       "id": "senatni-2022-13-a-459651-25",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Děti se speciálním nadáním by měly mít co největší možnost rozvíjet svůj potenciál a růst. Netřeba je inkluzí zbytečně držet zkrátka. "
     },
     {
       "id": "senatni-2022-13-a-459651-26",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no",
       "comment": "ne, viz předchozí odpověď. "
     },
     {
       "id": "senatni-2022-13-a-459651-27",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "yes",
       "comment": "V tuto dobu a za současné krize se jedná zřejmě o zbožné přání, ale přál bych si a zasadil se o srovnání právního rámce tak, abychom vrátily stav věcí před přijetí Lisabonské smlouvy, která umocnila demokratický deficit celé EU. Protože si ale myslím, že to v dnešní byrokratické Unii již není reálné, byl bych pro vystoupení, nebo pro vyškrtnutí článku 10a z naší Ústavy, a vrátil tak českému právu jeho sílu. "
     },
     {
       "id": "senatni-2022-13-a-459651-28",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "Přijetí eura bych nepodpořil. V tuto dobu máme stav, kdy je možné platit eurem, tak korunou, a o své měně si rozhodujeme sami. Proč se tedy zbavovat suverenity v této oblasti a zbytečně odevzdávat další kompetence do Bruselu. Česká koruna k nám patří a měly bychom si ji zachovat."
     },
     {
       "id": "senatni-2022-13-a-459651-29",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no",
       "comment": "Přestože má NATO spoustu chyb a naprosto se mi nelíbí, co předvádělo v 90. letech na Balkáně, naše armáda není ve stavu, aby např. jako Rakousko mohlo mít samostatnou sílu. Je třeba upozorňovat na chyby NATO a snažit se o jeho zlepšení, v případě, že bude existovat lepší alternativa, jsem pro vystoupení. "
     },
     {
       "id": "senatni-2022-13-a-459651-30",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no",
       "comment": "Místo ČR je tady u nás a případně u stolu s ostatními státy, které chtějí mezinárodně a diplomaticky jednat, a to rovnocenně. "
     },
     {
       "id": "senatni-2022-13-a-459651-31",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-459651-32",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-459651-33",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-459651-34",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-459651-35",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no",
       "comment": "Ne, rozhodně ne v tuto chvíli. Je třeba méně peněz lidem brát a ty co jsou již vybrány, investovat na důležitější věci, než je armáda. "
     },
     {
       "id": "senatni-2022-13-a-459651-36",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-459651-37",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-459651-38",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no",
       "comment": "Není-li to nutné, např. z finančních či dalších důvodů, není asi k centralizaci důvod."
     },
     {
       "id": "senatni-2022-13-a-459651-39",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-459651-40",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Ne. Jsem však pro zahájení úvahy nad úpravou dovolených rychlostí mimo obce a na dálnicích. "
     },
     {
       "id": "senatni-2022-13-a-459651-41",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes",
       "comment": "Ano. Nechtějme se dostat do podobného systému, jaký je nastolen v Číně.."
     },
     {
       "id": "senatni-2022-13-a-459651-42",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no",
       "comment": "Ukrajina naprosto není v kondici, aby mohla být přijata do EU. Je to stát s jednou z nejvyšších korupcí na světě a slabou ekonomikou. Pokud podmínky nesplňuje, což nesplňuje, nemůže být přijatata pouze z solidárních důvodů. "
     },
     {
       "id": "senatni-2022-13-a-459651-43",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-459651-44",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "Problém se zastropováním cen je ten, že v momentě, kdy k němu dojde, nenastane kýžený efekt - místo toho, aby byl plyn levnějším, stane se nedostupnějším. V historii již došlo k zastropování cen na jiné zboží, stačí se ale podívat, co to ve finále způsobilo. Místo zlevnění nastal nedostatek.  "
     },
     {
       "id": "senatni-2022-13-a-459651-45",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-459651-46",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-459651-47",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-459651-48",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "no",
       "comment": "Směrnice EU nemají nahrazovat národní zákony, přestože souhlasím s tím, aby se s situací ohledně domácího násilí něco dělalo. Pojďme to však vyřešit na tuzemské úrovni. "
     },
     {
       "id": "senatni-2022-13-a-459651-49",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "V momentě, kdy zuří energetická krize, je stanovování cílů, kdy ani nevíme, jestli budeme v daném roce mít dostatek ostatních zdrojů, naprostá utopie. Cíle musíme stanovovat s vědeckým poznáním, a ne politicky podle toho, jak se nám to zrovna líbí. "
     },
     {
       "id": "senatni-2022-13-a-459651-50",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "EU se musí vymanit ze svého iluzorního stavu, kdy největšími znečišťovately jsou rozvojové státy, Čína a USA. Pokud chce EU něco dělat s tímto stavem, měla by se zaměřit tímto směrem na tyto státy, a ne otravovat svoje občany nesmyslným green dealem a dalšími hloupostmi. "
     },
     {
       "id": "senatni-2022-13-a-459651-51",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-459651-52",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-459651-53",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes",
       "comment": "Finsko a Švédsko splnily vstupní podmínky, takže proč ne. "
     },
     {
       "id": "senatni-2022-13-a-459651-54",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "Zemědělské dotace by se měly hlavně zrušit, neboť už naše zemědělství poničily více než dost. Malé firmy mají být podporovány z pozice regionu, usnadnění prodeje ze dvora a marketingově. Dotace by také měly být směřovány, když už je tedy máme, na efektivní hospodaření a ne na plochu. "
     },
     {
       "id": "senatni-2022-13-a-459651-55",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-459651-56",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no",
       "comment": "Ne, neboť stát je zpravidla špatný hospodář a nedovedu si moc představit, že by je spravoval bez korupce či přebytečného vyhazování peněz. "
     },
     {
       "id": "senatni-2022-13-a-459651-57",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-459651-58",
       "candidate_id": "senatni-2022-13-c-459651",
-      "question_id": "senatni-2022-13-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Ano, avšak s přihlédnutím k osobě dlužníka."
     },
     {
       "id": "senatni-2022-13-a-338969-1",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "dont_know",
       "comment": "Při zdanění by se mělo jednat o skutečně dlouhodobé prázdné byty. Pokud si drží prázdný byt rodiče pro svoje děti, není důvod ho více zdaňovat. Pokud se jedná o \"kšeftování\" s byty a vydělávání na jejich nedostatku, tak by mělo větší zdanění nastoupit.   \n"
     },
     {
       "id": "senatni-2022-13-a-338969-2",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes",
       "comment": "Ano, ale jen u malých bytů. U velkých bytů bych regulaci neřešil.  "
     },
     {
       "id": "senatni-2022-13-a-338969-3",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Mělo by se týkat skutečně závažných rozhodnutí, ne na každou maličkost a s příslušným počtem podpisů. Ne všechno lze řešit referendem, to by potom byly volené orgány zbytečné a rozhodnutí by trvalo neskutečně dlouho.   "
     },
     {
       "id": "senatni-2022-13-a-338969-4",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "To bychom spojili jenom hlavní centra a ve zbytku republiky bychom neřešili ani základní dopravní infrastrukturu.  "
     },
     {
       "id": "senatni-2022-13-a-338969-5",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "V řadě povolání je uvedená hranice únosná, v některých už je za hranicí."
     },
     {
       "id": "senatni-2022-13-a-338969-6",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes",
       "comment": "Pokud chceme řešit zvyšující se nedostatek vody, musíme ji v krajině zadržet. Snažíme se o to v malém ve městech a obcích, ale je třeba to řešit komplexně. Dostatek vody je velice důležité pro celou krajinu.  "
     },
     {
       "id": "senatni-2022-13-a-338969-7",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes",
       "comment": "Dobrovolný sběr PET lahví a nápojových plechovek dosáhl určité hranice. Pokud chceme recyklaci navýšit, tak toho dosáhneme zřejmě pouze jejich zálohováním.  "
     },
     {
       "id": "senatni-2022-13-a-338969-8",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Z vyššího příjmu se čistě matematicky odvádí v absolutní částce větší daň. "
     },
     {
       "id": "senatni-2022-13-a-338969-9",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "no",
       "comment": "Kdo určí tu správnou hranici vlastní spotřeby? Léky s přísadou konopí ke koupi potřebným, to by mělo být zcela legální.   "
     },
     {
       "id": "senatni-2022-13-a-338969-10",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Důležitost vyplývá už ze samé podstaty činu."
     },
     {
       "id": "senatni-2022-13-a-338969-11",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Odvádění zisků zahraničních firem různým způsobem do zahraniční by se mělo dostat pod řádnou kontrolu.  "
     },
     {
       "id": "senatni-2022-13-a-338969-12",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes",
       "comment": "Každý by měl být zodpovědný za své chování a podnikání. "
     },
     {
       "id": "senatni-2022-13-a-338969-13",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes",
       "comment": "Samozřejmě po prověření."
     },
     {
       "id": "senatni-2022-13-a-338969-14",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Ale veřejnoprávní vysílání by mělo být skutečně veřejnoprávní bez vnucování názoru ze strany redaktorů."
     },
     {
       "id": "senatni-2022-13-a-338969-15",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no",
       "comment": "Zaplňují trh s pracovní silou, mají svůj význam."
     },
     {
       "id": "senatni-2022-13-a-338969-16",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know",
       "comment": "Zastávám tradiční hodnoty, to znamená, že manželství je svazkem ženy a muže. Vytvořme pro svazek dvojice stejného pohlaví nový institut a nemusí to být zrovna registrované partnerství, ve kterém by měla dvojice stejná práva a povinnosti jako manželé.   "
     },
     {
       "id": "senatni-2022-13-a-338969-17",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes",
       "comment": "Znalost místního prostředí by měla být výhodou."
     },
     {
       "id": "senatni-2022-13-a-338969-18",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes",
       "comment": "Pokud je myšleno, že jednoho dlužníka bude řešit jeden exekutor, tak je to v pořádku. Na druhou stranu jeden exekutor nemůže řešit jenom jednoho dlužníka.   "
     },
     {
       "id": "senatni-2022-13-a-338969-19",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "Obecní a státní výstavba jednoznačně, ale nařizovat při soukromé výstavbě podíl sociálních bytů, to ne. Při větších developerských celcích bych spíše soukromníkům nařídil výstavbu občanské vybavenosti, která potom často chybí a financuje ji obec.   "
     },
     {
       "id": "senatni-2022-13-a-338969-20",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Pokud máme zaveden pouze trvalý pobyt v obci či ve městě a velké množství lidí bydlí zcela jinde a neexistuje povinnost přechodného pobytu, tak je vyhledávání prakticky nemožné."
     },
     {
       "id": "senatni-2022-13-a-338969-21",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "Přílišná centralizace není dobrá."
     },
     {
       "id": "senatni-2022-13-a-338969-22",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no",
       "comment": "Řešme problémy, které nás skutečně trápí. Kolonizace Marsu mezi ně určitě nepatří."
     },
     {
       "id": "senatni-2022-13-a-338969-23",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Samozřejmě s příslušným zabezpečením proti manipulaci s hlasy. Bylo by to jednodušší, levnější a rychlejší."
     },
     {
       "id": "senatni-2022-13-a-338969-24",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "Ano v určitém období. A nyní se v tomto období nacházíme. To nemusí být dogma na celou věčnost."
     },
     {
       "id": "senatni-2022-13-a-338969-25",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Není důvod potírat talenty ve třídách. Mělo by se jednat skutečně o talenty, se kterými je vhodné pracovat samostatně. Průměrnosti a nevyčnívání z davu bylo již v minulosti dost.  "
     },
     {
       "id": "senatni-2022-13-a-338969-26",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no",
       "comment": "Ten, kdo chce skutečně vidět některé výsledky inkluze v praxi, tak by se k tomuto problému stavěl jinak. Nejedná se o slabší žáky, ti přece do normální třídy patří. V řadě případů se jedná o různě postižené, nemocné děti a mělo by být na odborníkovi určit zda půjdou do normální nebo jiné třídy. Větší objem inkluze ve třídě zhoršuje vzdělávání a celková úroveň kolektivu jde potom dolů.     "
     },
     {
       "id": "senatni-2022-13-a-338969-27",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no",
       "comment": "Mohou se nám některé věci nelíbit, nemusíme s něčím souhlasit, ale je na našich zástupcích co pro Českou republiku vybojují. Celý život je jeden velký kompromis a v rámci EU se o ně musíme snažit rovněž. "
     },
     {
       "id": "senatni-2022-13-a-338969-28",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "Je třeba ovšem vybrat ten správný okamžik."
     },
     {
       "id": "senatni-2022-13-a-338969-29",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no",
       "comment": "Nejsme schopni ufinancovat odpovídající armádu. Armády členských zemí by se měly v rámci NATO více specializovat a dohromady vytvořit silnou bojeschopnou armádu, která bude bránit zájmy EU.     "
     },
     {
       "id": "senatni-2022-13-a-338969-30",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes",
       "comment": "Pokud nechceme být na okraji zájmu, na okraji rozhodování a chceme ovlivňovat další vývoj EU musíme být aktivní.     "
     },
     {
       "id": "senatni-2022-13-a-338969-31",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know",
       "comment": "Jde o to, aby rozvoj zahraniční spolupráce a humanitární pomoci byl v souladu s rozvojem České republiky. Upřednostňovat zahraniční pomoc na úkor domácích problémů lze jednorázově při výjimečných událostech. Nemohu rozdělovat více než vydělám, a to platí nejen při zahraniční pomoci.    "
     },
     {
       "id": "senatni-2022-13-a-338969-32",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no",
       "comment": "Pokud bude platit řada zákonů např. v oblasti změn klimatu jen v České republice nebo jen v Evropě, tak to rozhodně problém neřeší a navíc nás zbytek světa ekonomicky převálcuje. "
     },
     {
       "id": "senatni-2022-13-a-338969-33",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Všichni jsem viděli, co udělal příliv imigrantů bez řízeného procesu v celé řadě zemí EU."
     },
     {
       "id": "senatni-2022-13-a-338969-34",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes",
       "comment": "V rámci Schengenu ano, ale hranice Schengenu by se měly více chránit. "
     },
     {
       "id": "senatni-2022-13-a-338969-35",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "dont_know",
       "comment": "Souvisí to se specializací armád jednotlivých členských zemí NATO. Pokud by došlo ke specializaci, potom by zřejmě k navyšování nemuselo docházet. "
     },
     {
       "id": "senatni-2022-13-a-338969-36",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Zastávám tradiční hodnoty, tohle už je skutečně velký zásah do dalšího vývoje lidstva. "
     },
     {
       "id": "senatni-2022-13-a-338969-37",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes",
       "comment": "Dobrovolnosti se meze nekladou. Samozřejmě s příslušnou kontrolou pojišťoven. "
     },
     {
       "id": "senatni-2022-13-a-338969-38",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes",
       "comment": "Personálně a technicky výborná zařízení by měla pracovat doslova ve dne v noci. Doprava pacientů na tato pracoviště je rozhodně méně nákladná než budování takových zařízení v každé nemocnici.  "
     },
     {
       "id": "senatni-2022-13-a-338969-39",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know",
       "comment": "Zatím, alespoň co vím, nemáme nic jiného. I v našem městě jsme zkoušeli jiný způsob likvidace plevelu, bohužel bezvýsledně.  "
     },
     {
       "id": "senatni-2022-13-a-338969-40",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Bohužel provoz na silnicích neustále roste a odpovědnost řidičů bohužel ne. Pokud prevence nezabírá, musí nastoupit v tomto případě represe.   "
     },
     {
       "id": "senatni-2022-13-a-338969-41",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes",
       "comment": "To už je velký zásah do naší svobody."
     },
     {
       "id": "senatni-2022-13-a-338969-42",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know",
       "comment": "Nechám na odbornících. Vstup je podmiňován vstupními podmínkami a v případě EU se nejedná o uzavřenou společnost.  "
     },
     {
       "id": "senatni-2022-13-a-338969-43",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "V současné době rozhodně ne. Až další vývoj ukáže, co je reálné a co jsou jen sny. "
     },
     {
       "id": "senatni-2022-13-a-338969-44",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes",
       "comment": "Pokud to přispěje k částečnému řešení problémů s cenou energií.  "
     },
     {
       "id": "senatni-2022-13-a-338969-45",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-338969-46",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-338969-47",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no",
       "comment": "Je řada jiných pěkných míst."
     },
     {
       "id": "senatni-2022-13-a-338969-48",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Problém se musí řešit i bez směrnice EU, ale pokud by řešení pomohla, proč ne. Ten problém je stejný bez ohledu na zemi. "
     },
     {
       "id": "senatni-2022-13-a-338969-49",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Bavit se při současné situaci o jakémkoli ukončování nevidím reálné. Pokud aktuální energetická krize přispěje k rychlejšímu využívání obnovitelných zdrojů při odpovídající,  ekonomice, potom bychom se měli k uvedenému problému vrátit.      "
     },
     {
       "id": "senatni-2022-13-a-338969-50",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know",
       "comment": "Evropa nemůže zůstat v této snaze sama. Stačí se podívat na zeměkouli, jak je velká Evropa a jak ostatní světadíly. Pokud v tom zůstane Evropa sama, tak se ekonomicky zničí. "
     },
     {
       "id": "senatni-2022-13-a-338969-51",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-338969-52",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no",
       "comment": "Jsme příliš malý stát. "
     },
     {
       "id": "senatni-2022-13-a-338969-53",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes",
       "comment": "Pokud splňují podmínky a povede to k naší větší bezpečnosti, potom ano."
     },
     {
       "id": "senatni-2022-13-a-338969-54",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "dont_know",
       "comment": "Je třeba najít ten správný poměr rozdělování dotací mezi velké a malé farmáře s cílem zajistit kvalitní, pokud možno levné, tuzemské potraviny.  "
     },
     {
       "id": "senatni-2022-13-a-338969-55",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "Trochu to zlehčím, ještě bych zakotvil povinnost poskytovat kartáčky na zuby."
     },
     {
       "id": "senatni-2022-13-a-338969-56",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "dont_know",
       "comment": "Zase další centrální orgán, který by rozhodoval o pronajmutí bytu v malé obci, to asi ne."
     },
     {
       "id": "senatni-2022-13-a-338969-57",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no",
       "comment": "Již v minulosti se někomu ustupovalo a všichni víme, tak to dopadlo. "
     },
     {
       "id": "senatni-2022-13-a-338969-58",
       "candidate_id": "senatni-2022-13-c-338969",
-      "question_id": "senatni-2022-13-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Bezvýsledná práce přece nemá smysl."
     },
     {
       "id": "senatni-2022-13-a-203124-1",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-2",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-3",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-4",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-5",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-6",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-7",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-8",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-9",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-10",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-11",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-12",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-13",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-14",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-15",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-16",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-17",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-18",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-19",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-20",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-21",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-22",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-23",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-24",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-25",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-26",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-27",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-28",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-29",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-30",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-31",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-32",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-33",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-34",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-35",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-203124-36",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-37",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-38",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-39",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-13-a-203124-40",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-41",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-42",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-43",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-44",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-45",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-46",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-47",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-48",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-49",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-50",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-51",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-52",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-53",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-54",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-55",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-13-a-203124-56",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-57",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-13-a-203124-58",
       "candidate_id": "senatni-2022-13-c-203124",
-      "question_id": "senatni-2022-13-q-58",
+      "question_id": "senatni-2022-global-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-1",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-1",
+      "answer": "no",
+      "comment": "Nelze odpovědět ano -ne , nemám názor"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-2",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-3",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-4",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-5",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-6",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-7",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-8",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-9",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-9",
+      "answer": "yes",
+      "comment": "Za podmínek kvalitního legislativního podložení a stanovení hranice"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-10",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-11",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-12",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-12",
+      "answer": "dont_know",
+      "comment": "Složitý legislativní problém, který řeší jak USA, tak EU a doposud bez jasného výsledku."
+    },
+    {
+      "id": "senatni-2022-13-a-440713-13",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-14",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-15",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-16",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-17",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-18",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-19",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-20",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-21",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-22",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-23",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-24",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-25",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-26",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-27",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-28",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-29",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-30",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-31",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-32",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-33",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-34",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-35",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-36",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-37",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-38",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-39",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-40",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-41",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-41",
+      "answer": "no",
+      "comment": "Nutno však stanovit velmi strikní legislativní regulativy"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-42",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-43",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-44",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-45",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-45",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-46",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-47",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-48",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-49",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-50",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-50",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-51",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-52",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-53",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-54",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-55",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-56",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-57",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-13-a-440713-58",
+      "candidate_id": "senatni-2022-13-c-440713",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     }
   ]

--- a/data/kalkulacka/senatni-2022/16.json
+++ b/data/kalkulacka/senatni-2022/16.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-16-c-875643",
       "name": "Michal Auředník",
       "type": "person",
-      "description": "Michal Auředník - DESCRIPTION",
+      "description": "Michal Auředník",
       "contacts": {
         "web": [],
         "twitter": "https://twitter.com/MichalAurednik"
@@ -491,7 +491,7 @@
         {
           "id": "senatni-2022-16-c-875643-p",
           "name": "Michal Auředník",
-          "description": "Michal Auředník - DESCRIPTION",
+          "description": "Michal Auředník",
           "contacts": {
             "web": [],
             "twitter": "https://twitter.com/MichalAurednik"
@@ -504,7 +504,7 @@
       "id": "senatni-2022-16-c-219251",
       "name": "Janis Sidovský",
       "type": "person",
-      "description": "Janis Sidovský - DESCRIPTION",
+      "description": "Janis Sidovský",
       "contacts": {
         "web": [
           {
@@ -528,7 +528,7 @@
         {
           "id": "senatni-2022-16-c-219251-p",
           "name": "Janis Sidovský",
-          "description": "Janis Sidovský - DESCRIPTION",
+          "description": "Janis Sidovský",
           "contacts": {
             "web": [
               {
@@ -556,7 +556,7 @@
       "id": "senatni-2022-16-c-728249",
       "name": "Jiří Oberfalzer",
       "type": "person",
-      "description": "Jiří Oberfalzer - DESCRIPTION",
+      "description": "Jiří Oberfalzer",
       "contacts": {
         "web": [
           {
@@ -571,7 +571,7 @@
         {
           "id": "senatni-2022-16-c-728249-p",
           "name": "Jiří Oberfalzer",
-          "description": "Jiří Oberfalzer - DESCRIPTION",
+          "description": "Jiří Oberfalzer",
           "contacts": {
             "web": [
               {
@@ -590,7 +590,7 @@
       "id": "senatni-2022-16-c-244153",
       "name": "Martin Karim",
       "type": "person",
-      "description": "Martin Karim - DESCRIPTION",
+      "description": "Martin Karim",
       "contacts": {
         "web": [
           {
@@ -618,7 +618,7 @@
         {
           "id": "senatni-2022-16-c-244153-p",
           "name": "Martin Karim",
-          "description": "Martin Karim - DESCRIPTION",
+          "description": "Martin Karim",
           "contacts": {
             "web": [
               {
@@ -651,1132 +651,1132 @@
     {
       "id": "senatni-2022-16-a-244153-1",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes",
       "comment": "Rád bych nějak motivoval vlastníky bytů k jejich použití pro bydlení."
     },
     {
       "id": "senatni-2022-16-a-244153-2",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes",
       "comment": "Bydlení musí zůstat pro lidi dostupné."
     },
     {
       "id": "senatni-2022-16-a-244153-3",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no",
       "comment": "Stávající úprava je dostatečná, Parlament v případě potřeby může referendum vyhlásit. "
     },
     {
       "id": "senatni-2022-16-a-244153-4",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-5",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Důchodový věk není možné neustále zvyšovat. "
     },
     {
       "id": "senatni-2022-16-a-244153-6",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-244153-7",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-8",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Určitá míra progresivního zdanění již funguje dnes. Zdroje musí stát hledat jinde, například v omezení daňových úniků. Zdanění práce je v ČR vysoké."
     },
     {
       "id": "senatni-2022-16-a-244153-9",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Uškodilo by to jen zločincům, kterým by klesly jejich nelegální příjmy."
     },
     {
       "id": "senatni-2022-16-a-244153-10",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Jedná se o zločin proti lidské důstojnosti, který je bohužel v mnoha případech buď neřešen nebo nedostatečně potrestán."
     },
     {
       "id": "senatni-2022-16-a-244153-11",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-12",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-13",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-14",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-244153-15",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-16",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-17",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-18",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-19",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-20",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-21",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know",
       "comment": "Bylo by hezké veřejnoprávní instituce rozmístit po celém území republiky, je to ale značná investice a je třeba dbát, aby to nemělo vliv na efektivitu státní správy."
     },
     {
       "id": "senatni-2022-16-a-244153-22",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-244153-23",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Dnes je mnoha lidem upřeno nebo ztíženo jejich volební právo a to je nepřijatelné."
     },
     {
       "id": "senatni-2022-16-a-244153-24",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-244153-25",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "dont_know",
       "comment": "Dvě z mých dětí prošly z různých důvodů osmiletými gymnázii. Byl bych rád, kdyby bylo možné stejně jako ve Finsku děti vzdělávat co nejdéle společně. Doufám, že až povyrostou mé dvě mladší děti, bude základní školství na tuto změnu již připraveno."
     },
     {
       "id": "senatni-2022-16-a-244153-26",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-27",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-244153-28",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-29",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-244153-30",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-31",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-32",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-33",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Současná platná česká právní úprava je dostatečná.\n"
     },
     {
       "id": "senatni-2022-16-a-244153-34",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-35",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-36",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-244153-37",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "dont_know",
       "comment": "Jsem pro možnost volby nadstandartů ze strany pojištěnců, ale obávám se, aby nedošlo k omezení standartní základní péče. Pokud bude zaručeno, aby funkční základní péče byla zachována, nemám s připojištěním problém.  "
     },
     {
       "id": "senatni-2022-16-a-244153-38",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-39",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-40",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Tyto systémy některé řidiče vedou k tomu, že v obci zvolní."
     },
     {
       "id": "senatni-2022-16-a-244153-41",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-42",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-43",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-44",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-45",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no",
       "comment": "Současný ochránce práv řadu let neoprávněně užíval titul JUDr. a není pro výkon funkce kompetentní.\n"
     },
     {
       "id": "senatni-2022-16-a-244153-46",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-47",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-244153-48",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-49",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Současná situace s drahými energiemi to neumožňuje."
     },
     {
       "id": "senatni-2022-16-a-244153-50",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-51",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-244153-52",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-244153-53",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-54",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-55",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-244153-56",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes",
       "comment": "Považuji to za dobrý nápad a také bych byl rád, aby nějaký veřejnoprávní bytový fond byl zapojen jako zdroj a investice do důchodové reformy."
     },
     {
       "id": "senatni-2022-16-a-244153-57",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-244153-58",
       "candidate_id": "senatni-2022-16-c-244153",
-      "question_id": "senatni-2022-16-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Dluhy sice mají být placeny, když jsou dlouhodobě nevymahatelné není efektivní je bezvýsledně dlouhodobě vymáhat."
     },
     {
       "id": "senatni-2022-16-a-219251-1",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-2",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Pokud ano, strop nájemného by měl být odstupňován dle lokalit. "
     },
     {
       "id": "senatni-2022-16-a-219251-3",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-219251-4",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-5",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Potřebujeme systémovou reformu udržitelných důchodů, ne neustálé zvyšování věkové hranice."
     },
     {
       "id": "senatni-2022-16-a-219251-6",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "Jsou ekologičtější a efektivnější metody zadržování vody v krajině."
     },
     {
       "id": "senatni-2022-16-a-219251-7",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-8",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Ne, ale mělo by se ulehčit daňové zatížení pracující střední třídy. Plus mám za to, že by vysokopříjmové osoby měly mít povinnost přispívat na sociální programy. "
     },
     {
       "id": "senatni-2022-16-a-219251-9",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Jsou škodlivější návykové látky a přesto jsou legální. "
     },
     {
       "id": "senatni-2022-16-a-219251-10",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-11",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-12",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes",
       "comment": "Ano, v případě nejzávaznějších narušení veřejného pořádku."
     },
     {
       "id": "senatni-2022-16-a-219251-13",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-14",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-219251-15",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-16",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-17",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-18",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-19",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "V drahých lokalitách by měli mít nárok například i učitelé, hasiči, zdravotní sestry a podobně."
     },
     {
       "id": "senatni-2022-16-a-219251-20",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Ale je třeba zlepšit informování veřejnosti v této otázce. "
     },
     {
       "id": "senatni-2022-16-a-219251-21",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-219251-22",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-23",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Jsem pro možnost korespondenční hlasování. Stát aktuálně není schopen zajistit funkčnost a bezpečnost online hlasování. "
     },
     {
       "id": "senatni-2022-16-a-219251-24",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no",
       "comment": "Jinak nepřestaneme být montovnou Evropy. Tyto profese jsou zároveň nejvíce ohroženy robotizací."
     },
     {
       "id": "senatni-2022-16-a-219251-25",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-219251-26",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "Ale je potřeba zlepšit financování a personální zajištění."
     },
     {
       "id": "senatni-2022-16-a-219251-27",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-219251-28",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "Vlastní měna při našem navázání na Německo je více zranitelná, jak ukazuje současná inflace. "
     },
     {
       "id": "senatni-2022-16-a-219251-29",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-219251-30",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-31",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes",
       "comment": "Ne ve smyslu rozdávání financí, ano ve smyslu podpory institucionálních změn. "
     },
     {
       "id": "senatni-2022-16-a-219251-32",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-33",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-16-a-219251-34",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-35",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "2% HDP, jak jsme se zavázali NATO"
     },
     {
       "id": "senatni-2022-16-a-219251-36",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-219251-37",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-219251-38",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-39",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-40",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-219251-41",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes",
       "comment": "Jedná se o významný zásah do soukromí. Dovedu si představit využívání jen v trestním řízení s dohledem soudu. "
     },
     {
       "id": "senatni-2022-16-a-219251-42",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes",
       "comment": "Za předpokladu splnění všech podmínek, včetně ekonomických ukazatelů a stavu demokratických institucí a za předpokladu odbourání systémové korupce, která na Ukrajině bují. "
     },
     {
       "id": "senatni-2022-16-a-219251-43",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-44",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-45",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-219251-46",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-47",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-219251-48",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-49",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-50",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-51",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-219251-52",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no",
       "comment": "Při společném vyjednávání s ostatními státy EU jsme silnější"
     },
     {
       "id": "senatni-2022-16-a-219251-53",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-219251-54",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes",
       "comment": "Jsem pro zachování rovnosti, rozhodně ne zvýhodňovat velké farmy."
     },
     {
       "id": "senatni-2022-16-a-219251-55",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "yes",
       "comment": "Především jsem zajištění těchto hygienických potřeb ve vzdělávacích zařízeních. "
     },
     {
       "id": "senatni-2022-16-a-219251-56",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes",
       "comment": "Především pro sociální bydlení. "
     },
     {
       "id": "senatni-2022-16-a-219251-57",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-219251-58",
       "candidate_id": "senatni-2022-16-c-219251",
-      "question_id": "senatni-2022-16-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "dont_know",
       "comment": "Ano, ale ne v případě, kdy dlužníci vyvedou majetek jinam a užívají jej nadále. Časové hledisko by mělo začínat na hranici 10 let. "
     },
     {
       "id": "senatni-2022-16-a-875643-1",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Jedná se o soukromý majetek a tyto \"dodatečné\" zdanění, která mají naplnit státní kasu, jsou krokem zpět. Co zdaníme dál? Auto, kterým nejezdíte nebo panenku, se kterou si nehrajete? Běžný občan půl roku vydělává na stát. Co takhle daleko efektivnější hospodaření státu, než další daně? "
     },
     {
       "id": "senatni-2022-16-a-875643-2",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "ČR by spíše měla regulovat ceny pohonných hmot, od kterých se pak odvíjí následné další zdražování. "
     },
     {
       "id": "senatni-2022-16-a-875643-3",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Ano. O důležitých věcech by měli lidé mít možnost hlasovat. Třeba o setrvání v EU. "
     },
     {
       "id": "senatni-2022-16-a-875643-4",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "dont_know",
       "comment": "Záleží na regionu. Konkrétně v Berouně & Praha západ by výstavba mohla velmi pomoci a ulehčit tak D5 a dopravě ve městě. "
     },
     {
       "id": "senatni-2022-16-a-875643-5",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-16-a-875643-6",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes",
       "comment": " "
     },
     {
       "id": "senatni-2022-16-a-875643-7",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "dont_know",
       "comment": "Nebyl bych asi proti. Nicméně, navýšil bych kapacitu kontejnerů na třídění odpadu. Často jsou přeplněné a pak se nepořádek válí všude kolem nebo odpad končí na nelegálních skládkách. "
     },
     {
       "id": "senatni-2022-16-a-875643-8",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Nesouhlasím s trestáním lidí, kteří dají práci více než ostatní. Je to z mého pohledu spíše daň za úspěch. Tito lidé vytváří pracovní pozice, zaměstnávají lidi a často se podílí i rozvoji samotného regionu.  "
     },
     {
       "id": "senatni-2022-16-a-875643-9",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Konopí je od pradávna známé jako bylina, které dokáže zázraky (především na klouby). Problém konopí je, že z něj na rozdíl od alkoholu, stát nemá příjmy. Alkohol je tvrdá droga, kterou si lze legálně koupit a která Vám může doslova zničit život. "
     },
     {
       "id": "senatni-2022-16-a-875643-10",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "100%   A nejen za znásilnění! Již samotný případný postih musí být takový, aby nebyl výsměchem, ale byl skutečným trestem. Výše trestu sám o sobě by měl být prevencí. Pokud násilník může zničit život někomu jinému, musí počítat s tím, že trest bude odpovídat. "
     },
     {
       "id": "senatni-2022-16-a-875643-11",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Nevidím jediný důvod, proč nemají odvádět daně, pokud podnikají na území ČR. "
     },
     {
       "id": "senatni-2022-16-a-875643-12",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Pokud se nejedná o vyloženě zakázaný obsah (např. pornografie), pak za obsah má být zodpovědný ten, kdo jej sdílí. Sociální sítě se často stávají cenzorem, který rozhoduje o tom, co je povolené a co zakázané. I sociální síť má svého majitele, kterému slouží a mají tak možnost ovlivnit názor ve společnosti. Přesně to se teď i nyní děje. "
     },
     {
       "id": "senatni-2022-16-a-875643-13",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "Otázkou je, co je \"fake news\"? Z minulosti víme, že byly mazané zprávy a lidé blokovaní, pokud napsali zprávu, která se o pár týdnů nebo měsíců ukázala, jako pravdivá. Především doba covidová zde přinesla spoustu takových případů. Žijeme v moderním světě, kdy si lidé snadno mohou ověřit, pokud je informace opravdu zajímá, co je na ní pravdy. Nelze vše cenzurovat a mazat. Zůstane pak jen vládní propaganda a povolený názor. "
     },
     {
       "id": "senatni-2022-16-a-875643-14",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes",
       "comment": "Jsem pro okamžité zrušení poplatků. Některá veřejnoprávní média opravdu nepůsobí jako nestranná. "
     },
     {
       "id": "senatni-2022-16-a-875643-15",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-16-a-875643-16",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Manželství je svazek muže a ženy. "
     },
     {
       "id": "senatni-2022-16-a-875643-17",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-16-a-875643-18",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-875643-19",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "Myslím, že existují jiná, lepší řešení. "
     },
     {
       "id": "senatni-2022-16-a-875643-20",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Stát se má především starat, aby těch lidí bylo co nejméně a ne je cíleně \"vyrábět\". "
     },
     {
       "id": "senatni-2022-16-a-875643-21",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know",
       "comment": "Spíše ano. Asi by to nemělo být přímo pravidlo, ale postupné zlepšení lepší dostupnosti by určitě ušetřilo čas a náklady. "
     },
     {
       "id": "senatni-2022-16-a-875643-22",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no",
       "comment": "Máme spoustu problémů zde v České republice. Až budou všechny vyřešeny, můžeme kolonizovat Mars.  "
     },
     {
       "id": "senatni-2022-16-a-875643-23",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Jen v případě, že daný volič prokazatelně nemůže (např. kvůli zdraví) se osobně dostavit. Doplnění: Osobně bych podpořil zamítnutí korespondenční volby ze zahraničí. Nevidím jediný důvod, proč by o lidé, kteří dlouhodobě žijí v cizině, měli rozhodovat a lidech žijících v ČR. "
     },
     {
       "id": "senatni-2022-16-a-875643-24",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "dont_know",
       "comment": "Spíše ano. "
     },
     {
       "id": "senatni-2022-16-a-875643-25",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Pokud má dítě talent na určitou věc, měl by se rozvíjet co nejdříve. Proč mučit někoho matikou, když je od přírody talent na zpěv nebo housle? "
     },
     {
       "id": "senatni-2022-16-a-875643-26",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no",
       "comment": "Bohužel, realita má spíše opačný efekt. Slabší žáci brzdí nebo mohou negativně ovlivnit nadané. "
     },
     {
       "id": "senatni-2022-16-a-875643-27",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "yes",
       "comment": "Včera bylo pozdě. Více o mém názoru na webu senatormichal.cz"
     },
     {
       "id": "senatni-2022-16-a-875643-28",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "Doufám, že nikdy. Po euro bude následovat CBDS (digitální měna) a dílo zkázy bude dokonáno. Opět je to složitější téma, ale pokud se podíváte, jak např. Piráti již dnes tlačí na digitalizaci, začne to vše do sebe velmi nebezpečně zapadat. "
     },
     {
       "id": "senatni-2022-16-a-875643-29",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes",
       "comment": "Jsem proti cizím vojenským základnám a pobytu cizích vojsk na území ČR. "
     },
     {
       "id": "senatni-2022-16-a-875643-30",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "dont_know",
       "comment": "Ano, jsme v srdci Evropy, to ale neznamená, že musíme být v jádru Evropské Unie. "
     },
     {
       "id": "senatni-2022-16-a-875643-31",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "ČR by měla PŘEDEVŠÍM podporovat vlastní obyvatele na prvním místě. "
     },
     {
       "id": "senatni-2022-16-a-875643-32",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no",
       "comment": "Kdo prosím bere ohledy na zájmy ČR? "
     },
     {
       "id": "senatni-2022-16-a-875643-33",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Právě naopak. ČR by si měla pečlivě vybírat, koho si pouští na své území. "
     },
     {
       "id": "senatni-2022-16-a-875643-34",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "no",
       "comment": "Není to tak dávno, co nás Němci odmítali pustit za hranice (lidi, kteří dojíždí za prací do Německa). Na hranicích se museli prokazovat PCR testy, aby vůbec mohli za prací. Příště si můžou vymyslet jiné důvody a pak smysl volného prostoru zcela ztrácí na svém významu.  Já bych byl pro obnovení kontroly na hranicích. Těch 5 minut nikoho nezabije a přesně budeme vědět, koho si pouštíme do země. To platí teď dvojnásob. Míří k nám ekonomických migrantů a pokud bude v Africe nouze o vodu, Evropa se má na co těšit. Měli bychom vědět, koho si pouštíme na své území. "
     },
     {
       "id": "senatni-2022-16-a-875643-35",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no",
       "comment": "Armáda má své opodstatnění, ale pokud u nás budou žít lidé, kteří zde pracovali a platili celý život daně na hranici chudoby, pak by se měl stát především postarat o ně. A to je jen jeden z mnoha příkladů. Jsem pro podporu vybavení, které může pomáhat např. při hašení požárů nebo při povodních, ale odmítám vyhazování desítek miliard za stíhačky a jiné válečné zbraně. "
     },
     {
       "id": "senatni-2022-16-a-875643-36",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Myslím, že to je zcela proti přírodě. Co si budou moci vybrat dále? Zda bude mít modrý oči, blond vlasy? "
     },
     {
       "id": "senatni-2022-16-a-875643-37",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-16-a-875643-38",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know",
       "comment": "Je to na diskuzi. Pokud by to pomohlo rychlejšímu termínu výkonu a lepší péci, byl bych určitě pro. "
     },
     {
       "id": "senatni-2022-16-a-875643-39",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know",
       "comment": "Nechal bych si poradit o odborníků. Z mého pohledu ANO, ale neznám názor druhé strany. Je to na diskuzi a zvážení pro vs. proti. "
     },
     {
       "id": "senatni-2022-16-a-875643-40",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Systémy měření jsou určitě dobrým nástrojem u škol, školek a míst se zvýšenou koncentrací chodců. Silnice se často mění v závodní dráhu a v případě, že pravidla dodržujete, pak o radarech ani nevíte. Nicméně, pokud jsou ale záměrně umístěny např. přímo na hranici obce, kde každý už trochu přidá nohu na plyn, není to šťastné řešení. "
     },
     {
       "id": "senatni-2022-16-a-875643-41",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes",
       "comment": "Zavádění podobných systémů je příprava na systém sociálního kreditu a cesta do otroctví. Opět složité a zásadní téma. "
     },
     {
       "id": "senatni-2022-16-a-875643-42",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-16-a-875643-43",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-16-a-875643-44",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "Pokud nechceme ztratit poslední možnost dodávky plynu na přímo z Ruska a zcela zničit ČR, pak určitě ne! "
     },
     {
       "id": "senatni-2022-16-a-875643-45",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-16-a-875643-46",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "dont_know",
       "comment": "Celé téma je velmi složité a nelze odpovědět ANO/NE. "
     },
     {
       "id": "senatni-2022-16-a-875643-47",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes",
       "comment": "Jedině tak se můžeme posunout blíže k míru. Místo posílání zbraní se pokusit diplomaticky vyjednávat jménem České republiky. "
     },
     {
       "id": "senatni-2022-16-a-875643-48",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Česká republika by s tím měla poradit sama a nečekat, co pošle Brusel. Máme spoustu velmi kvalitních právníků, kteří by si s problematikou dobře poradili. "
     },
     {
       "id": "senatni-2022-16-a-875643-49",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "dont_know",
       "comment": "Česká republiky musí pružně reagovat na situaci a tomu se přizpůsobit. Vše musí činit tak, aby rozhodnutí byla v nejlepším zájmu obyvatel, firem a institucí v ČR. V žádném případě na sebe nenechat tlačit z EU. "
     },
     {
       "id": "senatni-2022-16-a-875643-50",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "Já doufám, že do té doby už dávno v EU nebudeme a ČR si opět bude o všem rozhodovat sama."
     },
     {
       "id": "senatni-2022-16-a-875643-51",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "dont_know",
       "comment": "Opět složité téma, na které se nedá říci ANO-NE."
     },
     {
       "id": "senatni-2022-16-a-875643-52",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Nevidím jediný důvod, proč ne. Důležitá je pro nás cena a plynulost dodávek. Proč máme kupovat ruský plyn z Německa za násobky ceny, nebo \"ekologicky\" předražený od našich milovaných spojenců z USA? Prvním krokem k úspěšné diplomacii je demise vlády současných prozápadních politiků. "
     },
     {
       "id": "senatni-2022-16-a-875643-53",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "no",
       "comment": "Za současné situace je to přilévání oleje do ohně a eskalovat konflikt s Ruskem znamená zkázu pro Evropu. "
     },
     {
       "id": "senatni-2022-16-a-875643-54",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "dont_know",
       "comment": "Osobně jsem celkově proti dotacím, které často ničí přirozenou hospodářskou soutěž. V první řadě si musíme dostatečně ochránit vlastní trh a podporovat naše farmy a zemědělce. Jsou to oni, kdo by měl určovat ceny a ne se nechat vydírat supermarkety, kteří na úkor nich profitují. "
     },
     {
       "id": "senatni-2022-16-a-875643-55",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "Co je tohle za otázku? To jako přijdu na úřad a budu po někom požadovat vložky? To jako vážně? Co dál? Mýdlo a zubní pastu? "
     },
     {
       "id": "senatni-2022-16-a-875643-56",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes",
       "comment": "Jsem pro podporu bydlení a pokud by toto řešení pomohlo, pak jsem určitě pro. "
     },
     {
       "id": "senatni-2022-16-a-875643-57",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know",
       "comment": "Složité téma, nelze odpovědět ANO-NE. "
     },
     {
       "id": "senatni-2022-16-a-875643-58",
       "candidate_id": "senatni-2022-16-c-875643",
-      "question_id": "senatni-2022-16-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Pokud jsou opravdu dlouhodobě bezvýsledné, pak nemá smysl do nich nadále investovat čas a energii. "
     }

--- a/data/kalkulacka/senatni-2022/19.json
+++ b/data/kalkulacka/senatni-2022/19.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-19-c-420727",
       "name": "David Bohbot",
       "type": "person",
-      "description": "David Bohbot - DESCRIPTION",
+      "description": "David Bohbot",
       "contacts": {
         "web": [
           {
@@ -501,7 +501,7 @@
         {
           "id": "senatni-2022-19-c-420727-p",
           "name": "David Bohbot",
-          "description": "David Bohbot - DESCRIPTION",
+          "description": "David Bohbot",
           "contacts": {
             "web": [
               {
@@ -524,7 +524,7 @@
       "id": "senatni-2022-19-c-746291",
       "name": "Milan Urban",
       "type": "person",
-      "description": "Milan Urban - DESCRIPTION",
+      "description": "Milan Urban",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/milanu925"
@@ -533,7 +533,7 @@
         {
           "id": "senatni-2022-19-c-746291-p",
           "name": "Milan Urban",
-          "description": "Milan Urban - DESCRIPTION",
+          "description": "Milan Urban",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/milanu925"
@@ -546,7 +546,7 @@
       "id": "senatni-2022-19-c-999606",
       "name": "Šárka Oharková",
       "type": "person",
-      "description": "Šárka Oharková - DESCRIPTION",
+      "description": "Šárka Oharková",
       "contacts": {
         "web": [],
         "instagram": "https://www.instagram.com/senatorkasarka/"
@@ -555,7 +555,7 @@
         {
           "id": "senatni-2022-19-c-999606-p",
           "name": "Šárka Oharková",
-          "description": "Šárka Oharková - DESCRIPTION",
+          "description": "Šárka Oharková",
           "contacts": {
             "web": [],
             "instagram": "https://www.instagram.com/senatorkasarka/"
@@ -568,7 +568,7 @@
       "id": "senatni-2022-19-c-325120",
       "name": "Vladimír Špidla",
       "type": "person",
-      "description": "Vladimír Špidla - DESCRIPTION",
+      "description": "Vladimír Špidla",
       "contacts": {
         "web": [
           {
@@ -583,7 +583,7 @@
         {
           "id": "senatni-2022-19-c-325120-p",
           "name": "Vladimír Špidla",
-          "description": "Vladimír Špidla - DESCRIPTION",
+          "description": "Vladimír Špidla",
           "contacts": {
             "web": [
               {
@@ -602,7 +602,7 @@
       "id": "senatni-2022-19-c-107153",
       "name": "Ladislav Kos",
       "type": "person",
-      "description": "Ladislav Kos - DESCRIPTION",
+      "description": "Ladislav Kos",
       "contacts": {
         "web": [
           {
@@ -616,7 +616,7 @@
         {
           "id": "senatni-2022-19-c-107153-p",
           "name": "Ladislav Kos",
-          "description": "Ladislav Kos - DESCRIPTION",
+          "description": "Ladislav Kos",
           "contacts": {
             "web": [
               {
@@ -634,7 +634,7 @@
       "id": "senatni-2022-19-c-517013",
       "name": "Robert Vašíček",
       "type": "person",
-      "description": "Robert Vašíček - DESCRIPTION",
+      "description": "Robert Vašíček",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/robert.vasicek79",
@@ -644,7 +644,7 @@
         {
           "id": "senatni-2022-19-c-517013-p",
           "name": "Robert Vašíček",
-          "description": "Robert Vašíček - DESCRIPTION",
+          "description": "Robert Vašíček",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/robert.vasicek79",
@@ -658,7 +658,7 @@
       "id": "senatni-2022-19-c-358095",
       "name": "Tomáš Hudeček",
       "type": "person",
-      "description": "Tomáš Hudeček - DESCRIPTION",
+      "description": "Tomáš Hudeček",
       "contacts": {
         "web": [
           {
@@ -682,7 +682,7 @@
         {
           "id": "senatni-2022-19-c-358095-p",
           "name": "Tomáš Hudeček",
-          "description": "Tomáš Hudeček - DESCRIPTION",
+          "description": "Tomáš Hudeček",
           "contacts": {
             "web": [
               {
@@ -710,7 +710,7 @@
       "id": "senatni-2022-19-c-388017",
       "name": "Hana Kordová Marvanová",
       "type": "person",
-      "description": "Hana Kordová Marvanová - DESCRIPTION",
+      "description": "Hana Kordová Marvanová",
       "contacts": {
         "web": [
           {
@@ -726,7 +726,7 @@
         {
           "id": "senatni-2022-19-c-388017-p",
           "name": "Hana Kordová Marvanová",
-          "description": "Hana Kordová Marvanová - DESCRIPTION",
+          "description": "Hana Kordová Marvanová",
           "contacts": {
             "web": [
               {
@@ -747,1866 +747,1866 @@
     {
       "id": "senatni-2022-19-a-517013-1",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Vlastnictví nelze v právním státě trestat. Už vůbec samotná daň z nemovitostí je hanebná, protože penalizuje vlastnictví. Pokusy zdanit prázdné byty jsou reakcí na spekulativní trh s nemovitostmi. Já navrhuji vystavět na zelené louce nová sídliště napříč republikou a tyto státní byty už nikdy nikomu neprodat. Tím vyřešíme bytovou krizi. "
     },
     {
       "id": "senatni-2022-19-a-517013-2",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Na prvním místě jsou lidé, takže si dovedu představit 5letou lhůtu na výstavbu státních sídlišť a během výstavby si dovedu představit dočasnou regulaci, aby lidé po dobu těch 5 let měli kde bydlet. Jakmile zde vznikne alespoň 100 000 nových státních bytů napříč republikou, totiž zcela nová sídliště v katastru všech krajských měst, dále v dalších velkých sídlech v rámci republiky, tak odstranit jakoukoli regulaci. Protože buď se nabídka potká s poptávkou, nebo předražené byty zůstanou prázdné a lidé v nouzi půjdou bydlet do levných státních bytů. "
     },
     {
       "id": "senatni-2022-19-a-517013-3",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Samozřejmě ano. Petice a celostátní referendum je projev vůle občanů a jakmile se vůler občanů rozchází se zvolenými politiky, je na řadě korektiv v podobě celostátního referenda. Kdo se toho bojí, nepřeje lidem skutečnou demokracii. "
     },
     {
       "id": "senatni-2022-19-a-517013-4",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Odpověděl jsem NE, protože kandiduji v Praze a hájím zájmy svých voličů a ti rychlovlak v Praze nepotřebují. Potřebujeme lepší silnice, obchvaty, okruhy a nová parkovací místa. Takže stavím na stejnou úroveň výstavbu silnic a dálnic a rovněž výstavbu koridorů pro rychlovlaky. Je to skvělá představa, že jako dědeček jednou pojhedu na chalupu na Vysočině 30 minut. "
     },
     {
       "id": "senatni-2022-19-a-517013-5",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Odmítám okrádání důchodců, snižování reálné hodnoty důchodů a zvyšování věku pro odchod do důchodu. Nabízím lepší řešení. Jako bývalý poradce ministra práce a sociálních věcí jsem detailně studoval důchodový systém v České republice. Na uživení jednoho důchodce potřebujeme alespoň dva daňové poplatníky v produktivním věku. Takže je třeba okamžitě začít všemi způsoby podporovat porodnost. Ať je nás klidně 20 milionů. Ptáte se, kam pak s těmi lidmi v naší maličké zemi? Národy kolem nás vymírají, budou vznikat česká osídlení v zahraničí, jako se to kdysi povedlo Volyňským Čechům. "
     },
     {
       "id": "senatni-2022-19-a-517013-6",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "Z ekologického hlediska jsou vodní přehrady katastrofa, protože přerušují říční migraci. Tam, kde hrozily povodně, tam už dávno přehrady stojí a nové bych rozhodně nestavěl. Pokud jde o vodu, je třeba ji vrátit do krajiny formou hladiny spodních vod, nikoli formou přehradních bazénů. "
     },
     {
       "id": "senatni-2022-19-a-517013-7",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no",
       "comment": "Určitě ne, protože by to prodražilo v nich prodávané nápoje. Navíc narozdíl od skla je nelze recyklovat, aniž by prošly náročným tříděním a opětovným roztavením. "
     },
     {
       "id": "senatni-2022-19-a-517013-8",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Vyšší sazba daně pro vyšší příjmy je nespravedlivá. Skutečně bohatí lidé, milionáři a miliardáři si totiž platy nevyplácejí a své příjmy vyvádějí přes dividendy, akcie a zahraniční trusty mimo daňový systém České republiky. Dokud nedokážeme zdanit superbohaté lidi, proč bychom trestali ty méně bohaté? "
     },
     {
       "id": "senatni-2022-19-a-517013-9",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Marihuana ještě nikoho nezabila a naopak lidem s Alzheimerem nebo Parkinsonovou chorobou pomáhá od jejich nemoci. Kriminalizace se navíc děje jen proto, aby farmaceutické kartely mohly v lékárnách prodávat vlastní předraženou marihuanu, na kterou důchodce skutečně nemá. Takže okamžitě dekriminalizovat. "
     },
     {
       "id": "senatni-2022-19-a-517013-10",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Nejvyšší hodnotou svobody člověka je neporušitelná duševní, tělesná a právní integrita. Nikdo nemá právo vzít si násilím tělo druhého člověka. Jsem ochoten připustit, že jsou lidé, kteří se neovládají. Pak ale ať žijí v ústavech, protože jejich volný pohyb ohrožuje ostatní."
     },
     {
       "id": "senatni-2022-19-a-517013-11",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Pokud platí české e-shopy nebo inzertní portály, není žádný důvod, aby byla výjimka pro zahraniční společnosti. Ještě více je třeba řešit otázku dodržování Ústavy Čr a platných zákonů z hlediska svobody projevu, která je častokrát pošlapána na sociálních sítích. Zejména TikTok a Facebook bych přinutil dodržovat české zákony a svobodu slova. Obráceně každá urážka by byla ihned řešitelná právní cestou. V současnosti vás skupiny dezolátů napadají za váš názor brutálním a zastrašujícím způsobem. "
     },
     {
       "id": "senatni-2022-19-a-517013-12",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes",
       "comment": "Sociální sítě dnes v našich životech hrají stejně důležitou roli, jako naše projevy na veřejnosti a mají rovnocenný dosah na vaši pověst. "
     },
     {
       "id": "senatni-2022-19-a-517013-13",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes",
       "comment": "Neschvaluji současné mazání příspěvků neziskovkami, které nikdo z nás nezmocnil k vyrábění té jediné skutečné pravdy. Pokud se tedy vyskytne závadný výrok, měli byste mít možnost jej žalovat ke speciálnímu soudu, kde závadný výrok bude hájit jeho dohledatelný autor ze sociálních sítí a na druhé straně bude žalobce. Ten, kdo výrok zveřejní, by měl prokázat jeho pravdivost důkazy v jednodenním stání a obráceně ten, kdo výrok žaluje, by měl přinést důkazy jeho nepravdivosti. Výrok by měl padnout ten samý den zasedání a bude proti němu samozřejmě odvolání do 30 dnů od rozsudku a poté by měl být v případě potvrzujícího rozsudku závadný výrok okamžitě odstraněn. "
     },
     {
       "id": "senatni-2022-19-a-517013-14",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Česká televize a Český rozhlas plní veřejnoprávní roli, jsou ale bohužel nástrojem v rukou politiků. Navrhnu změnu zákona tak, abyste mohli učinit daňovou asignaci ve prospěch veřejnoprávních médií. Protože je jasné, že většina lidí by asignovala směrem k televizi, bude asignace pevně rozdělena v poměru 75:25 ve prospěch ČT před ČRo. Daňové asignace budou daňově odečitatelná položka, takže si tím snížíte základ daně. A tento systém nahradí povinné výpalné od všech občanů s přijímačem. Na jedné straně ubude počet předplatitelů, na druhé straně budete moci upsat daleko vyšší částku a především veřejnoprávní televize a rozhlas nebude vůbec závislé na politicích, ale jen na svých předplatitelích a tak je to v pořádku. Bude daleko nezávislejší žurnalistika. "
     },
     {
       "id": "senatni-2022-19-a-517013-15",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no",
       "comment": "Pracovní agentury jsou často poslední šance získat práci pro lidi, kteří nemají pracovní návyky a v běžném pracovním poměru by se neudrželi. Proto nevidím důvod, proč je omezovat. "
     },
     {
       "id": "senatni-2022-19-a-517013-16",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes",
       "comment": "Jsem pro rovná práva i pro stejnopohlavní páry, odmítám ale používat výraz manželství. Ten vychází ze staročeského mal žen a dva gayové prostě nemají ženu. Podobně nenazýváme tygra králíkem a hada slepicí. Každopádně je neudržitelné, aby registrované partnerství bylo jen lepším přátelstvím, ale mělo by dostat rovnocenná práva s manželstvím, ve smyslu práv partnerů, nebo dědictví, vdovského důchodu a podobně. "
     },
     {
       "id": "senatni-2022-19-a-517013-17",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "no",
       "comment": "Především bych přistřihl křídla exekučnímu businessu. Zločinné spolčení justiční mafie s lichváři zneužívá půjčky bez ručitele, aby okradly lidi o všechno. Nově nebude možné vzít si půjčku bez ručitele. Zabráníme tím lichvě a exekucím."
     },
     {
       "id": "senatni-2022-19-a-517013-18",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "no",
       "comment": "Především bych přistřihl křídla exekučnímu businessu. Zločinné spolčení justiční mafie s lichváři zneužívá půjčky bez ručitele, aby okradly lidi o všechno. Nově nebude možné vzít si půjčku bez ručitele. Zabráníme tím lichvě a exekucím."
     },
     {
       "id": "senatni-2022-19-a-517013-19",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "My na Praze 11, Praze 15, v Dolních Měcholupech, Praze 22 nebo Kolovratech víme, že developer se cpe pod různými záminkami do již uzavřeného městského prostředí a obsazuje při tom trávníky, parkoviště nebo původní objekt zboří a postaví tam něco megalomanského, aby na tom vydělal. To nechceme, nechte naše sídliště a naši zeleň být. Takže developer ať si staví tam, kde ho nechají místní a ať si s tím dělá, co chce. Naopak podporuji výstavbu státních bytů v nových lokalitách za městem tak, abychom za pět let postavili 100 000 nových bytů a ulevili tam lidem na trhu s nájemním bydlením a dali jim skutečnosu jistotu. "
     },
     {
       "id": "senatni-2022-19-a-517013-20",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Sociální dávky nevyřeší bytovou, ani pracovní situaci lidí. Lidem je třeba zajistit nová pracovní místa s takovým platem, aby žádné sociální dávky nepotřebovali. "
     },
     {
       "id": "senatni-2022-19-a-517013-21",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no",
       "comment": "Někdy si jako Pražan říkám, co bych dal za to, kdyby se úřady přesunuly do Brna nebo Olomouce, měli bychom tu větší klid. Je to ale strašně drahé a v době hospodářské krize si toto neumím představit. "
     },
     {
       "id": "senatni-2022-19-a-517013-22",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "yes",
       "comment": "Už moji prarodiče sledovali, jak pes Lajka a kosmonaut Gagarin obletěli Zemi. Je divné, že se za dalších 60 let nic nového neudálo. Česká republika nemůže na vědeckém programu prodělat. Naopak se může stát dodavatelem důležitých komponent pro let do Vesmíru. Takže podporuji. "
     },
     {
       "id": "senatni-2022-19-a-517013-23",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "V situaci, kdy bude volba veřejná, pak na způsobu volby nezáleží, protože každý si svůj hlas dohledá. V případě tajné volby, což je ústavním zvykem, není možné, aby jakákoli aplikace kontrolovala hlasy milionů voličů. Nevěřím aplikacím, věřím lidem. Takže jsem pro dosavadní způsob lidských volebních komisí. "
     },
     {
       "id": "senatni-2022-19-a-517013-24",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "To je přece jasná, sociologie ještě nic nevyrobila, řemeslo a technické znalosti ano. "
     },
     {
       "id": "senatni-2022-19-a-517013-25",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes",
       "comment": "Každé dítě je jiné a přesto nelze dítě na základě ADHD, dyslexie, nebo dysgrafie ihned vyřadit z lidské společnosti. "
     },
     {
       "id": "senatni-2022-19-a-517013-26",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "České školství si musí rozmyslet, jestli půjde západoevropskou cestou vychovávání debilů, kteří na mapě nedokážou najít jednotlivé kontinenty a pletou si Českou republiku s Čečenskem, nebo si ponecháme vysoký standard školství, ke kterému prostě biflování patří, a taky odborná pomoc problémovým žákům. "
     },
     {
       "id": "senatni-2022-19-a-517013-27",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "dont_know",
       "comment": "Ano, pokud to pro nás bude výhodné. Velká Británie je ostrov a není nijak závislá na evropském tranzitu. Kdokoli vykřikuje, jak hned teď odejdeme z Evropské unie, chci po něm všechny asociační dohody, nahrazující dosavadní členské výhody. Jsem ochoten se pustit do dobrodružství v podobě zajištění těchto dohod, ale to bude trvat nejméně 20 let. To jen pro ty, kdo hýkají blahem nad okamžitým odchodem z EU. A to píšu jako velký kritik Evropské unie. U mě jsou na prvním místě lidé a EU je pro mě souhrn mezinárodních záruk i negativ členství. A na na druhé straně, pokud se EU vzdá přílišné byrokracie, mohla by pro nás být vlastně výhodná. Každopádně rozhodnutí by mělo být vždy v rukou občanů v celostátním referendu, nikoli politiků, kteří podobným způsobem za našimi zády rozdělili Československo. "
     },
     {
       "id": "senatni-2022-19-a-517013-28",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "Euro je pro nás nevýhodné, protože se staneme provincií bez vlastní monetární politiky. Česká Koruna je stabilní a žádaná měna. "
     },
     {
       "id": "senatni-2022-19-a-517013-29",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes",
       "comment": "NATO  prokázalo na Ukrajině svou slabost. Koncepce společné obrany u nás za 20 let vytvořilo loutkovou armádu bez tanků a letadel. Upřednostňuji švýcarský model obrany území a agresivní styl obrany, kdy přeneseme vlastními akcemi boj na území protivníka. Navíc pokud zůstaneme nadále obklopeni členskými zeměmi NATO, nemáme se přece čeho bát. Nebo že by nás NATO jako neutrální zemi napadlo?"
     },
     {
       "id": "senatni-2022-19-a-517013-30",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no",
       "comment": "Proklamace o tvrdém jádru EU mně připomínají Radu vzájemné hospodářské pomoci za komunismu. Dokud není sídlo EU v Praze a nemáme stejný výtlak jako Francie a Německo, jako malý stát stejně musíme poslouchat Brusel, tak alespoň bez hlasitého tleskání. "
     },
     {
       "id": "senatni-2022-19-a-517013-31",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "Ptám se, kdo pomůže nám? Myslím, že bychom konečně měli začít dělat obchodní zahraniční politiku, takže každá naše investice by se měla vrátit v podobě zisku pro české občany. Dosud je tomu tak, že když někam pošleme pomoc, většinou ještě přijdeme o další obchodní partnery a zisky z mezinárodní spolupráce. "
     },
     {
       "id": "senatni-2022-19-a-517013-32",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes",
       "comment": "Samozřejmě, že bychom měli brát ohled na rozvojové země, protože po nás představují potenciální trhy a nasytí naše peněženky. "
     },
     {
       "id": "senatni-2022-19-a-517013-33",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Už Římská říše nahrazovala nedostatečnou porodnost římského obyvatelstva dovozem federátů, což se jí posléze vymstilo. Nemám vůbec problém s tím, že cizinec se zamiluje do Češky a rozhodne se splnit zákonné možnosti a žít tady. Nemám problém přijmout Páskistánského gaye, protože doma by ho ukamenovali. Ale opravdu odmítám usnadnit sem cestu ekonomickým migrantům. To jsou lidé, co se sem jdou najíst za naše, poberou výhody, ale nic nám nepřinesou. "
     },
     {
       "id": "senatni-2022-19-a-517013-34",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes",
       "comment": "Jednoznačně ano a to je jeden z důvodů, proč se nám stále EU vyplatí. "
     },
     {
       "id": "senatni-2022-19-a-517013-35",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "Česká armáda díky napojeným mafií spotřebuje dost peněz. To, co skutečně potřebujeme, je domácí výroba levných a primitivních zbraní, kvantitu před složitými technologiemi, objem před předraženými zahraničními krámy, jako je Pandur nebo Gripen. Chci česká BVPéčka, české tanky domácí konstrukce, česká letadla a Českou armádu. "
     },
     {
       "id": "senatni-2022-19-a-517013-36",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "yes",
       "comment": "Pokud to jde, neexistuje jediný důvod, proč jim to neumožnit. "
     },
     {
       "id": "senatni-2022-19-a-517013-37",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no",
       "comment": "Systém povinného zdravotního pojištění by se měl opět vrátit do rukou státu, protože soukromé subjekty z něj pouze čerpají peníze pro své akcionáře. "
     },
     {
       "id": "senatni-2022-19-a-517013-38",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no",
       "comment": "Chcete snad trestat lidi, že nebydlí v Praze? "
     },
     {
       "id": "senatni-2022-19-a-517013-39",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes",
       "comment": "Působení na lidskou DNA je zhoubné, navíc chemická rezidua zůstávají v půdě a dostávají se do člověka. "
     },
     {
       "id": "senatni-2022-19-a-517013-40",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "yes",
       "comment": "Vždyť je to jedna velká zlodějna. Například nepoužívaný železniční přejezd na Mělníce vydělal radnici a spřáteleným firmám desítky milionů korun na porušení rychlosti, ačkoli tam vlak neviděli 30 let. "
     },
     {
       "id": "senatni-2022-19-a-517013-41",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes",
       "comment": "Velmi těžká otázka, protože můžeme hledat ztracené dítě nebo dezorientovaného seniora. Ovšem zneužívání databáze ze strany státní orgánů ke sledování obyvatelstva je dostatečný důvod ke zrušení. "
     },
     {
       "id": "senatni-2022-19-a-517013-42",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no",
       "comment": "Otázka je nesmyslná. Problém Ukrajiny je obyvatelstvo, které si nechá rozkrádat zemi mafiemi a tento systém je ve společnosti zakořeněn po staletí. Proto na Ukrajině nevznikla skutečná demokracie ani po osamostatnění od Sovětského Svazu. Nedostatek kontrolních mechanismů znemožňuje vybudování občanské společnosti a udržení bohatství v zemi. Tudíž by to byl poslední hřebíček do rakve Evropské unie. "
     },
     {
       "id": "senatni-2022-19-a-517013-43",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "Otázka je nesmyslná. Právě přístupové hovory do NATO zahájily současnou válku na Ukrajině. Mnohem výhodnější pro nás je, aby se Ukrajina stala neutrálním státem a nárazníkovým státem mezi Ruskou federací a státy Evropské unie. "
     },
     {
       "id": "senatni-2022-19-a-517013-44",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "Evropská unie udělá nejlépe, když nechá své členské země potichu si vyjednat lepší podmínky na ruský plyna vybudovat nové plynovody z Polska nebo Itálie."
     },
     {
       "id": "senatni-2022-19-a-517013-45",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no",
       "comment": "Nejsem spokojen, protože se věnuje genderovým bojům před ochranou občanů před chudobou a ekonomickými mafiemi. "
     },
     {
       "id": "senatni-2022-19-a-517013-46",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "no",
       "comment": "Můžete trestat, pokud na to máte sílu a prostředky. Každá sankce se nám zatím vrátila jako bumerang. Nevšiml jsem si, že bychom si od zavedení sankcí polepšili. Právě naopak. "
     },
     {
       "id": "senatni-2022-19-a-517013-47",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no",
       "comment": "Krym není samostatná země, tudíž mohou probíhat maximálně zdvořilostní návštěvy a projevy. "
     },
     {
       "id": "senatni-2022-19-a-517013-48",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "no",
       "comment": "Potírání domácího násilí dostatečně řeší platné české zákony. "
     },
     {
       "id": "senatni-2022-19-a-517013-49",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Celé je to nesmysl. Zakážeme uhlí, až papaláši přestanou létat letadly a používat služební limuzíny s osmiválci, které žerou jako ruský zájezd. "
     },
     {
       "id": "senatni-2022-19-a-517013-50",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "Je to samozřejmě nesmysl. Výroba a provoz elektromobilu násobně překračuje emise moderního spalovacího motoru. Proto klimatická neutralita je nebetyčná lež a podvod tisíciletí. "
     },
     {
       "id": "senatni-2022-19-a-517013-51",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no",
       "comment": "Česká republika by se neměla plést do války velmocí. My tak maximálně můžeme uznávat domovníky na Žižkově. Velká politika škodí našim obchodním zájmům ve Světě. "
     },
     {
       "id": "senatni-2022-19-a-517013-52",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Jednoznačně ano. Zatímco Brusel dál pojede rétoriku boje za Ukrajinu, kam dosud neposlal ani jednoho vojáka, my můžeme potichu dojednat výhodné ceny zemního plynu. Píšu to jako uživatel automobilu na slačený zemní plyn, kterému za dva roky trojnásobně zdražil provoz. "
     },
     {
       "id": "senatni-2022-19-a-517013-53",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes",
       "comment": "Finsko a Švédsko jsou nezávislé země a mně nepřísluší rozhodovat o nich, když nejsem občanem těchto států. "
     },
     {
       "id": "senatni-2022-19-a-517013-54",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "Zemědělství je za 30 let Sametu v katastrofálním stavu. Odmítám řešit velikost farem. Rád bych, aby vedle sebe existovaly malé i velké zemědělské podniky s rovnocenným přístupem k dotacím. "
     },
     {
       "id": "senatni-2022-19-a-517013-55",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "To je takový nesmysl, jako bezplatné zubní kartáčky. Psal jsem to jinde: zajistěte lidem stálou práci s takovým platem, aby nepotřebovali žádné sociální dávky. "
     },
     {
       "id": "senatni-2022-19-a-517013-56",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes",
       "comment": "Určitě ano, ale namísto nákupu předražených bytů od spekulantů by měl sám stavět nová státní sídliště na zelené louce a postavit byt dvakrát levněji, než by ho koupil na spekulativním trhu s nemovitostmi. "
     },
     {
       "id": "senatni-2022-19-a-517013-57",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know",
       "comment": "To přece není starost občana České republiky, ale plně to přísluší Ukrajincům. Nejsem Ukrajinec a proto odmítám radit, co mají udělat. "
     },
     {
       "id": "senatni-2022-19-a-517013-58",
       "candidate_id": "senatni-2022-19-c-517013",
-      "question_id": "senatni-2022-19-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Samozřejmě, co jiného s nimi? Zároveň by měl být takový dlužník zanesen do stálého seznamu, který mu znemožní čerpat veškeré státní dotace, požitky, nebo si vzít nový úvěr. "
     },
     {
       "id": "senatni-2022-19-a-999606-1",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Vlastnictví znamená mimo jiné neomezené panství nad věcí, tady právo i danou věc neužívat. Jestliže vlastník bytu dodržuje veškeré právní předpisy týkající se vlastnictví nemovitosti, zejména nemovitost udržuje, neobtěžuje okolí apod., pak není důvod zatěžovat majitele dalšími zvýšenými náklady v podobě zvýšených daní. Stát v posledních 30 letech zcela selhal v bytové politice a nyní se toto snaží vyřešit přenesením své povinnosti na soukromý sektor ať už v podobě regulovaného nájemného nebo v podobě povinného obsazení bytu. "
     },
     {
       "id": "senatni-2022-19-a-999606-2",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Stát v současnosti už reguluje velké množství aktivit lidí a podnikatelů. Navíc regulace nájemného u bytů byla zrušena celkem nedávno a důvodem pro její zrušení bylo mimo jiné, že se toto ukázalo jako neefektivní a diskriminační vůči majitelům bytů."
     },
     {
       "id": "senatni-2022-19-a-999606-3",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-4",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-5",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-6",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-999606-7",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-8",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Stát se ukázal a stále ukazuje jako špatný hospodář. Není problém ten, že by se vybíralo málo na daních, problémem je výdajová politika státu. Rozhodně jsem pro zachování stejné rovné daně pro všechny fyzické osoby."
     },
     {
       "id": "senatni-2022-19-a-999606-9",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Vědecké výzkumy ukázaly nespornou výhodu lečbou konopí u některých nemocí, proto by tato možnost neměla být lidem odpírána."
     },
     {
       "id": "senatni-2022-19-a-999606-10",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-11",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "no",
       "comment": "Jakékoliv zvýšení daňového zatížení se drříve či později vždy promítne do ceny pro konečného spotřebitele. Zvýšení daně těmto subjektům by mohlo přinést zpoplatnění dosud bezplatných služeb a navýšení již zpoplatněných služeb. Googlu ani Facebooku nelze upřít zásadní roli v komunikaci lidí ve vyhledávání informací nebo v inzerci. "
     },
     {
       "id": "senatni-2022-19-a-999606-12",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-999606-13",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "Kdo určí, co je \"fake news\"?"
     },
     {
       "id": "senatni-2022-19-a-999606-14",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes",
       "comment": "Veřejnoprávní vysílání by mělo být hrazeno přímo ze státního rozpočtu, nikoliv koncesionářskými poplatky. Výše příjmu veřejnoprávnícho vysílání absolutně neodpovídá kvalitě poskytovaných informací."
     },
     {
       "id": "senatni-2022-19-a-999606-15",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no",
       "comment": "Pracovní agentury tvoří nezanebatelnou část naší ekonomiky a jsou alternativou ke zkostnatělému zákoníku práce, jehož zvýšená ochrana zaměstnanců je mnohdy kontraproduktivní."
     },
     {
       "id": "senatni-2022-19-a-999606-16",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-17",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "no",
       "comment": "Věřitel musí mít možnost volby exekutora, jelikož se jedná o jeho peníze, které mu má exekutor vymoci. Je to podobné, jako kdyby stát nařizoval, v jaké bance mají mít lidé peníze."
     },
     {
       "id": "senatni-2022-19-a-999606-18",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "no",
       "comment": "Toto pravidlo by znamenalo omezení věřitele zvolit si exekutora k úspěšnému vymáhání dluhu, což by dostalo věřitele do horšího postavení než je dlužník a takto si právní stát nepředstavuji."
     },
     {
       "id": "senatni-2022-19-a-999606-19",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-20",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-21",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-22",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no",
       "comment": "ČR má teď opravdu mnoho jiných starostí a důležitějších věcí na vyřešení."
     },
     {
       "id": "senatni-2022-19-a-999606-23",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Možnost volit osobně a tajně je základní součástí volebního práva, které nesmí být nikdy v této podobě odňato, a to ani formou alternativy, resp. možnosti vybrat si, zda volit osobně, nebo online. Při online volbě nikdy nelze 100% zajistit, že volbu provede skutečně dotyčný volič."
     },
     {
       "id": "senatni-2022-19-a-999606-24",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-25",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Naopak. Každý člověk je unikátní a vzdělávací systém by se měl snažit odhalit v dětech, co nejdříve jejich nadání a talent, a ten dále rozvíjet.  Není nutné technicky zaměřeného člověka od základní školy trápit 2 cizími jazyky, pokud má problém už s jedním, ale spíše ho podpořit v tom, co ho zajímá, a tak prohloubit jeho znalosti. "
     },
     {
       "id": "senatni-2022-19-a-999606-26",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-27",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-28",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-29",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes",
       "comment": "Namísto účasti v NATO by ČR měla více spolupracovat s okolními zeměmi, nejen na společné obraně, ale i v ekonomických a hospodářských záležitostech."
     },
     {
       "id": "senatni-2022-19-a-999606-30",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-31",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-32",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no",
       "comment": "Zákony by měly být v první řadě v zájmu občanů ČR, případně v zájmu samotné ČR, aby se všem v naší republice žilo co nejlépe, abychom zde mohli pracovat, podnikat a vychovávat děti. Nevidím jediný důvod, proč by se u nás měl při schvalování zákonů brát ohled na rozvojové zěmě, když v nejlidnatějších zemí světa (Čína, Indie) se toto neděje. Vliv českých zákonů na rozvojové země není žádný, avšak je zásadní pro lidi žijící v ČR."
     },
     {
       "id": "senatni-2022-19-a-999606-33",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-34",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-35",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-999606-36",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-37",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-38",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-39",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-40",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-41",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-42",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-43",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-44",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "EU by měla co nejdříve zrušit sankce vůči Rusku a začít s Ruskem vyjádnávat o dodávkách a cenách plynu. Toto by bylo v zájmu občanů členských států EU."
     },
     {
       "id": "senatni-2022-19-a-999606-45",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-46",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-47",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-48",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-49",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-999606-50",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-999606-51",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-52",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-53",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "no",
       "comment": "Rozšiřování NATO dále na východ je v rozporu se závazkem z 90. let, který NATO dalo Rusku. "
     },
     {
       "id": "senatni-2022-19-a-999606-54",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-999606-55",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "Toto bych ponechala na rozhodnutí daného úřadu, rozhodně bych to nedávala do zákona."
     },
     {
       "id": "senatni-2022-19-a-999606-56",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no",
       "comment": "Další státní úřad znamená další výdaje státu. Navíc stát se už několikrát ukázal a stále ukazuje jako špatný hospodář. Víme jistě, že nový úřad by znamenal nemalé státní výdaje, ale nevíme, zda by jeho přínos tyto výdaje vyvážil."
     },
     {
       "id": "senatni-2022-19-a-999606-57",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-999606-58",
       "candidate_id": "senatni-2022-19-c-999606",
-      "question_id": "senatni-2022-19-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "no",
       "comment": "Znamenalo by to jasný signál, že nepracovat a mít dluhy v této zemi je lepší, než pracovat a řádně splácet své závazky."
     },
     {
       "id": "senatni-2022-19-a-107153-1",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-107153-2",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-3",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-4",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-5",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-6",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-7",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-8",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-9",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-10",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-11",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-12",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-13",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-14",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-15",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-16",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-17",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-18",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-19",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-107153-20",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-21",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-22",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-23",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-24",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-25",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-26",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-107153-27",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-28",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "Zatím ne"
     },
     {
       "id": "senatni-2022-19-a-107153-29",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-30",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-31",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-107153-32",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-33",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-34",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-35",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-36",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-37",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-38",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-39",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-40",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-41",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-42",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-43",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-44",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-107153-45",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-46",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-47",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-48",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-49",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-50",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-51",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-52",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-53",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-107153-54",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-55",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-56",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-57",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-107153-58",
       "candidate_id": "senatni-2022-19-c-107153",
-      "question_id": "senatni-2022-19-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-325120-1",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes",
       "comment": "Bydlení je základní lidská potřeba, byty nemají zůstávat prázdné, protože tak zbytečně roste cena nájemního i vlastnického bydlení. Mít byt jen jako investici se nemá vyplácet. "
     },
     {
       "id": "senatni-2022-19-a-325120-2",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes",
       "comment": "Bytová politika má zajišťovat také dostupnost různých typů bydlení v různých lokalitách. Např. i pracovníci služeb mají mít možnost bydlet v rozumné vzdálenosti od práce. Výše regulovaného nájemného by měla zajistit prostředky na opravy domů/bytů v odpovídajícím čase a přiměřený zisk. Regulace nájemného zákonem je možná. "
     },
     {
       "id": "senatni-2022-19-a-325120-3",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Výsledek občanského hlasování by musel následně projednat Parlament. "
     },
     {
       "id": "senatni-2022-19-a-325120-4",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Rychlovlaky jsou důležité pro zapojení ČR do mezinárodní dopravy, není dobrá vizitka, že vlaky s Berlína do Vídně dnes jezdí rychlejí kolem ČR než přes naše území. Je třeba udržovat také běžné rychlíkové a regionální tratě a pro lokální tratě vyvinout nový osobní vlak pro menší počet cestujících. "
     },
     {
       "id": "senatni-2022-19-a-325120-5",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "V řadě profesí není možné po lidech žádat, aby je při jejich fyzické i psychické náročnosti zvládali i ve vysokém věku. Navíc ne všem lidem roste naděje na dožití a život ve zdraví. Je třeba se zaměřit na zlepšování pracovních podmínek lidí. Průběžný důchodový systém navíc při doplnění daňových příjmů a jistých parametrických změnách může dobře fungovat dalších desetiletí. Odmítnout je třeba opakované pokusy pravice průběžný důchodový systém oslabit anebo privatizovat. "
     },
     {
       "id": "senatni-2022-19-a-325120-6",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "Jedinou možnou výjimkou je zajištění základního zásobování obyvatel suchou vodou. Pro ochranu před povodněmi je dostupná řada jiných řešení. "
     },
     {
       "id": "senatni-2022-19-a-325120-7",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes",
       "comment": "Lze využít norské anebo slovenské zkušenosti. Zejména nápojové plechovky jsou i potřebnou surovinou. "
     },
     {
       "id": "senatni-2022-19-a-325120-8",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes",
       "comment": "Daleko důležitější je zvýšení progrese u daně z příjmu právnických osob. "
     },
     {
       "id": "senatni-2022-19-a-325120-9",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-325120-10",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Potřeba je také lépe definovat, co je znásilnění. "
     },
     {
       "id": "senatni-2022-19-a-325120-11",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Je třeba, aby danily alespoň v takové výši jako jejich české protějšky. "
     },
     {
       "id": "senatni-2022-19-a-325120-12",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes",
       "comment": "Mají mít nejen odpovědnost, ale také kapacity, aby mohly své odpovědnosti dostát. Při komunikaci se sociálními sítěmi je často problém s určením a dostupností odpovědných osob."
     },
     {
       "id": "senatni-2022-19-a-325120-13",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-325120-14",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Veřejnoprávní vysílání je klíčové jako měřítko pro věrohodnost informací a jejich výklad. Neznám žádný účinnější nástroj. "
     },
     {
       "id": "senatni-2022-19-a-325120-15",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes",
       "comment": "Základem musí být, že agentury musí zajišťovat naprosto stejné pracovní podmínky, jako mají pracovníci ve stálém zaměstnání. Dosavadní systém umožňuje využívat agenturní pracovníky jako nekalou konkurenci a tím snižovat kvalitu pracovních podmínek obecně. "
     },
     {
       "id": "senatni-2022-19-a-325120-16",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes",
       "comment": "Jsem pro manželství osob stejného pohlaví, protože nepochybuji o jejich schopnosti milovat a vytvářet láskyplná životní partnerství. "
     },
     {
       "id": "senatni-2022-19-a-325120-17",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes",
       "comment": "Exekutor je soudní komisař, ne soukromý podnikatel, jde o to, aby tak byl také skutečně vnímán a pracoval tak. Místní příslušnost exekutorů znamená, že dlužník i věřitel budou mít místo k projednávání své věci v dosahu, kdo bude z Prahy v Praze, kdo bude z Mikulova v Mikulově. Zabrání také soutěžení mezi exekutory, kdo bude mít více zakázek. Když jde o exekuce, nejde o podnikání, ale výkon rozhodnutí soudu. Soudce si také nevybíráme. "
     },
     {
       "id": "senatni-2022-19-a-325120-18",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes",
       "comment": "Jeden dlužník - jeden exekutor, a to nejlépe exekutor z místa dlužníkova bydliště je důležitá změna, která posílí přehlednost systému a zlevní ho. "
     },
     {
       "id": "senatni-2022-19-a-325120-19",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "U veřejné výstavby by sociální byty nebo dostupné bydlení měly představovat převážnou část fondu. Součástí větších soukromých investic má být i výstavba prostor pro základní služby pro občany od pošty a obchodu po lékařskou ordinaci. "
     },
     {
       "id": "senatni-2022-19-a-325120-20",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes",
       "comment": "V současné době 75 procent lidí, kteří mají nárok na příspěvek na bydlení, o něj nepožádá, např. to by mělo aktivní vyhledávání potřebných odstranit. Sociální poradenství je třeba dovést i do malých obcí a k lidem, pro které je cesta do okresního města plánovanou celodenní záležitostí. "
     },
     {
       "id": "senatni-2022-19-a-325120-21",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no",
       "comment": "K regionálnímu aspektu by se mělo přihlížet, ale nelze to zformulovat jako mechanické pravidlo. Rozhodující je, aby služba, kterou státní instituce mají poskytovat, byla rovnorměrně rozmístěna v území. To v zásadě nesouvisí s tím, kde bude centrála. "
     },
     {
       "id": "senatni-2022-19-a-325120-22",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know",
       "comment": "Jistě je potřebné, abychom se účastnili projektů Evropské kosmické agentury a sledovat vývoj v této oblasti, ale kolonizace Marsu pro mě není priorita. "
     },
     {
       "id": "senatni-2022-19-a-325120-23",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Náš současný systém je dostatečně pružný a současně věrohodný, takto je přijímán a není důvod ho měnit. Laická kontrola prostřednictvím volebních komisí je bezpečná a pochopitelná. "
     },
     {
       "id": "senatni-2022-19-a-325120-24",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-325120-25",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes",
       "comment": "Jednotná škola je mj. základem úspěchu Finska. "
     },
     {
       "id": "senatni-2022-19-a-325120-26",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "Má být obecně inkluzivní, má pomáhat i nadaným žákům zapojovat se do kolektivu a motivovat je k učení. "
     },
     {
       "id": "senatni-2022-19-a-325120-27",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no",
       "comment": "Evropská unie je nástroj, jehož pomocí jsme schopni odpovídat na krize a výzvy, které přicházejí. Na národní úrovni téměř žádná z nich není řešitelná, bezpečnostními hrozbami počínaje a klimatickými změnami konče. "
     },
     {
       "id": "senatni-2022-19-a-325120-28",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "Možnosti intervencí národní banky prostřednictvím národní měny jsou omezené a zavedním eura bychom získali vliv na měnovou politiku hlavního měnového prostoru, který nás ovlivňuje. V průběhu času i tak dochází ke spontánní europeizaci. Neměla by být v pozici země platící eurem bez vlivu na měnovou politiku, jako je např. Černá Hora. "
     },
     {
       "id": "senatni-2022-19-a-325120-29",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-325120-30",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-325120-31",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes",
       "comment": "Je to otázka naší mezinárodní odpovědnosti, zaměřit se můžeme třeba specificky na zlepšování pracovních podmínek a podporu odborové organizovanosti, nemusíme se omezovat jen na již dnes realizované projekty např. podpory vzdělávání."
     },
     {
       "id": "senatni-2022-19-a-325120-32",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-325120-33",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-325120-34",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-325120-35",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "Důležitá je koordinace s našimi mezinárodními partnery a také otevřená diskuse o potřebách, které v EU/NATO má která armáda plnit a jaké vybavení k tomu např. potřebuje. "
     },
     {
       "id": "senatni-2022-19-a-325120-36",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Pokud by se k tomu přistoupilo, otevírá to naprosto neřešitelné etické otázky. Rovnost má být zajištěna i při početí. "
     },
     {
       "id": "senatni-2022-19-a-325120-37",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no",
       "comment": "Znamenalo by to vznik zdravotnictví, kde by rozhodovala peněženka nemocného. Smutným příkladem je stav české stomatologie. "
     },
     {
       "id": "senatni-2022-19-a-325120-38",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes",
       "comment": "Je specifická odborná otázka, co lze považovat za specializované, ale obecně lze říci, že vysoce specializované výkony vyžadují vysoce specializované týmy a není pravděpodobné, že by je bylo možné po území rovnoměrně rozptýlit. "
     },
     {
       "id": "senatni-2022-19-a-325120-39",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-325120-40",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-325120-41",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know",
       "comment": "V každém případě má být výrazně omezeno, jeho uplatnění by mělo být přísně upraveno zákonem. "
     },
     {
       "id": "senatni-2022-19-a-325120-42",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-325120-43",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know",
       "comment": "Otázka vstupu do NATO je otázka celkového uspořádání bezpečnostní situace po válce. "
     },
     {
       "id": "senatni-2022-19-a-325120-44",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes",
       "comment": "Je na místě co nejvíce omezit útočníkovi prostředky na vedení války. "
     },
     {
       "id": "senatni-2022-19-a-325120-45",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-325120-46",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes",
       "comment": "První podstatnou věcí je, že nesmí dosáhnout svých strategických cílů. "
     },
     {
       "id": "senatni-2022-19-a-325120-47",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-325120-48",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-325120-49",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "V dané situaci je to nerealistické, ale je třeba spalování uhlí co nejrychleji ukončit. V časovém okně 2033-2038. Konec konců většina současně těžených ložisek bude dotěžena nejdéla na přelomu padesátých let. "
     },
     {
       "id": "senatni-2022-19-a-325120-50",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes",
       "comment": "Je to racionální odpověď na klimatický rozvrat a jeho důsledky. "
     },
     {
       "id": "senatni-2022-19-a-325120-51",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-325120-52",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-325120-53",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-325120-54",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "Dotace by měly směřovat k udržitelnosti zemědělství, jak v ekologickém, tak produkčním smyslu. "
     },
     {
       "id": "senatni-2022-19-a-325120-55",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "yes",
       "comment": "Toaletní papír také poskytují zdarma. "
     },
     {
       "id": "senatni-2022-19-a-325120-56",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes",
       "comment": "Obecně je třeba posílit veřejné vlastnictví nájemních bytů, a to i na dalších úrovních. "
     },
     {
       "id": "senatni-2022-19-a-325120-57",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no",
       "comment": "Podmínky míru musí Ukrajina určit sama. "
     },
     {
       "id": "senatni-2022-19-a-325120-58",
       "candidate_id": "senatni-2022-19-c-325120",
-      "question_id": "senatni-2022-19-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Dluh nemá znamenat vyloučení člověka z běžného života a jeho vytlačení třeba do pololegálních forem práce. Pokud někdo do dluhů upadá opakovaně, je třeba se věnovat sociální práci a pomáhat mu dalším dluhům předcházet. "
     },
     {
       "id": "senatni-2022-19-a-388017-1",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-2",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-3",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Je nutné přijmout kvalitní zákon o obecném referendu, který by měl upravit podmínky vyhlášení referenda, okruh témat, které mohou nebo nemohou být předmětem referenda, platnost referenda a jeho účinnost apod."
     },
     {
       "id": "senatni-2022-19-a-388017-4",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-5",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "dont_know",
       "comment": "Je nutné důchodová reforma, která by měla být komplexní a nelze to redukovat na otázku zvýšení věku odchodu do důchodu."
     },
     {
       "id": "senatni-2022-19-a-388017-6",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-388017-7",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-8",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Měly by se odstranit mezery v daňových předpisech, které umožňují mnoha firmám si daně podstatně snížit nebo v ČR vůbec daně neplatit"
     },
     {
       "id": "senatni-2022-19-a-388017-9",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-10",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Měla by se rozšířit definice znásilnění, kdy nemusí jít přímo o násilí či pohrůžku násilí, a přesto jde o znásilnění."
     },
     {
       "id": "senatni-2022-19-a-388017-11",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-12",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-13",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-14",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-15",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-388017-16",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-17",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-18",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-19",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "U obecní a státní výstavby souhlasím, u soukromé výstavby by nemělo být toto pravidlo uzákoněno, ale mohlo by to být součástí dohody o výstavbě uzavřené s obcí."
     },
     {
       "id": "senatni-2022-19-a-388017-20",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-21",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-388017-22",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-388017-23",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-24",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-25",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-26",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-27",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-28",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-29",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-30",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-31",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-388017-32",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-388017-33",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-34",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-35",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-36",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-388017-37",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-38",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-39",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-388017-40",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-41",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-42",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-43",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-44",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-45",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-388017-46",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-47",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-48",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-49",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-50",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-19-a-388017-51",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-52",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-53",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-54",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-19-a-388017-55",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-56",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-57",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-19-a-388017-58",
       "candidate_id": "senatni-2022-19-c-388017",
-      "question_id": "senatni-2022-19-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     }
   ]

--- a/data/kalkulacka/senatni-2022/22.json
+++ b/data/kalkulacka/senatni-2022/22.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-22-c-972050",
       "name": "Bohumil Zoufalík",
       "type": "person",
-      "description": "Bohumil Zoufalík - DESCRIPTION",
+      "description": "Bohumil Zoufalík",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/Bohumil-Zoufal%C3%ADk-202898533222807/?_rdr"
@@ -491,7 +491,7 @@
         {
           "id": "senatni-2022-22-c-972050-p",
           "name": "Bohumil Zoufalík",
-          "description": "Bohumil Zoufalík - DESCRIPTION",
+          "description": "Bohumil Zoufalík",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/Bohumil-Zoufal%C3%ADk-202898533222807/?_rdr"
@@ -504,7 +504,7 @@
       "id": "senatni-2022-22-c-371682",
       "name": "Renata Chmelová",
       "type": "person",
-      "description": "Renata Chmelová - DESCRIPTION",
+      "description": "Renata Chmelová",
       "contacts": {
         "web": [
           {
@@ -528,7 +528,7 @@
         {
           "id": "senatni-2022-22-c-371682-p",
           "name": "Renata Chmelová",
-          "description": "Renata Chmelová - DESCRIPTION",
+          "description": "Renata Chmelová",
           "contacts": {
             "web": [
               {
@@ -556,7 +556,7 @@
       "id": "senatni-2022-22-c-549994",
       "name": "Jan Pirk",
       "type": "person",
-      "description": "Jan Pirk - DESCRIPTION",
+      "description": "Jan Pirk",
       "contacts": {
         "web": [
           {
@@ -578,7 +578,7 @@
         {
           "id": "senatni-2022-22-c-549994-p",
           "name": "Jan Pirk",
-          "description": "Jan Pirk - DESCRIPTION",
+          "description": "Jan Pirk",
           "contacts": {
             "web": [
               {
@@ -604,7 +604,7 @@
       "id": "senatni-2022-22-c-878037",
       "name": "Helena Leisztner",
       "type": "person",
-      "description": "Helena Leisztner - DESCRIPTION",
+      "description": "Helena Leisztner",
       "contacts": {
         "web": []
       },
@@ -612,7 +612,7 @@
         {
           "id": "senatni-2022-22-c-878037-p",
           "name": "Helena Leisztner",
-          "description": "Helena Leisztner - DESCRIPTION",
+          "description": "Helena Leisztner",
           "contacts": {
             "web": []
           },
@@ -624,7 +624,7 @@
       "id": "senatni-2022-22-c-762354",
       "name": "Štěpán Kavur",
       "type": "person",
-      "description": "Štěpán Kavur - DESCRIPTION",
+      "description": "Štěpán Kavur",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/stepan.kavur"
@@ -633,7 +633,7 @@
         {
           "id": "senatni-2022-22-c-762354-p",
           "name": "Štěpán Kavur",
-          "description": "Štěpán Kavur - DESCRIPTION",
+          "description": "Štěpán Kavur",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/stepan.kavur"
@@ -646,7 +646,7 @@
       "id": "senatni-2022-22-c-357855",
       "name": "Jiří Kobza",
       "type": "person",
-      "description": "Jiří Kobza - DESCRIPTION",
+      "description": "Jiří Kobza",
       "contacts": {
         "web": []
       },
@@ -654,7 +654,7 @@
         {
           "id": "senatni-2022-22-c-357855-p",
           "name": "Jiří Kobza",
-          "description": "Jiří Kobza - DESCRIPTION",
+          "description": "Jiří Kobza",
           "contacts": {
             "web": []
           },
@@ -667,1446 +667,1446 @@
     {
       "id": "senatni-2022-22-a-371682-1",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-2",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-3",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-4",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-5",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-6",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-7",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-8",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-9",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-10",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-11",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-12",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-13",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-14",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-15",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-16",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-17",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-18",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-19",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-20",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-21",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-22",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-23",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-24",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-25",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-26",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-27",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-28",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-29",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-30",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-31",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-32",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-33",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-34",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-35",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-36",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-37",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-38",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-39",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-40",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-41",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-42",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-43",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-44",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-45",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-46",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-47",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-48",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-49",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-50",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-51",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-52",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-53",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-54",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-55",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-371682-56",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-57",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-371682-58",
       "candidate_id": "senatni-2022-22-c-371682",
-      "question_id": "senatni-2022-22-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-1",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes",
       "comment": "Jednalo by se o další zdroj financování výstavby obecních bytů."
     },
     {
       "id": "senatni-2022-22-a-762354-2",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes",
       "comment": "Jsem pro zavedení podobně jako v jiných evropských vyspělých zemích (např. v Rakousku)."
     },
     {
       "id": "senatni-2022-22-a-762354-3",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Je třeba, aby veřejnost měla možnost rozhodovat o důležitých otázkách."
     },
     {
       "id": "senatni-2022-22-a-762354-4",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Všechny druhy dopravy by měly mít podporu."
     },
     {
       "id": "senatni-2022-22-a-762354-5",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Vzhledem ke zdravotnímu stavu populace nepřijatelné."
     },
     {
       "id": "senatni-2022-22-a-762354-6",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "Nové přehrady už není kde stavět."
     },
     {
       "id": "senatni-2022-22-a-762354-7",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-8",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes",
       "comment": "Základní prvek solidarity."
     },
     {
       "id": "senatni-2022-22-a-762354-9",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-762354-10",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-762354-11",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Vydělávají u nás, proto je spravedlivé je zdanit."
     },
     {
       "id": "senatni-2022-22-a-762354-12",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-13",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-14",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes",
       "comment": "Aby byla zaručena nezávislost, nelze je financovat z vládních peněz."
     },
     {
       "id": "senatni-2022-22-a-762354-15",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes",
       "comment": "Je nutné, aby byly pod větší kontrolou."
     },
     {
       "id": "senatni-2022-22-a-762354-16",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know",
       "comment": "Ve svazku by páry měly mít stejná práva, ale nemohou se nazývat manželství."
     },
     {
       "id": "senatni-2022-22-a-762354-17",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-18",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-19",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Nutná podmínka pro řešení bydlení u nás."
     },
     {
       "id": "senatni-2022-22-a-762354-20",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Je však nutno o dávkách srozumitelně komunikovat."
     },
     {
       "id": "senatni-2022-22-a-762354-21",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-762354-22",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-762354-23",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "To by voličům usnadnilo život."
     },
     {
       "id": "senatni-2022-22-a-762354-24",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no",
       "comment": "Všem stejné podmínky, v případě potřeby mohou podporovat firmy/zaměstnavatelé."
     },
     {
       "id": "senatni-2022-22-a-762354-25",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "1. stupeň společně, od 2. stupně rozdělení podle dalšího studia."
     },
     {
       "id": "senatni-2022-22-a-762354-26",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no",
       "comment": "Pro inkluzi musí být vytvořeny podmínky, které zatím nejsou."
     },
     {
       "id": "senatni-2022-22-a-762354-27",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no",
       "comment": "Pozitiva převažují nad negativy."
     },
     {
       "id": "senatni-2022-22-a-762354-28",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "Ano, ale až to bude výhodné."
     },
     {
       "id": "senatni-2022-22-a-762354-29",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-762354-30",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-762354-31",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know",
       "comment": "ČR podporuje v rámci svých možností."
     },
     {
       "id": "senatni-2022-22-a-762354-32",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-33",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Stávající systém plní svoji funkci."
     },
     {
       "id": "senatni-2022-22-a-762354-34",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-35",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "dont_know",
       "comment": "Je však třeba dodržet pravidla NATO."
     },
     {
       "id": "senatni-2022-22-a-762354-36",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-762354-37",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-38",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-39",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-40",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "dont_know",
       "comment": "Pouze a místech, nutných kvůli bezpečnosti."
     },
     {
       "id": "senatni-2022-22-a-762354-41",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-42",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes",
       "comment": "Ano, ale musí projít stejným procesem přijetí."
     },
     {
       "id": "senatni-2022-22-a-762354-43",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "To by bylo velké riziko."
     },
     {
       "id": "senatni-2022-22-a-762354-44",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-45",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-46",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-47",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes",
       "comment": "Jednat je třeba s každým."
     },
     {
       "id": "senatni-2022-22-a-762354-48",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-49",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Vzhledem k akutní energetické potřebě ne."
     },
     {
       "id": "senatni-2022-22-a-762354-50",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-51",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-762354-52",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "dont_know",
       "comment": "Vyplyne to z naší potřeby nebo nutnosti."
     },
     {
       "id": "senatni-2022-22-a-762354-53",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-762354-54",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "Měly by být pro všechny podle jednotných pravidel."
     },
     {
       "id": "senatni-2022-22-a-762354-55",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-762354-56",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-762354-57",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know",
       "comment": "To záleží na Ukrajině a jejím stanovisku i na výsledku vyjednávání."
     },
     {
       "id": "senatni-2022-22-a-762354-58",
       "candidate_id": "senatni-2022-22-c-762354",
-      "question_id": "senatni-2022-22-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Je však třeba tuto situaci řešit adekvátními nástroji (oddlužení, insolvence, osobní finanční plán)."
     },
     {
       "id": "senatni-2022-22-a-878037-1",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "dont_know",
       "comment": "Jedná se většinou o majitele, kteří dlouhodobě na nákup bytu šetřili, mají hypotéky nebo zdědili od svých nejbližších, případně již zajistili své děti do budoucna.. Starají se o budoucnost rodiny. Lepší je vždy motivovat než trestat. Proto by bylo vhodnější daň z nemovitosti odpustit, v případě dlouhodobého  pronájmu. Majitelé platí a budou platit daň z příjmu. \nV případě dlouhodobých prázdných bytů ve vlastnictví právnických osob - při vlastnictví více bytů než 2 by bylo vhodné zdanit více s dalším koeficientem daně z nemovitosti až do výše 5."
     },
     {
       "id": "senatni-2022-22-a-878037-2",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "dont_know",
       "comment": "U obecních a státních ano, u soukromých majitelů ne. Je zapotřebí okamžitě nastartovat masivní výstavbu obecních nájemních bytů s regulovaným nájmem jako ve Vídni. "
     },
     {
       "id": "senatni-2022-22-a-878037-3",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Možnost ano, povinnost ne."
     },
     {
       "id": "senatni-2022-22-a-878037-4",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes",
       "comment": "Komfortní rychlovlaky s dostupnou cenou jízdného po vzoru mnoha vyspělých zemí - Francie, Švýcarsko, Jižní Korea - razantně uleví silniční dopravě."
     },
     {
       "id": "senatni-2022-22-a-878037-5",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-6",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know",
       "comment": "Domnívám se, že z důvodu klimatických změn -např. sucho, povodně - bude zadržování a regulace vody v přírodě pro ČR důležité. Pro zvýšení produkce elektřiny obdobně. Kombinovat s tvorbou menších jezer a vodních nádrží."
     },
     {
       "id": "senatni-2022-22-a-878037-7",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no",
       "comment": "Ne, existuje tříděný odpad."
     },
     {
       "id": "senatni-2022-22-a-878037-8",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Je to populistický pokus. Progrese daně z příjmu již existuje a u nás je účinná. Prosím spočítat daně u mzdy 30.000 Kč a 70.000Kč a rozdíl je jednoznačný. "
     },
     {
       "id": "senatni-2022-22-a-878037-9",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-878037-10",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-878037-11",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-878037-12",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-878037-13",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-878037-14",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Ale ani více."
     },
     {
       "id": "senatni-2022-22-a-878037-15",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-878037-16",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-878037-17",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-878037-18",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-19",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-878037-20",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-21",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-22",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-23",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Obtížná kontrola pravosti volebního hlasu."
     },
     {
       "id": "senatni-2022-22-a-878037-24",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-878037-25",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes",
       "comment": "Podporuje sociální a společenské vnímaní kolektivu. Talentované děti využívají vedle toho množství dalších vzdělávacích nabídek."
     },
     {
       "id": "senatni-2022-22-a-878037-26",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-878037-27",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-28",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "Ne teď. EU prochází turbulentním obdobím."
     },
     {
       "id": "senatni-2022-22-a-878037-29",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-30",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-878037-31",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "Dle názoru mnoha zemí ČR pomáhá na maximum."
     },
     {
       "id": "senatni-2022-22-a-878037-32",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-878037-33",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-34",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-878037-35",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-36",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-37",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "dont_know",
       "comment": "Soukromé zdravotní  pojištění již existuje."
     },
     {
       "id": "senatni-2022-22-a-878037-38",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-878037-39",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-878037-40",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-41",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-878037-42",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-878037-43",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-44",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "Když EU zastropuje cenu ruského plynu při nákupu Rusko již sdělilo, že nebude dodávat. Zastropovat konečnou cenu je nutné směrem k občanům, firmám a institucím."
     },
     {
       "id": "senatni-2022-22-a-878037-45",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-46",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-878037-47",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-48",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-878037-49",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-50",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-51",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-52",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Jako ostatní státy EU."
     },
     {
       "id": "senatni-2022-22-a-878037-53",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-878037-54",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-878037-55",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-878037-56",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes",
       "comment": "Jenom pro byty s regulovaným nájmem."
     },
     {
       "id": "senatni-2022-22-a-878037-57",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know",
       "comment": "Rozhodnutí je výsostným právem Ukrajiny. "
     },
     {
       "id": "senatni-2022-22-a-878037-58",
       "candidate_id": "senatni-2022-22-c-878037",
-      "question_id": "senatni-2022-22-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-1",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-2",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-549994-3",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-4",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-549994-5",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-6",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-549994-7",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-8",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-9",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-549994-10",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-11",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-549994-12",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-13",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-14",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-549994-15",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-16",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know",
       "comment": "Myslím, že z právního hlediska by svazek stejnopohlavních partnerů měl opravdu být na právní úrovni svazku muže a ženy. „Manželství“ bych ale chtěl zachovat jako svazek muže a ženy, protože z mého pohledu vytváří rodinu."
     },
     {
       "id": "senatni-2022-22-a-549994-17",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-18",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-19",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-20",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-21",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-549994-22",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-23",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "dont_know",
       "comment": "V první řadě je potřeba prosadit korespondenční volbu. A posléze se můžeme zabývat i jinými způsoby voleb. "
     },
     {
       "id": "senatni-2022-22-a-549994-24",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-25",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-26",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-549994-27",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-28",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "Nicméně je potřeba zvažovat hospodářskou situaci a plnění Maastrichtských kritérií. "
     },
     {
       "id": "senatni-2022-22-a-549994-29",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no",
       "comment": "Na Ukrajině vidíme názorně důležitost a smysluplnost institucí, jako je právě NATO. "
     },
     {
       "id": "senatni-2022-22-a-549994-30",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-31",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-32",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-33",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-549994-34",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-35",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "Česká republika by měla plnit svůj vlastní závazek, který dala v roce 2014 vůči NATO na summitu ve Walesu, tedy že bude do armády investovat 2 procenta svého HDP."
     },
     {
       "id": "senatni-2022-22-a-549994-36",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-549994-37",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-38",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-39",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-549994-40",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-41",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-549994-42",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-43",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-44",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-45",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-46",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-47",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-549994-48",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-49",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-549994-50",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-22-a-549994-51",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-52",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-53",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-54",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-22-a-549994-55",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-56",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-57",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-22-a-549994-58",
       "candidate_id": "senatni-2022-22-c-549994",
-      "question_id": "senatni-2022-22-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     }
   ]

--- a/data/kalkulacka/senatni-2022/25.json
+++ b/data/kalkulacka/senatni-2022/25.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-25-c-842348",
       "name": "Jaroslav Dvořák",
       "type": "person",
-      "description": "Jaroslav Dvořák - DESCRIPTION",
+      "description": "Jaroslav Dvořák",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/JarDvorak"
@@ -491,7 +491,7 @@
         {
           "id": "senatni-2022-25-c-842348-p",
           "name": "Jaroslav Dvořák",
-          "description": "Jaroslav Dvořák - DESCRIPTION",
+          "description": "Jaroslav Dvořák",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/JarDvorak"
@@ -504,7 +504,7 @@
       "id": "senatni-2022-25-c-377248",
       "name": "Petr Pavlík",
       "type": "person",
-      "description": "Petr Pavlík - DESCRIPTION",
+      "description": "Petr Pavlík",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/petr.pavlik.3154",
@@ -515,7 +515,7 @@
         {
           "id": "senatni-2022-25-c-377248-p",
           "name": "Petr Pavlík",
-          "description": "Petr Pavlík - DESCRIPTION",
+          "description": "Petr Pavlík",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/petr.pavlik.3154",
@@ -530,7 +530,7 @@
       "id": "senatni-2022-25-c-678819",
       "name": "Jiří Pavel Pešek",
       "type": "person",
-      "description": "Jiří Pavel Pešek - DESCRIPTION",
+      "description": "Jiří Pavel Pešek",
       "contacts": {
         "web": []
       },
@@ -538,7 +538,7 @@
         {
           "id": "senatni-2022-25-c-678819-p",
           "name": "Jiří Pavel Pešek",
-          "description": "Jiří Pavel Pešek - DESCRIPTION",
+          "description": "Jiří Pavel Pešek",
           "contacts": {
             "web": []
           },
@@ -550,7 +550,7 @@
       "id": "senatni-2022-25-c-813666",
       "name": "Jiří Růžička",
       "type": "person",
-      "description": "Jiří Růžička - DESCRIPTION",
+      "description": "Jiří Růžička",
       "contacts": {
         "web": [
           {
@@ -570,7 +570,7 @@
         {
           "id": "senatni-2022-25-c-813666-p",
           "name": "Jiří Růžička",
-          "description": "Jiří Růžička - DESCRIPTION",
+          "description": "Jiří Růžička",
           "contacts": {
             "web": [
               {
@@ -594,7 +594,7 @@
       "id": "senatni-2022-25-c-426167",
       "name": "Petr Hannig",
       "type": "person",
-      "description": "Petr Hannig - DESCRIPTION",
+      "description": "Petr Hannig",
       "contacts": {
         "web": []
       },
@@ -602,7 +602,7 @@
         {
           "id": "senatni-2022-25-c-426167-p",
           "name": "Petr Hannig",
-          "description": "Petr Hannig - DESCRIPTION",
+          "description": "Petr Hannig",
           "contacts": {
             "web": []
           },
@@ -614,7 +614,7 @@
       "id": "senatni-2022-25-c-630845",
       "name": "Lenka Helena Koenigsmark",
       "type": "person",
-      "description": "Lenka Helena Koenigsmark - DESCRIPTION",
+      "description": "Lenka Helena Koenigsmark",
       "contacts": {
         "web": [
           {
@@ -638,7 +638,7 @@
         {
           "id": "senatni-2022-25-c-630845-p",
           "name": "Lenka Helena Koenigsmark",
-          "description": "Lenka Helena Koenigsmark - DESCRIPTION",
+          "description": "Lenka Helena Koenigsmark",
           "contacts": {
             "web": [
               {
@@ -666,7 +666,7 @@
       "id": "senatni-2022-25-c-188521",
       "name": "Petr Vacek",
       "type": "person",
-      "description": "Petr Vacek - DESCRIPTION",
+      "description": "Petr Vacek",
       "contacts": {
         "web": []
       },
@@ -674,7 +674,7 @@
         {
           "id": "senatni-2022-25-c-188521-p",
           "name": "Petr Vacek",
-          "description": "Petr Vacek - DESCRIPTION",
+          "description": "Petr Vacek",
           "contacts": {
             "web": []
           },
@@ -686,7 +686,7 @@
       "id": "senatni-2022-25-c-290001",
       "name": "Dana Balcarová",
       "type": "person",
-      "description": "Dana Balcarová - DESCRIPTION",
+      "description": "Dana Balcarová",
       "contacts": {
         "web": [
           {
@@ -706,7 +706,7 @@
         {
           "id": "senatni-2022-25-c-290001-p",
           "name": "Dana Balcarová",
-          "description": "Dana Balcarová - DESCRIPTION",
+          "description": "Dana Balcarová",
           "contacts": {
             "web": [
               {
@@ -731,2256 +731,2256 @@
     {
       "id": "senatni-2022-25-a-630845-1",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Spíše ne. Ale nutno také dodat, že vzhledem k rozšířenému skupování nemovitostí ze strany zahraničních investorů by bylo dobře otevřít otázku, zda nezavést zdanění jejich vlastnictví většího počtu nemovitostí, které omezuje dostupnost pro české občany. Další otázkou je pak fungování platforem typu AirBnB, které by bylo záhodno regulovat, protože nejen že vysávájí realitní trh, ale také to slouží k obcházení pravidel pro hotely a podobná zařízení krátkodobého ubytování a často je to v rozporu s kvalitou života místních."
     },
     {
       "id": "senatni-2022-25-a-630845-2",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-3",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-4",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-5",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "yes",
       "comment": "Bohužel se tomuto nepopulárnímu kroku nevyhneme což je dáno především stárnoucí populací."
     },
     {
       "id": "senatni-2022-25-a-630845-6",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-25-a-630845-7",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-8",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-9",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-10",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-11",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-12",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-13",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-14",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-15",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-25-a-630845-16",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-17",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-18",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-19",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-20",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-21",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-22",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-23",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-24",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-25",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-26",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-27",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-28",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-29",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-30",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-31",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-32",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-33",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-25-a-630845-34",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-35",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-36",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-37",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-38",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-39",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-40",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-41",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-42",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-43",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-44",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-45",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-46",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-47",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-48",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-49",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-50",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-51",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-52",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-53",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-54",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-55",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-630845-56",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-57",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-630845-58",
       "candidate_id": "senatni-2022-25-c-630845",
-      "question_id": "senatni-2022-25-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-426167-1",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes",
       "comment": "Tyto dlouhodobě prázdné byty jsou mnohdy majetkem zahraničních vlastníků, které si je pořídili jako investici."
     },
     {
       "id": "senatni-2022-25-a-426167-2",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "dont_know",
       "comment": "Někteří majitelé domů jsou rozumní a vědí, když nastaví nájemné pro nájemce vysoké, tak příjdou o nájemníka a pokud je nájemník slušný, tak slušného nájemníka aby majitel domu pohledal."
     },
     {
       "id": "senatni-2022-25-a-426167-3",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Referendum o jakýchkoliv otázkách. Občané musí mít možnost rozhodnout o své budoucnosti. "
     },
     {
       "id": "senatni-2022-25-a-426167-4",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "dont_know",
       "comment": "I dálnice jsou důležité."
     },
     {
       "id": "senatni-2022-25-a-426167-5",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Senioři by měli mít možnost, prožít svůj důchodový věk aktivně."
     },
     {
       "id": "senatni-2022-25-a-426167-6",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know",
       "comment": "Spíše si myslím, že ano. Cenná surovina voda nám odtéká často nevyužita z ČR pryč. Je však třeba mít souhlas s obyvateli budoucích zaplavených oblastí."
     },
     {
       "id": "senatni-2022-25-a-426167-7",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no",
       "comment": "Jsem zásadně proti Green Dealu, který ničí Českou republiku a ostatně i celou  Evropskou unii. Oceány zamořené plovoucími ostrovy z plastů rozhodně nejsou u břehů Evropy, ale naopak Asie, Afriky a Jižní Ameriky. Pokud se tam nezmění vnímání v tomto směru, nemá cenu abychom my  v Evropě takové záležitosti zaváděli."
     },
     {
       "id": "senatni-2022-25-a-426167-8",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "dont_know",
       "comment": "Dřív jsem byl rozhodně proti. Ovšem nyní je zcela jiná situace. Příjmy některých firem jsou vzhledem k inflaci nespravedlivě vysoké. Je třeba jiná speciální daň na tyto nezasloužené příjmy. Ale obecná progresivita spíše NE."
     },
     {
       "id": "senatni-2022-25-a-426167-9",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know",
       "comment": "Poskytneš prstíček a za chvíli to bude i pro tvrdší drogy."
     },
     {
       "id": "senatni-2022-25-a-426167-10",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "no",
       "comment": "Je to diskutabilní. V mnoha případech dochází k zneužívání tohoto institutu, neboť se dnes jako znásilnění považuje cokoliv, co dříve znásilněním nebylo. Například některé metody trenérů ve sportu, aby ze svých svěřenkyň dostali maximum pro jejich sportovní výkony. Dále se zneužívá tento institut v manželstvích, která se rozpadají. A bývá to zneužíváno různými zlatokopkami, kdy se za znásilnění považuje i bývalý dobrovolný sex. Nejsem si v tomto případě vědom, zda v případě znásilnění se vším, co se dnes pod tímto pojmem rozumí ( i bez koitu) nemá obviněný povinnost dokazovat nevinu, či je to jako v jiných trestních činech, že platí presumpce neviny."
     },
     {
       "id": "senatni-2022-25-a-426167-11",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-25-a-426167-12",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Jsem proti jakékoliv cenzuře, to jest i na internetu."
     },
     {
       "id": "senatni-2022-25-a-426167-13",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "Kdo určí, co je falešná správa. Jak se říká, je třeba počkat půl roku a z fake news se stane relevantní, pravdivá zpráva. "
     },
     {
       "id": "senatni-2022-25-a-426167-14",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Ale rozhodně by mělo být pravdivé a ne stranící jakékoliv politické myšlence či vládní politice. Katastrofální je v tomto případě ČT a její pořady 168 hodin, Reportéři, Newsroom a Václav Moravec. Ten je ovšem také v současné době neskonale zastaralý a nudný v porovnání s CNN Prima News."
     },
     {
       "id": "senatni-2022-25-a-426167-15",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes",
       "comment": "Vraťme věci do řádných kolejí."
     },
     {
       "id": "senatni-2022-25-a-426167-16",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Registrované partnerství, to ano, ale svátost manželská je institut původně zamýšlený jako plození a výchovu dětí, budoucích generací pro republiku."
     },
     {
       "id": "senatni-2022-25-a-426167-17",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes",
       "comment": "Exekuce nesmí být pro někoho kšeft a pro druhého životní katastrofa."
     },
     {
       "id": "senatni-2022-25-a-426167-18",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes",
       "comment": "Samozřejmě."
     },
     {
       "id": "senatni-2022-25-a-426167-19",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Ale musí to být pro řádné občany, kteří se dostali do platebních neschopností vlivem nestoudných cen elektřiny, plynu a tepla a základních potravin. Např. vdovy, vdovci a pod."
     },
     {
       "id": "senatni-2022-25-a-426167-20",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes",
       "comment": "Rozhodně ano. Slušní lidé, kteří se dostanou do potíží, se za svou neschopnost dostát všem platbám za elektřinu, plyn, nájemné, se za tento fakt stydí, protože celý život vše řádně a včas platili."
     },
     {
       "id": "senatni-2022-25-a-426167-21",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no",
       "comment": "Zvýší to náklady a teď je doba, kdy je potřeba nevynakládat zbytečné výdaje."
     },
     {
       "id": "senatni-2022-25-a-426167-22",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no",
       "comment": "Starejme se radši o to, abychom v zimě měli čím topit a nezabývat se takovými hloupostmi."
     },
     {
       "id": "senatni-2022-25-a-426167-23",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Zachovejme takovou volbu, která je svobodná a dostupná i pro starší spoluobčany, aniž by museli žádat o asistenci své potomky, kteří by je často nutili volit proti jejich vlastnímu přesvědčení. Viz akce \" přemluv bábu\"."
     },
     {
       "id": "senatni-2022-25-a-426167-24",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "Těch genderových odborníků, politických geografů, politologů a dalších \"nezbytných\" profesí, které jsou houfně využívány ve veřejnoprávních médiích, aby vůbec měli tito absolventi jakoukoliv činnost a v podstatě ovlivňují názory lidí podle svých politických preferencí, je nadbytek. I nadbytek právníků je zbytečný. Právníci vyhledávají ne řešení, která by pomohla lidem, ale naopak jim jde o zdroje jejich i tak dost vysokých příjmů."
     },
     {
       "id": "senatni-2022-25-a-426167-25",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Každé dítě je specifické svými vlohami pro rozdílnou životní dráhu."
     },
     {
       "id": "senatni-2022-25-a-426167-26",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no",
       "comment": "Inkluze ničí naše školství. Měli jsme a stále máme výborné speciální školy a vysokoškolsky vyškolené pedagogy pro tento obor. Naše speciální školství bylo vzorem pro jiné státy. Nepřejímejme ze západu všechno, když jsem v něčem lepší."
     },
     {
       "id": "senatni-2022-25-a-426167-27",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "dont_know",
       "comment": "Velké státy EU nás nutí, abychom se vzdali posledních pravomocí  a práva veta. To by znamenalo konec samostatného státu a stali bychom se kolonií západních států. Na druhou stranu schengenský prostor je praktický pro obyčejné lidi ohledně cestování např. do letních destinací. EU musí opustit nesmyslný Green Deal. Dřív jsem byl spíše nakloněn zůstat v EU, nyní spíše odejít, protože se EU stává něčím, co už jsme zažili a nechceme to zažívat znovu. Evropská unie je nyní pro nás brzdou a nebezpečím. Lépe být jako Švýcarsko. Schengen ano, jinak samostatnost a svoboda."
     },
     {
       "id": "senatni-2022-25-a-426167-28",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "Rozhodně NE. Samostatná měna znamená samostatnost pro stát."
     },
     {
       "id": "senatni-2022-25-a-426167-29",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes",
       "comment": "Byli jsme nadšeni ze slov Václava Havla v roce 1990, že ČSR musí být neutrální. Neutralita je to nejlepší řešení. Podívejme se na prosperitu neutrálního Švýcarska, ale i Rakouska. Účast v NATO je hrozně drahá a ne, jak neustále vtloukají do hlavy, že by samostatnost by byla dražší.\n"
     },
     {
       "id": "senatni-2022-25-a-426167-30",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no",
       "comment": "Místo ČR je ve středoevropských státech. Západ nás stále vnímá jako jakýsi přívěsek, který je tak jenom dobrý jako levná montovna a odbytiště nadbytečných potravin. Ideální byl Visegrád ( do té doby než začal válka na Ukrajině)"
     },
     {
       "id": "senatni-2022-25-a-426167-31",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "Vláda ČR by rozhodně měla více podporovat naše občany v této době katastrofální inflace a astronomických cen energií."
     },
     {
       "id": "senatni-2022-25-a-426167-32",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes",
       "comment": "Asi ano. Protože ony ještě neztratily zdravý rozum a kašlou na nějakou ekologii, jde jim o prosperitu a ne o zelenou ideologii a Evropu ničící Green Deal."
     },
     {
       "id": "senatni-2022-25-a-426167-33",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "A zároveň nějakým relevantním způsobem ukončit současnou politiku k imigrantům z Ukrajiny. Buďto jim zde umožnit pracovat a žít jako to fungovalo před válkou, to jest, jak to měli v ČR Ukrajinci před napadením Ukrajiny Ruskem, bez současných speciálních benefitů. Nebo, pokud zde nebudou mít práci a prostředky k žití, tak jen poslat zpět. Stejně je jich většina z válkou nezasažených oblastí. S ukrajinskými pracovníky a pracovnicemi jsme byli zde nadmíru spokojeni, pro jejich pracovitost a skromnost. Ten nadměrný nárůst imigrantů z UA a hlavně rozdílný přístup k těm, co tu pracovali a těm, co si přijeli pouze pro podporu, nadělal dost zlé krve v náhledu našich občanů k, do této doby, většinou sympatickým zde žijícím a pracujícím, či podnikajícím Ukrajincům."
     },
     {
       "id": "senatni-2022-25-a-426167-34",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes",
       "comment": "Samozřejmě, to budu neustále prosazovat i kdybychom vystoupili z EU a NATO."
     },
     {
       "id": "senatni-2022-25-a-426167-35",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no",
       "comment": "Nejbezpečnějším a nejstabilnějším státem Střední Ameriky je Kostarika, demokracie od roku 1902. Jediný vojenský puč byl v roce 1948, trval pouze dva měsíce a jeho následkem bylo zrušení armády a od roku 1949 v Ústavě Kostariky je zákaz mít armádu a od té doby nebyl žádný vojenský puč. Volby jsou povinné pro všechny občany.  Prezident může vykonávat funkci pouze jedno volební období, myslím že 4leté."
     },
     {
       "id": "senatni-2022-25-a-426167-36",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Nějak příliš si hrajeme na Stvořitele. Pokud se umělé oplodnění podaří a dítě bude zdravé, tak by rodiče měli děkovat Bohu za ten zázrak a nevymýšlet si další zásahy do přirozeného průběhu těhotenství.\n"
     },
     {
       "id": "senatni-2022-25-a-426167-37",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "dont_know",
       "comment": "Obávám se, že by to rozevřelo nůžky mezi občany."
     },
     {
       "id": "senatni-2022-25-a-426167-38",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know",
       "comment": "Neměnit fungující systémy."
     },
     {
       "id": "senatni-2022-25-a-426167-39",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know",
       "comment": "Je třeba zvážit rizika a přínos."
     },
     {
       "id": "senatni-2022-25-a-426167-40",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "dont_know",
       "comment": "Toho sledování je někdy až příliš. Ovšem je třeba zase nějaká disciplína. Řidiči, zvláště ti mladí, bývají často bezohlední."
     },
     {
       "id": "senatni-2022-25-a-426167-41",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes",
       "comment": "Nechci zde velkého bratra, tak jak je to v Číně."
     },
     {
       "id": "senatni-2022-25-a-426167-42",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no",
       "comment": "proč by měla, když nesplňuje ani jedno z kritérií."
     },
     {
       "id": "senatni-2022-25-a-426167-43",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "Nechci třetí světovou válku."
     },
     {
       "id": "senatni-2022-25-a-426167-44",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "To by znamenalo vůbec žádný plyn z Ruska a katastrofu pro všechny aspekty našeho života. Nesouhlasím s válkou na Ukrajině a se vpádem RF ( i když je třeba brát v potaz i předchozí signály, které k tomu vpádu vedly) na Ukrajinské území. Ale veškeré sankce neničí Rusko, ale  EU a hlavně ČR, které je jako bývalá plynová velmoc Evropy na ruském plynu plně závislá."
     },
     {
       "id": "senatni-2022-25-a-426167-45",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes",
       "comment": "Oceňuji jeho nestrannost a v podstatě hrdinství odolávat neustálým útokům médií."
     },
     {
       "id": "senatni-2022-25-a-426167-46",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "no",
       "comment": "Ty následky neseme my. Rusko ne. Rubl stoupá. Inkaso za plyn a ropu je pro Rusko neustále vyšší a vyšší. Musíme si toto uvědomit. politický systém v Rusku je imunní proti jakýmkoliv občanským nepokojům. Můžeme změnit imperiální choutky RF spíše spoluprací s ním, než s neustálým zvyšováním sankcí, které dopadají hlavně jako bumerang zpět na EU a na občany RF, kteří v podstatě s V.V. Putinem nesouhlasí. Nemohou cestovat do EU. Ruská vládnoucí třída je tzv. za vodou a nějaké sankce se jich netýkají. Tak místo na francouzskou Riviéru, budou jezdit na tureckou Riviéru. či do Spojených arabských emirátů, Ománu atd. Chtělo by to špetku zdravého rozumu a výměnu na špici EU."
     },
     {
       "id": "senatni-2022-25-a-426167-47",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "dont_know",
       "comment": "Proč by měli vyjednávat. Krym je nedůležitý. Je důležitý pouze pro ruskou černomořskou flotilu a z Krymu je pro Rusko nezbytný pouze Sevastopol (vojenství) a Jalta (rekreace). Jinak je Krym pro RF v podstatě asi jenom přítěží."
     },
     {
       "id": "senatni-2022-25-a-426167-48",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "no",
       "comment": "Je to zneužitelné. Máme dostatečné a účinné zákonodárství, nemusíme přejímat něco, co má zase v podstatě jiný cíl, než chránit ženy před domácím násilím."
     },
     {
       "id": "senatni-2022-25-a-426167-49",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "V současné situaci budeme ještě za uhlí velice rádi, abychom v zimě nezmrzli, nemocnice mohly fungovat, protože bez tepla nemohou atd. atd."
     },
     {
       "id": "senatni-2022-25-a-426167-50",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "Nepodporuji šílené nápady, když ostatní svět si pojede podle svých not. Na celosvětovém znečištění se EU podílí pouze 8%. A ta mantra klimatické neutrality EU je v tomto světle naprosto směšná."
     },
     {
       "id": "senatni-2022-25-a-426167-51",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "dont_know",
       "comment": "Co je nám do Krymu. To ať si vyřeší ti, co tam bydlí. a oni si to již vyřešili referendem."
     },
     {
       "id": "senatni-2022-25-a-426167-52",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Dost ideologie Je potřeba jednat ve prospěch našich občanů, tak jak to dělá Viktor Orbán v Maďarsku."
     },
     {
       "id": "senatni-2022-25-a-426167-53",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "no",
       "comment": "Švédsko ať si dělá co chce, pokud si chce zničit to, na čem vydělávalo po čas druhé světové války, kdy kšeftovalo jak s Hitlerovským Německem, tak se spojenci. Co se týká Finska, tam je to jiné. Myslím, že se Finsko zavázalo k neutralitě po druhé světové válce. Zde to opět zavání rozpoutáním třetí světové války. "
     },
     {
       "id": "senatni-2022-25-a-426167-54",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "dont_know",
       "comment": "Pro malé i velké. Ale hlavně by měly jít do výroby a ne do vlastnictví."
     },
     {
       "id": "senatni-2022-25-a-426167-55",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "To už jsme zase v komunismu? Co to je za otázku? Je to vůbec u nás problém? Nebo se počítá s větším počtem mladých žen, které skončí jako bezdomovkyně?"
     },
     {
       "id": "senatni-2022-25-a-426167-56",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes",
       "comment": "A zároveň tvrdá kontrola, aby se s tím nekšeftovalo a byty byly pronajímány těmi skutečně potřebnými. Vdovci či vdovy už nebudou moci utáhnout nájem a energie bytů, kde žili se svými dosavadními partnery. To je nejzranitelnější skupina, která by se mohla ocitnout na ulici. "
     },
     {
       "id": "senatni-2022-25-a-426167-57",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know",
       "comment": "Je potřeba zainteresovat mezinárodní neutrální společenství a ukončit válku. Jak? To už nechám na jednání. Ústupky musí učinit obě strany."
     },
     {
       "id": "senatni-2022-25-a-426167-58",
       "candidate_id": "senatni-2022-25-c-426167",
-      "question_id": "senatni-2022-25-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "dont_know",
       "comment": "Dluhy se mají platit. Ovšem pokud takové exekuce jsou jalové a při tom drahé, tak by měl být nějaký státní orgán, nezávislý na stranách sporu, který by měl rozhodnout."
     },
     {
       "id": "senatni-2022-25-a-842348-1",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Proč Praha nestaví svoje byty ? Proč prodává pozemky ?  Žádné byty by nebyly prázdné nebo nehorázně předražené kdyby Praha uvolňovala na trh svoje byty pro své Pražany."
     },
     {
       "id": "senatni-2022-25-a-842348-2",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Kdyby Praha stavěla své byty na svých pozemcích a ty pak uvolňovala na trh neměla by důvod regulovat nájemné."
     },
     {
       "id": "senatni-2022-25-a-842348-3",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-25-a-842348-4",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Praha potřebuje především dostavbu vnitřního (tunelového) a vnějšího okruhu"
     },
     {
       "id": "senatni-2022-25-a-842348-5",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-25-a-842348-6",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-842348-7",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-842348-8",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-842348-9",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-842348-10",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-842348-11",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-842348-12",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-842348-13",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-842348-14",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes",
       "comment": "Společnost ČT by měla být rozdělena na zpravodajství a ostatní tvorbu a tu zprivatizovat..."
     },
     {
       "id": "senatni-2022-25-a-842348-15",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no",
       "comment": "Měla by být zavedena silná regulace a povinností PA. Nemohou zneužívat své autority vůči svým klientům."
     },
     {
       "id": "senatni-2022-25-a-842348-16",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Je mi to líto ale manželství je mezi ženou a mužem.... přesto láska nezná hranic..."
     },
     {
       "id": "senatni-2022-25-a-842348-17",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-25-a-842348-18",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-842348-19",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Na výstavbu \"svých\" bytů Praha Praha dávno rezignovala..... k velké radosti developerů..."
     },
     {
       "id": "senatni-2022-25-a-842348-20",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes",
       "comment": "Zvláště v dnešní době... stát utratí 70 miliard - bez efektu - a na občany v nouzi nemá \"kapacitu ?\""
     },
     {
       "id": "senatni-2022-25-a-842348-21",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-842348-22",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-842348-23",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Téma korespondenčního či internetového hlasování je pro mne tématem o totalitární budoucnosti...."
     },
     {
       "id": "senatni-2022-25-a-842348-24",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "Stát musí definovat svou \"generační strategickou politiku zaměstnanosti a rozvoje\" a aktuálně nepreferované obory dotovat pro budoucnost.... jsme jen ve vleku neexistující ruky trhu.... "
     },
     {
       "id": "senatni-2022-25-a-842348-25",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-842348-26",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no",
       "comment": "Stejně jako psychologie definuje své základní hranice formou, norma, širší norma, ..., je možné se takto dívat i na schopnosti a možnosti studentů....."
     },
     {
       "id": "senatni-2022-25-a-842348-27",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "yes",
       "comment": "ČR je v EU za \"Oslíčku otřes se \".... zahraniční firmy odvádějí své zisky z ČR, nereinvestují je zde. Nemají o to zájem. Proto u nás nepodnikají, aby zde reinvestovali zisky (..jako například distributoři energií nebo banky). Podíl peněz \"zcizených z ČR\" je stonásobně vyšší než \"almužna\" ve formě dotací z EU.... "
     },
     {
       "id": "senatni-2022-25-a-842348-28",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "To by byla konečná pro českou státnost a konec světla na konci tunelu... "
     },
     {
       "id": "senatni-2022-25-a-842348-29",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes",
       "comment": "V současném a zdá se že i budoucím světě má ČR budoucnost jako neutrální země (jako Rakousko) a jako součást neutrálního pásu oddělující zájmy RU/CHI vs Evropa-USA"
     },
     {
       "id": "senatni-2022-25-a-842348-30",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no",
       "comment": "ČR má místo v \"Pásy Svobody neutrálních států\" - Část Německa (NDR)+ČESKO+RAKOUSKO+SLOVINSKO ... mimo EU mimo NATO mimo RUSKO"
     },
     {
       "id": "senatni-2022-25-a-842348-31",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-842348-32",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-25-a-842348-33",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-842348-34",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-842348-35",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no",
       "comment": "Žádnou armádu, která by mohla nabídnout svým občanům aspoň nějaký pocit bezpečí NEMÁME. Máme jen spousty úředníků na pořádání výběrových (neveřejných - dle průzkumu a zadání) řízení...."
     },
     {
       "id": "senatni-2022-25-a-842348-36",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-842348-37",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes",
       "comment": "tato možnost zachrání státní a krajské nemocnice. Jinak \"bohatí\" pacienti odejdou do soukromých klinik a my budeme muset opět více dotovat naše zdravotnictví..."
     },
     {
       "id": "senatni-2022-25-a-842348-38",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-842348-39",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes",
       "comment": "Je ostuda že již zakázáno nebylo.... podobné jako s tabákovými výrobky.... jak dlouho výrobce ví o pochybnostech svých produktů ?"
     },
     {
       "id": "senatni-2022-25-a-842348-40",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-842348-41",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes",
       "comment": "1984"
     },
     {
       "id": "senatni-2022-25-a-842348-42",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no",
       "comment": " Z EU, z hospodářské a politické solidarity se stal nástroj ekonomického kolonialismu a rozpínavosti států EHS jenž se cítí a jednají jako jediní možní...my jsme jen \"Oslíčku otřes se\". EU ví všechno nejlépe"
     },
     {
       "id": "senatni-2022-25-a-842348-43",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "Vstupem Ukrajiny do EU a NATO zahájíme 3. Světovou válku, která se samozřejmě odehraje v Evropě. Nikoliv v USA, Rusku, Číně.... "
     },
     {
       "id": "senatni-2022-25-a-842348-44",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "EU by měla být rozpuštěna. Už jsem se stejně zadlužili jako oni, už nic nevlastníme a nemáme...jen dluhy"
     },
     {
       "id": "senatni-2022-25-a-842348-45",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-842348-46",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "no",
       "comment": "Jaké nesly USA \"následky za vylhanou válku\" v Iráku a válku v Afghanistánu ?. Proč se o tom nemluví ? Kdo Iráckým matkám nahradí jejich syny, kdo nese následky za ten omyl ?"
     },
     {
       "id": "senatni-2022-25-a-842348-47",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes",
       "comment": "Proč ne ? "
     },
     {
       "id": "senatni-2022-25-a-842348-48",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "no",
       "comment": "To musí řešit český zákonodárce, Proč opět EU ?"
     },
     {
       "id": "senatni-2022-25-a-842348-49",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Čím je to pro nás výhodné ? "
     },
     {
       "id": "senatni-2022-25-a-842348-50",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "Podporuji, aby EU byla rozpuštěna do konce roku 2023. To je jediné světlo na konci tunelu.."
     },
     {
       "id": "senatni-2022-25-a-842348-51",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-842348-52",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Jiná cesta není a o jiné nemá smysl jednat... bez levných vstupů energií nemáme šanci uspět v novém světě..."
     },
     {
       "id": "senatni-2022-25-a-842348-53",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "dont_know",
       "comment": "Považuji to za nerozumné a \"populistické\""
     },
     {
       "id": "senatni-2022-25-a-842348-54",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes",
       "comment": "Zemědělství je po armádě druhým sektorem zdecimovaným EU a EHS"
     },
     {
       "id": "senatni-2022-25-a-842348-55",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "Tato možnost by měla být součástí sociálních dávek"
     },
     {
       "id": "senatni-2022-25-a-842348-56",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no",
       "comment": "Obce, kraje musí být garanty a nositeli bytové politiky. Stát má tyto politiky samosprávných celků a obcí podporovat "
     },
     {
       "id": "senatni-2022-25-a-842348-57",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "yes",
       "comment": "Má jinou šanci ? Má to jít vybojovat naše armáda ? podobně jako Irák a Afganistán ?"
     },
     {
       "id": "senatni-2022-25-a-842348-58",
       "candidate_id": "senatni-2022-25-c-842348",
-      "question_id": "senatni-2022-25-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "no",
       "comment": "Ale mají být přezkoumány a znovu posouzeny, především s ohledem na postup exeturského úřadu - exekutora"
     },
     {
       "id": "senatni-2022-25-a-377248-1",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-377248-2",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-377248-3",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-377248-4",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes",
       "comment": "Vlaková doprava je ekologičtější než automobilová, což platí i pro přepravu nákladů."
     },
     {
       "id": "senatni-2022-25-a-377248-5",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Dokud nebude připravena smysluplná důchodová reforma nevidím důvod budoucím důchodcům nastavovat jiné podmínky, než mají ti současní."
     },
     {
       "id": "senatni-2022-25-a-377248-6",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-377248-7",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-377248-8",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes",
       "comment": "Současný systém je výhodný pro bohaté a nevýhodný pro lidi práce a nízkopříjmové skupiny obyvatelstva. Je výmluvné, že v každé civilizované zemi na západ od našich hranic je progresivní zdanění."
     },
     {
       "id": "senatni-2022-25-a-377248-9",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-377248-10",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Současné tresty za sexuální násilí jsou ostudně nízké a soudy navíc zpravidla ukládají nižší trestné sazby z možného rozpětí či dokonce jen podmíněné tresty. "
     },
     {
       "id": "senatni-2022-25-a-377248-11",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "no",
       "comment": "Nevidím důvod proč selektivně danit jen tyto dvě společnosti."
     },
     {
       "id": "senatni-2022-25-a-377248-12",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes",
       "comment": "Je to ale otázka míry. Nemohou být zodpovědné za vše, ale nemělo by jim také být tolerováno šíření nenávistných, rasistických atd. obsahů."
     },
     {
       "id": "senatni-2022-25-a-377248-13",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-377248-14",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Naopak by měly být televizní a rozhlasové poplatky zvýšeny a měl by být zákonný mechanismus pro jejich zvyšování s inflací. Jsou zásadní pro demokracii a neměly by být rukojmími poslanců. "
     },
     {
       "id": "senatni-2022-25-a-377248-15",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes",
       "comment": "Omezena a výrazně regulována."
     },
     {
       "id": "senatni-2022-25-a-377248-16",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes",
       "comment": "Podle Ústavy máme mít všichni stejná práva a stejné povinnosti. Pokud někomu upíráme nějaké právo jen na základě sexuální orientace, porušujeme Ústavu a Listinu základních práv a svobod. Je to stejné, jako kdybychom upírali někomu právo uzavřít manželství na základě rasy, etnicity či náboženského vyznání."
     },
     {
       "id": "senatni-2022-25-a-377248-17",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-377248-18",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-377248-19",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Když to jde v Německu, v Rakousku či v Dánsku, proč by to nemělo jít u nás?"
     },
     {
       "id": "senatni-2022-25-a-377248-20",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-377248-21",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no",
       "comment": "Je to velmi nepraktické a v tak malé zemi zbytečné."
     },
     {
       "id": "senatni-2022-25-a-377248-22",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-25-a-377248-23",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Žijeme ve 21. století a v řadě zemí je to standard. Mnoha lidem by to pomohlo a takové opatření má potenciál zvýšit účast u voleb. "
     },
     {
       "id": "senatni-2022-25-a-377248-24",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-377248-25",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes",
       "comment": "Brzká selekce dětí vede ke zvýhodňování těch, které měly štěstí a narodily se do lepšího sociálního prostředí. Celkově na tom ale tratíme všichni."
     },
     {
       "id": "senatni-2022-25-a-377248-26",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "Je v našem zájmu, aby každý mohl maximálně rozvinout svůj potenciál a své talenty. "
     },
     {
       "id": "senatni-2022-25-a-377248-27",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no",
       "comment": "Vystoupení z Evropské unie by mělo fatální následky ekonomické, společenské i kulturní."
     },
     {
       "id": "senatni-2022-25-a-377248-28",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "Včera bylo pozdě. Dnes v době krizí se ukazuje, jaký problém bylo lpění na koruně."
     },
     {
       "id": "senatni-2022-25-a-377248-29",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no",
       "comment": "V žádném případě nesmíme oslabit naši mezinárodní ochranu a musíme být součástí demokratického světa včetně jeho společné obrany."
     },
     {
       "id": "senatni-2022-25-a-377248-30",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-377248-31",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes",
       "comment": "Ač si to mnozí nemyslí, jsme v rámci světa jednou z těch bohatších zemí a bohatství zavazuje. "
     },
     {
       "id": "senatni-2022-25-a-377248-32",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-377248-33",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "yes",
       "comment": "Dnešní azylové řízení je nekonečné martýrium a ministerstvo vnitra s v podstatě snaží všem žadatelům o azyl situaci co nejvíce ztížit. "
     },
     {
       "id": "senatni-2022-25-a-377248-34",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes",
       "comment": "Musíme zůstat pevnou součástí Evropské unie a Schengenu. Přináší nám to obrovské výhody a usnadňuje to život a cestování, což ví každý, kdo někdy cestoval do Chorvatska."
     },
     {
       "id": "senatni-2022-25-a-377248-35",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no",
       "comment": "Armáda by měla nejprve prokázat, že miliardy, které se na ní vydávají, jsou vynakládány účelně. Zatím spíše prokazuje opak."
     },
     {
       "id": "senatni-2022-25-a-377248-36",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Lidé si nemají hrát na Boha. Je úžasné, že existuje možnost umělého oplodnění pro páry, které by jinak děti mít nemohly, ale vše má své hranice. "
     },
     {
       "id": "senatni-2022-25-a-377248-37",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no",
       "comment": "Možnost soukromého připojištění předpokládá existenci dvojího standardu ve zdravotnictví, což je nepřijatelné. Každý má mít právo na to nejlepší možné ošetření, nehledě na to, kolik má peněz."
     },
     {
       "id": "senatni-2022-25-a-377248-38",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know",
       "comment": "Nejsem odborník na zdravotnictví a toto je vysoce odborná otázka. "
     },
     {
       "id": "senatni-2022-25-a-377248-39",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes",
       "comment": "Jako včelař vím, jaké škody takové přípravky dokáží napáchat na včelstvech, a nedělám si proto iluze o jejich dopadech na životní prostředí."
     },
     {
       "id": "senatni-2022-25-a-377248-40",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Měl by se ale změnit systém vybírání pokut, aby nebyl motivační pro vybírání pokud za každou cenu a účelovému umisťování těchto systémů do míst, kde jde jen o vybírání pokut."
     },
     {
       "id": "senatni-2022-25-a-377248-41",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes",
       "comment": "Možnosti dohledu se s novými technologiemi dramaticky rozšiřují a s tím se zároveň zmenšuje naše svoboda. Takové technologie jsou snadno zneužitelné, jak můžeme vidět v Číně, která je vyžívá k tyranizování ujgurské menšiny. To by pro nás mělo být varování. "
     },
     {
       "id": "senatni-2022-25-a-377248-42",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes",
       "comment": "Ale teprve až k tomu bude po všech stránkách připravena, což ještě dlouho nebude."
     },
     {
       "id": "senatni-2022-25-a-377248-43",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes",
       "comment": "Ale teprve až k tomu bude po všech stránkách připravena, což ještě dlouho nebude."
     },
     {
       "id": "senatni-2022-25-a-377248-44",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "dont_know",
       "comment": "To je velmi odborná otázka a nejsem expert na dopady takového kroku. "
     },
     {
       "id": "senatni-2022-25-a-377248-45",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no",
       "comment": "Současný veřejný ochránce práv jedná podle mne v rozporu se svými povinnostmi a poškozuje obraz této instituce, který budovali takové nezpochybnitelné morální autority jako pan Motejl či paní Šabatová."
     },
     {
       "id": "senatni-2022-25-a-377248-46",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes",
       "comment": "Vojenské napadení suverénního státu nemá ve 21. století místo a pachatel by měl nést veškeré následky takového konání."
     },
     {
       "id": "senatni-2022-25-a-377248-47",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-377248-48",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Násilí vůči ženám a domácí násilí je palčivý problém a kauzy jako ta Feriho, Trávníčka či Cimického jsou jen špičkou ledovce. Je třeba dělat mnohem více v jeho potírání, navíc v zemi, jejíž Parlament neschválil Istambulskou úmluvu."
     },
     {
       "id": "senatni-2022-25-a-377248-49",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "dont_know",
       "comment": "Vše bude záležet na tom, jak se bude vyvíjet energetická krize. Jakýkoliv kategorický soud je v této chvíli předčasný, protože nikdo z nás nemá křišťálovou kouli."
     },
     {
       "id": "senatni-2022-25-a-377248-50",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-377248-51",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no",
       "comment": "Násilná anexe území svrchovaného státu nesmí být schvalována. Je naivní si myslet, že by Putin skončil u Krymu."
     },
     {
       "id": "senatni-2022-25-a-377248-52",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no",
       "comment": "Jsme součástí Evropské unie a nesmíme podkopávat její jednotu, jako to dělá Viktor Orbán."
     },
     {
       "id": "senatni-2022-25-a-377248-53",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-377248-54",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-377248-55",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-377248-56",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "dont_know",
       "comment": "To je technická otázka. Ďábel je vždy v detailech a musel bych vidět konkrétní návrh takového fondu."
     },
     {
       "id": "senatni-2022-25-a-377248-57",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no",
       "comment": "Násilná agrese proti suverénnímu státu je hrubým porušením mezinárodního práva a nesmí vést k tomu, že by byl na Ukrajinu vyvíjen tlak, aby se vzdala svých okupovaných území. Putin by to stejně bral jako schvalování agrese a pokračoval by dále třeba až do Prahy."
     },
     {
       "id": "senatni-2022-25-a-377248-58",
       "candidate_id": "senatni-2022-25-c-377248",
-      "question_id": "senatni-2022-25-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-1",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-2",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Vláda by měla podporovat obce a města, která by obecní byty stavěla."
     },
     {
       "id": "senatni-2022-25-a-813666-3",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-4",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes",
       "comment": "Pokud by měla Evropa dokončenou síť pro rychlovlaky, mohla by výrazně omezit neekologické létání a zlepšit standart dopravy pro cestující."
     },
     {
       "id": "senatni-2022-25-a-813666-5",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "dont_know",
       "comment": "Je třeba vzít v úvahu udržitelnost systému, případně ho upravit např. vlastním spořením, důchodovou reformou atd."
     },
     {
       "id": "senatni-2022-25-a-813666-6",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-7",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-8",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Tento princip už je uplatňován vyšším zdaněním příjmů nad milion Kč ročně."
     },
     {
       "id": "senatni-2022-25-a-813666-9",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-10",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-11",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-12",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes",
       "comment": "Stejně jako jakákoliv jiná média."
     },
     {
       "id": "senatni-2022-25-a-813666-13",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-14",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-15",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-16",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-17",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes",
       "comment": "Výsledkem si ovšem nemůžeme být jisti..."
     },
     {
       "id": "senatni-2022-25-a-813666-18",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-19",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-20",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Lidé mají být vedeni k zodpovědnosti za své jednání."
     },
     {
       "id": "senatni-2022-25-a-813666-21",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "Je to mimo jiné důležité i pro život a normální fugování menších měst i dopravu."
     },
     {
       "id": "senatni-2022-25-a-813666-22",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-23",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Ale jen pro volby parlamentní, prezidentské a do Evropského parlamentu."
     },
     {
       "id": "senatni-2022-25-a-813666-24",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-25",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Vzdělávání by mělo být formou i obsahem co nejvíce individualizováno."
     },
     {
       "id": "senatni-2022-25-a-813666-26",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-27",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-28",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-29",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no",
       "comment": "V současnosti se ukazuje, jak je naše členství v NATO důležité pro naši obranu."
     },
     {
       "id": "senatni-2022-25-a-813666-30",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-31",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes",
       "comment": "Postupovat společně s ostatními vyspělými zeměmi."
     },
     {
       "id": "senatni-2022-25-a-813666-32",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-33",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-25-a-813666-34",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-35",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-36",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-37",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes",
       "comment": "Lidé by se měli o své zdraví starat a měli by k tomu být motivováni i tímto způsobem."
     },
     {
       "id": "senatni-2022-25-a-813666-38",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes",
       "comment": "Jedná se o finanční udržitelnost, vybavení i odbornou připravenost personálu."
     },
     {
       "id": "senatni-2022-25-a-813666-39",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-40",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-41",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-42",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-43",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes",
       "comment": "Spíše ano, pokud bude sama chtít."
     },
     {
       "id": "senatni-2022-25-a-813666-44",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-45",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-46",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-47",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-48",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-49",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Dlouho jsme přešlapovali na místě s budováním alternativních zdrojů..."
     },
     {
       "id": "senatni-2022-25-a-813666-50",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-813666-51",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-52",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-53",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes",
       "comment": "Už jsem podpořil svým hlasováním v Senátu"
     },
     {
       "id": "senatni-2022-25-a-813666-54",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes",
       "comment": "Současný systém je velmi nespravedlivý vůči malým a středním firmám či jednotlivcům"
     },
     {
       "id": "senatni-2022-25-a-813666-55",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-25-a-813666-56",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-813666-57",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no",
       "comment": "To by byl konec zásad a principů mezinárodního práva a popření suverenity a svobody v  těsné blízkosti naší země"
     },
     {
       "id": "senatni-2022-25-a-813666-58",
       "candidate_id": "senatni-2022-25-c-813666",
-      "question_id": "senatni-2022-25-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Už se tak děje v případě Milostivého léta"
     },
     {
       "id": "senatni-2022-25-a-290001-1",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-290001-2",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-290001-3",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no",
       "comment": "Riziko zneužití, právě v době je ko je tato, např. k vyvolaní referenda o vystoupení z EU a podobně"
     },
     {
       "id": "senatni-2022-25-a-290001-4",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Přesto vysokorychlostní tratě pokládám za velmi důležité, zejména kvůli propojení s Evropou a vytváření alternativy proti letecké dopravě. "
     },
     {
       "id": "senatni-2022-25-a-290001-5",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-6",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "Podporuji přehrady pouze v případě, kdy slouží jako zdroj pro zásobování pitnou vodou."
     },
     {
       "id": "senatni-2022-25-a-290001-7",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-8",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "dont_know",
       "comment": "Daně nesmí mít podobu trestu za schopnost."
     },
     {
       "id": "senatni-2022-25-a-290001-9",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-10",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-11",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-12",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes",
       "comment": "Odpovědnost ano, ale absolutní kontrola je nebezpečná. Nechceme dopadnout jako v Číně"
     },
     {
       "id": "senatni-2022-25-a-290001-13",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes",
       "comment": "Po upozornění je nutné toto důsledně prověřit a případně zprávy vymazat."
     },
     {
       "id": "senatni-2022-25-a-290001-14",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-290001-15",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know",
       "comment": "Požaduji větší kontrolu pracovních agentur ohledně dodržování zákoníku práce."
     },
     {
       "id": "senatni-2022-25-a-290001-16",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-17",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-18",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-19",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-290001-20",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-21",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "Platí pro krajská města a města s dobrou dopravní dostupností."
     },
     {
       "id": "senatni-2022-25-a-290001-22",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know",
       "comment": "V tomto bychom měli postupovat společně v rámci EU."
     },
     {
       "id": "senatni-2022-25-a-290001-23",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-24",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-290001-25",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Víceletá gymnázia mají smysl pokud přijímají skutečně talentované děti."
     },
     {
       "id": "senatni-2022-25-a-290001-26",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "Je třeba podporovat i speciální školy, protože ne pro každé dítě je běžný způsob výuky vhodný."
     },
     {
       "id": "senatni-2022-25-a-290001-27",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-290001-28",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-29",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-290001-30",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-31",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-32",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-33",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-25-a-290001-34",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-35",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-36",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-290001-37",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-38",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes",
       "comment": "Je třeba zajistit lepší dopravní obslužnost v regionech."
     },
     {
       "id": "senatni-2022-25-a-290001-39",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-40",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-290001-41",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-42",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know",
       "comment": "Nové země musí prokázat, že budou platnými členy a budouctít hodnoty na kterých je EU postavena"
     },
     {
       "id": "senatni-2022-25-a-290001-43",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know",
       "comment": "Nové země musí prokázat, že budou platnými členy a budou ctít hodnoty na kterých je NATO založeno."
     },
     {
       "id": "senatni-2022-25-a-290001-44",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "Je třeba oddělit cenu elektřiny od ceny plynu, tedy dotovat cenu plynu pro výrobu elektřiny v plynových elektrárnách. A jak navrhuje Evropská komise, cílem je zbavit se závislosti na ruském plynu do roku 2030."
     },
     {
       "id": "senatni-2022-25-a-290001-45",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-290001-46",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-47",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-290001-48",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-49",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-50",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-51",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-290001-52",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-290001-53",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-54",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-25-a-290001-55",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-25-a-290001-56",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no",
       "comment": "Toto by mělo být v kompetenci obcí, případně krajů."
     },
     {
       "id": "senatni-2022-25-a-290001-57",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-25-a-290001-58",
       "candidate_id": "senatni-2022-25-c-290001",
-      "question_id": "senatni-2022-25-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "no",
       "comment": "Dobrým řešením je akce typu Milostivé léto."
     }

--- a/data/kalkulacka/senatni-2022/28.json
+++ b/data/kalkulacka/senatni-2022/28.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-28-c-454822",
       "name": "Zdeněk Šarapatka",
       "type": "person",
-      "description": "Zdeněk Šarapatka - DESCRIPTION",
+      "description": "Zdeněk Šarapatka",
       "contacts": {
         "web": [
           {
@@ -505,7 +505,7 @@
         {
           "id": "senatni-2022-28-c-454822-p",
           "name": "Zdeněk Šarapatka",
-          "description": "Zdeněk Šarapatka - DESCRIPTION",
+          "description": "Zdeněk Šarapatka",
           "contacts": {
             "web": [
               {
@@ -532,7 +532,7 @@
       "id": "senatni-2022-28-c-553512",
       "name": "Andrea Brzobohatá",
       "type": "person",
-      "description": "Andrea Brzobohatá - DESCRIPTION",
+      "description": "Andrea Brzobohatá",
       "contacts": {
         "web": [
           {
@@ -548,7 +548,7 @@
         {
           "id": "senatni-2022-28-c-553512-p",
           "name": "Andrea Brzobohatá",
-          "description": "Andrea Brzobohatá - DESCRIPTION",
+          "description": "Andrea Brzobohatá",
           "contacts": {
             "web": [
               {
@@ -568,7 +568,7 @@
       "id": "senatni-2022-28-c-720036",
       "name": "Milan Němec",
       "type": "person",
-      "description": "Milan Němec - DESCRIPTION",
+      "description": "Milan Němec",
       "contacts": {
         "web": []
       },
@@ -576,7 +576,7 @@
         {
           "id": "senatni-2022-28-c-720036-p",
           "name": "Milan Němec",
-          "description": "Milan Němec - DESCRIPTION",
+          "description": "Milan Němec",
           "contacts": {
             "web": []
           },
@@ -588,7 +588,7 @@
       "id": "senatni-2022-28-c-289041",
       "name": "Petr Holeček",
       "type": "person",
-      "description": "Petr Holeček - DESCRIPTION",
+      "description": "Petr Holeček",
       "contacts": {
         "web": [
           {
@@ -612,7 +612,7 @@
         {
           "id": "senatni-2022-28-c-289041-p",
           "name": "Petr Holeček",
-          "description": "Petr Holeček - DESCRIPTION",
+          "description": "Petr Holeček",
           "contacts": {
             "web": [
               {
@@ -640,7 +640,7 @@
       "id": "senatni-2022-28-c-704700",
       "name": "Jarmila Smotlachová",
       "type": "person",
-      "description": "Jarmila Smotlachová - DESCRIPTION",
+      "description": "Jarmila Smotlachová",
       "contacts": {
         "web": [
           {
@@ -655,7 +655,7 @@
         {
           "id": "senatni-2022-28-c-704700-p",
           "name": "Jarmila Smotlachová",
-          "description": "Jarmila Smotlachová - DESCRIPTION",
+          "description": "Jarmila Smotlachová",
           "contacts": {
             "web": [
               {
@@ -674,7 +674,7 @@
       "id": "senatni-2022-28-c-972909",
       "name": "Karen Pumrová",
       "type": "person",
-      "description": "Karen Pumrová - DESCRIPTION",
+      "description": "Karen Pumrová",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/karen.pumrova.3"
@@ -683,7 +683,7 @@
         {
           "id": "senatni-2022-28-c-972909-p",
           "name": "Karen Pumrová",
-          "description": "Karen Pumrová - DESCRIPTION",
+          "description": "Karen Pumrová",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/karen.pumrova.3"
@@ -696,7 +696,7 @@
       "id": "senatni-2022-28-c-205170",
       "name": "Ivan Noveský",
       "type": "person",
-      "description": "Ivan Noveský - DESCRIPTION",
+      "description": "Ivan Noveský",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/ivan.novesky",
@@ -706,7 +706,7 @@
         {
           "id": "senatni-2022-28-c-205170-p",
           "name": "Ivan Noveský",
-          "description": "Ivan Noveský - DESCRIPTION",
+          "description": "Ivan Noveský",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/ivan.novesky",
@@ -721,1045 +721,1045 @@
     {
       "id": "senatni-2022-28-a-289041-1",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-2",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-3",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-4",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-5",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-6",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-289041-7",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-8",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-289041-9",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-10",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-289041-11",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-12",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-13",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-14",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-15",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-289041-16",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-17",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-18",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-19",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-20",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-289041-21",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-289041-22",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-23",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-24",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-25",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-26",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-27",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-28",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-29",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-30",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-31",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-289041-32",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-289041-33",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-34",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-35",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-36",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-37",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-38",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-289041-39",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-289041-40",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-41",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-42",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-289041-43",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-44",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-45",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-46",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-47",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-48",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-289041-49",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-50",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-51",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-52",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-53",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-54",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-289041-55",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-56",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-57",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-289041-58",
       "candidate_id": "senatni-2022-28-c-289041",
-      "question_id": "senatni-2022-28-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-1",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-2",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-3",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-4",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-5",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-6",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-454822-7",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-8",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-9",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-10",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-11",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-12",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-13",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-14",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-15",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-16",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-17",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-18",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-19",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-20",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-21",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-22",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-23",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-24",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-25",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-26",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-27",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-28",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-29",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-30",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-31",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-32",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-33",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-34",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-35",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-36",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-454822-37",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-38",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-39",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-454822-40",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-41",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-42",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-43",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-44",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-45",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-46",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-47",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-48",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-49",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-50",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-51",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-52",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-53",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-54",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-454822-55",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-56",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-57",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-454822-58",
       "candidate_id": "senatni-2022-28-c-454822",
-      "question_id": "senatni-2022-28-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-1",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-2",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-3",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-4",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-704700-5",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-6",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-7",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-8",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-9",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-10",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-11",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-12",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-13",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-14",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-15",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-16",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-704700-17",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-18",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-19",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-20",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-21",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-22",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-23",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-24",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-25",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-26",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-27",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-28",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-29",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-30",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-31",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-32",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-704700-33",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-34",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-35",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-36",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-37",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-38",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-39",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-40",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-41",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-42",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-43",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-44",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-45",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-46",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-47",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-48",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-49",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-50",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-28-a-704700-51",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-52",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-53",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-54",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-28-a-704700-55",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-56",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-57",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-28-a-704700-58",
       "candidate_id": "senatni-2022-28-c-704700",
-      "question_id": "senatni-2022-28-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "no"
     }
   ]

--- a/data/kalkulacka/senatni-2022/31.json
+++ b/data/kalkulacka/senatni-2022/31.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-31-c-665893",
       "name": "Věra Nechybová",
       "type": "person",
-      "description": "Věra Nechybová - DESCRIPTION",
+      "description": "Věra Nechybová",
       "contacts": {
         "web": [
           {
@@ -506,7 +506,7 @@
         {
           "id": "senatni-2022-31-c-665893-p",
           "name": "Věra Nechybová",
-          "description": "Věra Nechybová - DESCRIPTION",
+          "description": "Věra Nechybová",
           "contacts": {
             "web": [
               {
@@ -534,7 +534,7 @@
       "id": "senatni-2022-31-c-165219",
       "name": "Martin Krsek",
       "type": "person",
-      "description": "Martin Krsek - DESCRIPTION",
+      "description": "Martin Krsek",
       "contacts": {
         "web": [
           {
@@ -553,7 +553,7 @@
         {
           "id": "senatni-2022-31-c-165219-p",
           "name": "Martin Krsek",
-          "description": "Martin Krsek - DESCRIPTION",
+          "description": "Martin Krsek",
           "contacts": {
             "web": [
               {
@@ -576,7 +576,7 @@
       "id": "senatni-2022-31-c-619365",
       "name": "Alfréd Dytrt",
       "type": "person",
-      "description": "Alfréd Dytrt - DESCRIPTION",
+      "description": "Alfréd Dytrt",
       "contacts": {
         "web": [
           {
@@ -591,7 +591,7 @@
         {
           "id": "senatni-2022-31-c-619365-p",
           "name": "Alfréd Dytrt",
-          "description": "Alfréd Dytrt - DESCRIPTION",
+          "description": "Alfréd Dytrt",
           "contacts": {
             "web": [
               {
@@ -610,7 +610,7 @@
       "id": "senatni-2022-31-c-246453",
       "name": "Jan Beer",
       "type": "person",
-      "description": "Jan Beer - DESCRIPTION",
+      "description": "Jan Beer",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/jan.beer.39"
@@ -619,7 +619,7 @@
         {
           "id": "senatni-2022-31-c-246453-p",
           "name": "Jan Beer",
-          "description": "Jan Beer - DESCRIPTION",
+          "description": "Jan Beer",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/jan.beer.39"
@@ -632,7 +632,7 @@
       "id": "senatni-2022-31-c-699892",
       "name": "Martin Balej",
       "type": "person",
-      "description": "Martin Balej - DESCRIPTION",
+      "description": "Martin Balej",
       "contacts": {
         "web": [
           {
@@ -652,7 +652,7 @@
         {
           "id": "senatni-2022-31-c-699892-p",
           "name": "Martin Balej",
-          "description": "Martin Balej - DESCRIPTION",
+          "description": "Martin Balej",
           "contacts": {
             "web": [
               {
@@ -676,7 +676,7 @@
       "id": "senatni-2022-31-c-800949",
       "name": "Jaroslav Telecký",
       "type": "person",
-      "description": "Jaroslav Telecký - DESCRIPTION",
+      "description": "Jaroslav Telecký",
       "contacts": {
         "web": [
           {
@@ -695,7 +695,7 @@
         {
           "id": "senatni-2022-31-c-800949-p",
           "name": "Jaroslav Telecký",
-          "description": "Jaroslav Telecký - DESCRIPTION",
+          "description": "Jaroslav Telecký",
           "contacts": {
             "web": [
               {
@@ -718,7 +718,7 @@
       "id": "senatni-2022-31-c-163515",
       "name": "René Hladík",
       "type": "person",
-      "description": "René Hladík - DESCRIPTION",
+      "description": "René Hladík",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/rene.hladik.1"
@@ -727,7 +727,7 @@
         {
           "id": "senatni-2022-31-c-163515-p",
           "name": "René Hladík",
-          "description": "René Hladík - DESCRIPTION",
+          "description": "René Hladík",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/rene.hladik.1"
@@ -740,7 +740,7 @@
       "id": "senatni-2022-31-c-570575",
       "name": "Miloslav Buldra",
       "type": "person",
-      "description": "Miloslav Buldra - DESCRIPTION",
+      "description": "Miloslav Buldra",
       "contacts": {
         "web": [
           {
@@ -753,7 +753,7 @@
         {
           "id": "senatni-2022-31-c-570575-p",
           "name": "Miloslav Buldra",
-          "description": "Miloslav Buldra - DESCRIPTION",
+          "description": "Miloslav Buldra",
           "contacts": {
             "web": [
               {
@@ -770,7 +770,7 @@
       "id": "senatni-2022-31-c-392644",
       "name": "Petr Nedvědický",
       "type": "person",
-      "description": "Petr Nedvědický - DESCRIPTION",
+      "description": "Petr Nedvědický",
       "contacts": {
         "web": []
       },
@@ -778,7 +778,7 @@
         {
           "id": "senatni-2022-31-c-392644-p",
           "name": "Petr Nedvědický",
-          "description": "Petr Nedvědický - DESCRIPTION",
+          "description": "Petr Nedvědický",
           "contacts": {
             "web": []
           },
@@ -791,1546 +791,1546 @@
     {
       "id": "senatni-2022-31-a-246453-1",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes",
       "comment": "Vlastnictví prostoru k bydlení zavazuje k poskytnutí práva na bydlení. "
     },
     {
       "id": "senatni-2022-31-a-246453-2",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Volný trh klepne hamižné přes prsty sám."
     },
     {
       "id": "senatni-2022-31-a-246453-3",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Šlechtické tituly jsou v ČR zakázané od roku 1918, od té doby vládne demokracie, což by se mělo respektovat."
     },
     {
       "id": "senatni-2022-31-a-246453-4",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Prozatím není vůbec jasné, jakou energii budeme využívat doma, natož jakou bude využívat rychlovlak. Svět je příliš nestabilní k podpoře kolejí."
     },
     {
       "id": "senatni-2022-31-a-246453-5",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Solidarita je vlastní člověku."
     },
     {
       "id": "senatni-2022-31-a-246453-6",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "Příroda je mocná čarodějka. Poradí si zcela jistě i bez zásahů člověka."
     },
     {
       "id": "senatni-2022-31-a-246453-7",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes",
       "comment": "Jakékoliv drancování přináší více škody než užitku."
     },
     {
       "id": "senatni-2022-31-a-246453-8",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes",
       "comment": "Lidé mají souměřitelné žaludky."
     },
     {
       "id": "senatni-2022-31-a-246453-9",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Nikdy jsem neslyšel o regulaci rajčat nebo okurek, proč tedy nenechat na zahrádkářích, čím si chtějí osadit zahrádku?"
     },
     {
       "id": "senatni-2022-31-a-246453-10",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "dont_know",
       "comment": "Systém by měl především pachatele napravit!"
     },
     {
       "id": "senatni-2022-31-a-246453-11",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "no",
       "comment": "Nevidím rozdíl mezi Googlem, Facebookem nebo velkohokynářskými obchody typu Albert či Makro. Proč by jedni měli mít daň speciální a jiní ne? Každému stejně!"
     },
     {
       "id": "senatni-2022-31-a-246453-12",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Zodpovědnost musí mít jedinec, pokud není zbaven svéprávnosti."
     },
     {
       "id": "senatni-2022-31-a-246453-13",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "Neznám žádný věrohodný orgán, který by mohl zodpovědně říci, co je nebo není fake news."
     },
     {
       "id": "senatni-2022-31-a-246453-14",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Pokud nelze u veřejnoprávních médií inkasovat peníze z reklam a přesto musí plnit svoji roli, není na místě prostor k ukusování z koláče."
     },
     {
       "id": "senatni-2022-31-a-246453-15",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes",
       "comment": "Provize považuji za běžné u přeprodeje zboží, tady jde o lidskou sílu, práci a otrokářskou společnost jsme přece již dávno opustili."
     },
     {
       "id": "senatni-2022-31-a-246453-16",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-246453-17",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes",
       "comment": "Jen supi pořádají hostiny na cizích!"
     },
     {
       "id": "senatni-2022-31-a-246453-18",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes",
       "comment": "Jeden správní orgán k projednání věci také stačí."
     },
     {
       "id": "senatni-2022-31-a-246453-19",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Každá společnost na světě má nějaké procento těch, kteří si neumí pomoci sami a jejich situace by měla být řešitelná."
     },
     {
       "id": "senatni-2022-31-a-246453-20",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes",
       "comment": "Pokud by tomu tak nebylo, na holičkách by zůstalo mnoho nesvéprávných jedinců."
     },
     {
       "id": "senatni-2022-31-a-246453-21",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "Praha není a nemůže být hlavou chobotnice."
     },
     {
       "id": "senatni-2022-31-a-246453-22",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no",
       "comment": "Prozatím bych nechal politiky řídit ČR a až když se to naučí, mohou dostat řidičský průkaz pro jiná území."
     },
     {
       "id": "senatni-2022-31-a-246453-23",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Algoritmy jsou zrádné."
     },
     {
       "id": "senatni-2022-31-a-246453-24",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "Absolventi nepotřebných oborů pak nebudou přivádět do rozpaků úředníky na Úřadu práce."
     },
     {
       "id": "senatni-2022-31-a-246453-25",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Talent neumlčíš."
     },
     {
       "id": "senatni-2022-31-a-246453-26",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "Kde není podpora, je ohroženo sebevědomí."
     },
     {
       "id": "senatni-2022-31-a-246453-27",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no",
       "comment": "Melouny na zahradě nerostou, ty nám musí dovézt ze Španělska."
     },
     {
       "id": "senatni-2022-31-a-246453-28",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "Prozatím vedlo zavedení Eura kdykoliv ke zvýšení cen u všeho zboží a služeb."
     },
     {
       "id": "senatni-2022-31-a-246453-29",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no",
       "comment": "Nedovedu si představit nikoho, kdo by mohl ČR bránit, když se jdu podívat třeba jen na hodinu tělocviku ve škole, kde učím. Kdo uběhne alespoň 2 kilometry bez zadýchání?"
     },
     {
       "id": "senatni-2022-31-a-246453-30",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes",
       "comment": "Já pán, ty pán = musíme si být všichni rovni. Německo jako Češi!"
     },
     {
       "id": "senatni-2022-31-a-246453-31",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes",
       "comment": "Pokud na to budeme mít a nepůjde o vyhazování peněz oknem, proč ne."
     },
     {
       "id": "senatni-2022-31-a-246453-32",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes",
       "comment": "Všechno nás jednou může dohnat. Nyní jde o zvyšování teploty, proto jsem pro."
     },
     {
       "id": "senatni-2022-31-a-246453-33",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Pokud již nyní odpovídá standardům demokratického světa, není třeba pravidla rozvolňovat."
     },
     {
       "id": "senatni-2022-31-a-246453-34",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes",
       "comment": "S tím, že zavedení vnitřních kontrol na území ČR nic nebrání."
     },
     {
       "id": "senatni-2022-31-a-246453-35",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "Ovšem ze začátku klidně více peněz na brannou výchovu do škol."
     },
     {
       "id": "senatni-2022-31-a-246453-36",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Stačí, že si v krámě mohou vybrat růžovou nebo modrou dupačku."
     },
     {
       "id": "senatni-2022-31-a-246453-37",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes",
       "comment": "Kdo chce být na pokoji sám nebo k obědu si i v nemocnici zadebužírovat minutkou, proč ne."
     },
     {
       "id": "senatni-2022-31-a-246453-38",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no",
       "comment": "Šlo by totiž jen o vznik zdravotnické turistiky."
     },
     {
       "id": "senatni-2022-31-a-246453-39",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know",
       "comment": "Je možné omezovat vědu v zájmu lidstva?"
     },
     {
       "id": "senatni-2022-31-a-246453-40",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "yes",
       "comment": "Bojím se, že jednoho dne automatický výběr sáhne i do mého účtu, mojí peněženky."
     },
     {
       "id": "senatni-2022-31-a-246453-41",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no",
       "comment": "Pokud je kdokoliv schopen garantovat jeho nezneužití."
     },
     {
       "id": "senatni-2022-31-a-246453-42",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no",
       "comment": "Ukrajina by si měla vyřešit problémy uvnitř svého území tak, aby v ní nevládl klientelismus a korupce, která nemá v EU prostor + začít přibližovat svůj právní systém Evropě, pak mohou přicházet úvahy o jejím vstupu kamkoliv."
     },
     {
       "id": "senatni-2022-31-a-246453-43",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "Je k tomu nějaký zvláštní důvod?"
     },
     {
       "id": "senatni-2022-31-a-246453-44",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes",
       "comment": "Jedině strop může přinutit prodejce k zodpovědnější formě prodeje."
     },
     {
       "id": "senatni-2022-31-a-246453-45",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes",
       "comment": "Agenda běží dál, pokud se nemýlím. Úřad zaměstnává několik desítek právníků, personální nouzí netrpí. "
     },
     {
       "id": "senatni-2022-31-a-246453-46",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "dont_know",
       "comment": "Mezinárodní tribunály mají v oblasti válečných zločinů procesními předpisy upraveno, kdo je nebo není válečný zločinec. Nechme jim jejich autonomii a nikam je netlačme, plně jim důvěřuji."
     },
     {
       "id": "senatni-2022-31-a-246453-47",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "dont_know",
       "comment": "Pokud je součástí mandátu jednat za ČR v zájmu lidu a není jiné cesty, než komunikovat s ruskou administrativou na Krymu, ať jednají a pokud nejsou s Krymem životu nutná témata, ať nejednají."
     },
     {
       "id": "senatni-2022-31-a-246453-48",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Pokud se nebude překrývat s tuzemskými právními předpisy."
     },
     {
       "id": "senatni-2022-31-a-246453-49",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Vznik nových ložisek bude trvat tisíce let, takže rok nebo dva v procesu spalování uhlí nehrají žádnou roli."
     },
     {
       "id": "senatni-2022-31-a-246453-50",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "Obávám se, že i nyní jde o výkřik do tmy aktivistů Green Dealu."
     },
     {
       "id": "senatni-2022-31-a-246453-51",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "dont_know",
       "comment": "Právo na sebeurčení je nutné respektovat. I když jak víme z nedávné minulosti, Čechů ani Slováků se nikdo na nic neptal."
     },
     {
       "id": "senatni-2022-31-a-246453-52",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Oni se snad Maďaři nebo Bulhaři nechávají někým zastupovat? Když chci koupit rohlík, také jdu do pekárny sám."
     },
     {
       "id": "senatni-2022-31-a-246453-53",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes",
       "comment": "Díky jejich připravenosti v oblasti obrany v odpovědi na tuto otázku nevidím žádný problém."
     },
     {
       "id": "senatni-2022-31-a-246453-54",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "Každému podle velikosti obdělávané plochy. Pokud dám více menšímu, nevyprodukuje víc."
     },
     {
       "id": "senatni-2022-31-a-246453-55",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "Jen těm, kdo jsou v tísni."
     },
     {
       "id": "senatni-2022-31-a-246453-56",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes",
       "comment": "Stále jde o lepší řešení, než bylo zvoleno v Teplicích, kde bylo rozprodáno do mrtě úplně vše a pokud má nyní město občana ve stavu tísně nebo jiného handicapu, nemůže mu nabídnout vůbec nic!"
     },
     {
       "id": "senatni-2022-31-a-246453-57",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know",
       "comment": "Nejsem expert, nerad mluvím do cizích věcí. Co dělají sousedé u mě v baráku je mně také do jisté míry jedno."
     },
     {
       "id": "senatni-2022-31-a-246453-58",
       "candidate_id": "senatni-2022-31-c-246453",
-      "question_id": "senatni-2022-31-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Kde nic není, ani smrt nebere."
     },
     {
       "id": "senatni-2022-31-a-570575-1",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-570575-2",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-570575-3",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Jak se ukazuje při současné energetické krizi by tento požadavek byl velmi důležitý."
     },
     {
       "id": "senatni-2022-31-a-570575-4",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "I za cenu \"lehkého\" zdržení by výstavba měla jít ruku v ruce s výstavbou další dopravní infrastruktury."
     },
     {
       "id": "senatni-2022-31-a-570575-5",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-570575-6",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know",
       "comment": "Tohle je spíše otázka pro odborníky. Nemám takové informace, abych mohl vědět, jestli v ČR existují vhodná místa pro takovou výstavbu. Pokud ano, nejsem proti."
     },
     {
       "id": "senatni-2022-31-a-570575-7",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-570575-8",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-570575-9",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-570575-10",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-570575-11",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-31-a-570575-12",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Výjimkou by měl být obsah rasistický,nacistický a fašistický."
     },
     {
       "id": "senatni-2022-31-a-570575-13",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "Jsem proti jakékoli názorové cenzuře."
     },
     {
       "id": "senatni-2022-31-a-570575-14",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes",
       "comment": "Vzhledem k tomu co plodí veřejno-právní \"sdělovadla\" by neměly dostávat peníze žádné."
     },
     {
       "id": "senatni-2022-31-a-570575-15",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-570575-16",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know",
       "comment": "Kdo s kým žije je soukromá záležitost a nemyslím si, že by se to mělo na veřejnosti příliš ventilovat."
     },
     {
       "id": "senatni-2022-31-a-570575-17",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-570575-18",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-570575-19",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-570575-20",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "dont_know",
       "comment": "Pravdou je, že řada našich spoluobčanů nemá ani potuchy o tom, že nárok na nějakou \"dávku\" vůbec mají."
     },
     {
       "id": "senatni-2022-31-a-570575-21",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-31-a-570575-22",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-570575-23",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Zde vidím slabé místo pro regulérnost voleb."
     },
     {
       "id": "senatni-2022-31-a-570575-24",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "dont_know",
       "comment": "Jsem pro podporu technického vzdělání, ale i tady je potřeba rozlišovat neboť ne každý člověk má tzv. technické buňky."
     },
     {
       "id": "senatni-2022-31-a-570575-25",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Inkluzi v základním vzdělání nepovažuji za cestu správným směrem."
     },
     {
       "id": "senatni-2022-31-a-570575-26",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no",
       "comment": "Zde si myslím, že je to přesně naopak, a sice, že \"pomalejší\" jedinci zpomalují výuku pro ostatní."
     },
     {
       "id": "senatni-2022-31-a-570575-27",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "yes",
       "comment": "Již v referendu o vstupu do EU jsem byl proti!"
     },
     {
       "id": "senatni-2022-31-a-570575-28",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "Rozhodně jsem proti!"
     },
     {
       "id": "senatni-2022-31-a-570575-29",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes",
       "comment": "Jako člověk vyznávající mírovou spolupráci mezi národy a převědčením \"pacifista\" odmítám jakékoli použití zbraní, snad a výjimkou policie, sportovců a v myslivosti!"
     },
     {
       "id": "senatni-2022-31-a-570575-30",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no",
       "comment": "Jsem pro neutralitu."
     },
     {
       "id": "senatni-2022-31-a-570575-31",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know",
       "comment": "Protiotázka: Víme kde taková pomoc vždy končí?"
     },
     {
       "id": "senatni-2022-31-a-570575-32",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no",
       "comment": "Změna klimatu? Nesmysl, zkoncovat s greendealem!"
     },
     {
       "id": "senatni-2022-31-a-570575-33",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "yes",
       "comment": "Ano, ale jen v nutných případech a řádně prověřených."
     },
     {
       "id": "senatni-2022-31-a-570575-34",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes",
       "comment": "Vzhledem k tomu, že jak jsem již výše uvedl jsem pro vystoupení z EU, by samozřejmě záleželo na tom jaké bychom si vyjednali podmínky v jednotlivých oblastech, včetně cestování."
     },
     {
       "id": "senatni-2022-31-a-570575-35",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-570575-36",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-31-a-570575-37",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "dont_know",
       "comment": "Zde jsem spíše pro pojištění státní a snížení počtu ZP."
     },
     {
       "id": "senatni-2022-31-a-570575-38",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-570575-39",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know",
       "comment": "Rozhodně si myslím, že by používání těchto látek mělo být omezeno na nenutnější mez."
     },
     {
       "id": "senatni-2022-31-a-570575-40",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-570575-41",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-31-a-570575-42",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no",
       "comment": "To je obcházení vstupních regulí, které si EU sama nastavila! Podpora nacizmu v těchto podmínkách není."
     },
     {
       "id": "senatni-2022-31-a-570575-43",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "Nevidím jediný důvod, proč by se mělo NATO \"roztahovat\" východním či jakýmkoli jiným směrem. Ostatně jsem pro zrušení NATO, tak jak bylo \"hlášeno\" již v roce 1989."
     },
     {
       "id": "senatni-2022-31-a-570575-44",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "Jestli chceme skutečně přijít o možnost dostat do ČR vůbec nějaký zemní plyn, tak to udělejme ale, pak ať si to státní moc \"vysvětlí\" občanům i firmám!"
     },
     {
       "id": "senatni-2022-31-a-570575-45",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know",
       "comment": "Vždy je možné, aby to bylo lepší."
     },
     {
       "id": "senatni-2022-31-a-570575-46",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "no",
       "comment": "Otázka je špatně formulována. Za prvé by měl být uzavřen mír. Za druhé NATO se musí stáhnout a nedráždit RF. Západ by se měl spolupodílet na denacifikaci Ukrajiny, když už nedokázal Ukrajinu donutit dodržovat \"Minské dohody\"."
     },
     {
       "id": "senatni-2022-31-a-570575-47",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes",
       "comment": "Každá mírová jednání včetně obchodních jsou lepší než válčit."
     },
     {
       "id": "senatni-2022-31-a-570575-48",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Samozřejmě, pokud z toho nevznikne paskvil jako v 90% všeho co EU přijímá."
     },
     {
       "id": "senatni-2022-31-a-570575-49",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "dont_know",
       "comment": "I zde je otázkou jak se bude situace vyvíjet v jiných energetických oblastech."
     },
     {
       "id": "senatni-2022-31-a-570575-50",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know",
       "comment": "V té době věřím, že již v EU nebudeme, případně již EU nebude v dnešní formě a podobě existovat."
     },
     {
       "id": "senatni-2022-31-a-570575-51",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-570575-52",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Vyjednávání o energetické soběstačnosti bych rozhodně nenechával na nikom jiném než na našich odbornících např. ing. Vlad. Štěpán, ing. Ivan Noveský, Alena Vitásková, Fr, Janeček, ad."
     },
     {
       "id": "senatni-2022-31-a-570575-53",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "no",
       "comment": "NATO by se mělo ropustit!"
     },
     {
       "id": "senatni-2022-31-a-570575-54",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "dont_know",
       "comment": "Nemyslím, že by se mělo příliš rozlišovat. Pro mě je nejdůležitější podpora samostatného českého zemědělství tak, aby jsme v plodinách, kterým se daří v našem podnebním pásmu mohli býti soběstační, taktéž v chovu \"masné\" zvěře."
     },
     {
       "id": "senatni-2022-31-a-570575-55",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "Populismus."
     },
     {
       "id": "senatni-2022-31-a-570575-56",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes",
       "comment": "Určitě za přesně specifikovaných podmínek dobrá myšlenka."
     },
     {
       "id": "senatni-2022-31-a-570575-57",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "yes",
       "comment": "Já ten konflikt nadále vidím jako vyprovokovaný tzv. kolektivním západem prostřednictvím Ukrajiny a tím zabíjení se slovanů navzájem, což vyhovuje hlavně USA a západu."
     },
     {
       "id": "senatni-2022-31-a-570575-58",
       "candidate_id": "senatni-2022-31-c-570575",
-      "question_id": "senatni-2022-31-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-1",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-2",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes",
       "comment": "Dalo by se tím předejít nehorázně vysokým nájmům, které požadují takzvaní obchodníci s chudobou, tedy vlastníci zchátralých nemovitostí, v nichž ubytovávají zejména nepřizpůsobivé občany. Je to jedno z dílčích opatření, které by řešilo problém sociálně vyloučených lokalit. "
     },
     {
       "id": "senatni-2022-31-a-665893-3",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-4",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-5",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-6",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-31-a-665893-7",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-8",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Stávající solidární daň v tuto chvíli považuji za dostatečnou. "
     },
     {
       "id": "senatni-2022-31-a-665893-9",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Pro léčebné účely. "
     },
     {
       "id": "senatni-2022-31-a-665893-10",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Sexuální zločiny patří k jedním z nejzávažnějších. "
     },
     {
       "id": "senatni-2022-31-a-665893-11",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-12",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-13",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-14",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-15",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes",
       "comment": "Měla by být omezena. "
     },
     {
       "id": "senatni-2022-31-a-665893-16",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-17",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-18",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-19",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Ano, zejména obecní a státní výstavba. "
     },
     {
       "id": "senatni-2022-31-a-665893-20",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Ale jsou ohrožené skupiny, jako třeba senioři a samoživitelé, které nemají povědomí o tom, jak by jim stát mohl v nouzi pomoci. Stát musí o možnostech podpory pro ohrožené skupiny více informovat. "
     },
     {
       "id": "senatni-2022-31-a-665893-21",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-22",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-31-a-665893-23",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-24",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-25",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-26",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-27",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-28",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "V tuto chvíli na to není správná doba. "
     },
     {
       "id": "senatni-2022-31-a-665893-29",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-30",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-31",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes",
       "comment": "Ano, pomáhat a současně zabránit ekonomickému a sociálnímu rozpadu vlastní země."
     },
     {
       "id": "senatni-2022-31-a-665893-32",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know",
       "comment": "Částečně ano, ale jasně daných podmínek. "
     },
     {
       "id": "senatni-2022-31-a-665893-33",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-34",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-35",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "Měla by plnit svůj závazek vůči Severoatlantické alianci."
     },
     {
       "id": "senatni-2022-31-a-665893-36",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know",
       "comment": "Důležité pro tyto rodiče je, aby vůbec dítě měli a zdravé. "
     },
     {
       "id": "senatni-2022-31-a-665893-37",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-38",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-39",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-40",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-41",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-42",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know",
       "comment": "Jsem příznivcem rozšiřování EU. Ovšem země, které by se měly stát její součástí, by měly projít celým kandidátským procesem a současně by mělo jí o stabilní demokratické země. "
     },
     {
       "id": "senatni-2022-31-a-665893-43",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know",
       "comment": "Podobně jako při vstupu do EU ba měla kandidátská stana projít celým vstupním procesem a mělo by jít o stabilní demokratickou zemi, což Ukrajina v tuto chvíli není. "
     },
     {
       "id": "senatni-2022-31-a-665893-44",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-45",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-46",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-47",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-48",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-49",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-50",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know",
       "comment": "V tuto chvíli , kdy ceny energií letí raketově vzhůru, EU musí přehodnotit Green Deal. "
     },
     {
       "id": "senatni-2022-31-a-665893-51",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-52",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "dont_know",
       "comment": "Česká republika v době radikálního zvyšování ceny plynu musí vyjednat dodávky za rozumnou cenu. "
     },
     {
       "id": "senatni-2022-31-a-665893-53",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-54",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-55",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-56",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-665893-57",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-665893-58",
       "candidate_id": "senatni-2022-31-c-665893",
-      "question_id": "senatni-2022-31-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-165219-1",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "dont_know",
       "comment": "Může to být účinné lokální opatření, tam panuje bytová  nouze."
     },
     {
       "id": "senatni-2022-31-a-165219-2",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Jsou jiné možnosti jak v lokalitách, kde je nadstandardní výše nájemného, tento problém korigovat, a to vhodnou bytovou politikou s komunálními a státními byty. "
     },
     {
       "id": "senatni-2022-31-a-165219-3",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no",
       "comment": "To nahrává hlavně populistům. Při vší úctě k vůli občanů, jsme přeci jen parlamentní demokracie. Víme, jak to dopadlo v případě přímé volby prezidenta, před kterou všichni politilogové varovali právě proto, že nesystémově  narušuje naše parlamentní zřízení.  Oproti tomu místní referenda plně podporuji, jsou projevem aktivního občanství."
     },
     {
       "id": "senatni-2022-31-a-165219-4",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes",
       "comment": "Kdo zažil rychlovlaky jinde v Evropě, ve světě, ví že je to velmi fektivní a pohodlný způsob dopravy. Využívají jej rádi i ti, kdo jinak preferují osobní vůz. Rychlovlaky mohou být i pro náš kraj ekonomicky tím, co před sto a více lety bylo zavádění železnice. Tedy startem k rozvoji. Může to být i impuls decentralizaci státní správy z Prahy na periferii, když například do Ústí se zkrátí dojezdová vzdálenost na 20 minut. "
     },
     {
       "id": "senatni-2022-31-a-165219-5",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "dont_know",
       "comment": "Ale rád podpořím kroky kterékoliv vlády ke smysluplné důchodové reformě."
     },
     {
       "id": "senatni-2022-31-a-165219-6",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "Budovatelská era socialismu snad již skončila. Dnes je známo, že existují přírodě bližší opatření, jak udržet vodu v krajině. V USA i v Evropě se velké přehrady naopak ruší. "
     },
     {
       "id": "senatni-2022-31-a-165219-7",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes",
       "comment": "O tom není pochyb. Zajeďte se podívat na Slovensko. Pomáhá to i udržovat pořádek. Pro některé sociálně slabé se totiž stane sběr vyhozených PETek a plechovek vítaným přivýdělkem.  "
     },
     {
       "id": "senatni-2022-31-a-165219-8",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "dont_know",
       "comment": "V krizi by to mohlo být jedno z řešení, jak z bohatších vrstev získat finance pro chudší. Systém však musí zohledňovat případné dobrovolné mecenášství. Aby se státním přerozdělováním neomezovala iniciativa cílit pomoc dle vlastních preferencí.  "
     },
     {
       "id": "senatni-2022-31-a-165219-9",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Je zbytečné vyrábět si kriminálníky z lidí, kteří si pro svou potřebu pěstují pár rostlin. Trend je jasný."
     },
     {
       "id": "senatni-2022-31-a-165219-10",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "A k tomu je třeba školit policisty, státní zástupce, soudce, neb oběti znásilnění se u nás často potkávají se zlehčováním jejich situace, nedůvěrou a hloupými macho vtípky."
     },
     {
       "id": "senatni-2022-31-a-165219-11",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "dont_know",
       "comment": "Bavme se prosím o evropské regulaci a společném zdanění těchto velkých hráčů, kteří možná až příliš vstupují do našich životů a zasahují do chodu politiky třeba neochotou zabránit šíření dezinformací. "
     },
     {
       "id": "senatni-2022-31-a-165219-12",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes",
       "comment": "Jsem liberál, ale ukazuje se, že sociální sítě přispívají k radikalizaci společnosti, akcelerují konflikty mezi lidmi atd. Určení pravidel hry je na místě."
     },
     {
       "id": "senatni-2022-31-a-165219-13",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes",
       "comment": "A netvařme se, že nevíme, které zprávy jsou falešné. Na to stačí dobré základní vzdělání."
     },
     {
       "id": "senatni-2022-31-a-165219-14",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-165219-15",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes",
       "comment": "Z našeho regionu vím, že tzv. agenturní pracovníci jsou na tom často hůře než tzv. kmenoví zaměstnanci. Činnost agentur se musí řídit férovými a jasnými pravidly."
     },
     {
       "id": "senatni-2022-31-a-165219-16",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes",
       "comment": "Patřím k většině české společnosti, která rovná práva v lásce podporuje. Podívejte se, kolik dětí vyrůstá v nevhodných podmínkách klasických ale nefunkčních rodin."
     },
     {
       "id": "senatni-2022-31-a-165219-17",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes",
       "comment": "Ano, rozhodně a co nejdřív."
     },
     {
       "id": "senatni-2022-31-a-165219-18",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes",
       "comment": "Ano, rozhodně a co nejdřív."
     },
     {
       "id": "senatni-2022-31-a-165219-19",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "To není socialismus, ale naprostá a racionální nutnost. V tom ČR zaspala."
     },
     {
       "id": "senatni-2022-31-a-165219-20",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "dont_know",
       "comment": "Stačilo by, aby digitalizace skutečně fungovala a lidé nemuseli běhat po úřadech."
     },
     {
       "id": "senatni-2022-31-a-165219-21",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "A samozřejmě v Ústí. Tento pragocentrismus vycucává schopné obyvatele z periferií a škodí i samotné Praze, která je pak přelidněná a předražená. V Ústí nám padají na hlavu prázdné historické budovy a v Praze se musí stavět nové. "
     },
     {
       "id": "senatni-2022-31-a-165219-22",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-31-a-165219-23",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Je to s podmínkou, když budu vědět, že české nabubřelé a předražné IT systémy jsou připraveny. Zatím se česká digitalizace potýká pravidelně s problémy a korupcí."
     },
     {
       "id": "senatni-2022-31-a-165219-24",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no",
       "comment": "Zní to lákavě a logicky, ale věřím, že chceme být mozkovna, nikoliv montovna. Mezi klíčové kompetence robotické budoucnosti patří podle OECD kreativita, schopnost spolupráce, komplexní myšlení. Tedy i měkké dovednosti. Takže soustřeďme se na budoucnost."
     },
     {
       "id": "senatni-2022-31-a-165219-25",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "dont_know",
       "comment": "Víceletá gymnázia dávají příležitost těm talentovanějším a zaroveň jejich omezená kapacita zdaleka není schopna vysát všechny talenty. Takže společná výuka u nás funguje.  "
     },
     {
       "id": "senatni-2022-31-a-165219-26",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "dont_know",
       "comment": "Inkluzivní vzdělávání samozřejmě podporuji, ale dle zkušeností z našeho regionu je to provázeno řadou problémů a nedostatečnou personální kapacitou škol. Stát by měl přidat finance i odborné vzdělávání, pokud chceme tak skvělé školství jako ve Skandinávii."
     },
     {
       "id": "senatni-2022-31-a-165219-27",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no",
       "comment": "To vážně někdo chce?"
     },
     {
       "id": "senatni-2022-31-a-165219-28",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "Mám rád tradice a s českou korunou je spojeno dost historických momentů. Myslím ale, že není důvod být mezi posledními v EU, kdo na své měně tak sentimentálně trvají. Mnohé české firmy už na € přešly, je to pro jejich byznys výhodnější a jednodušší. I pro řadové občany bude na dovolených po Evropě úleva pořád složitě nepřepočítávat ceny. "
     },
     {
       "id": "senatni-2022-31-a-165219-29",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-165219-30",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes",
       "comment": "Buďme sebevědomá a moderní země, a ne věční kverulanti, kterým opakovaně ujíždí vlak."
     },
     {
       "id": "senatni-2022-31-a-165219-31",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes",
       "comment": "Jsme dost vyspělá země na to, abychom pomáhali tam, kde to potřebují. A pokud vím, tak ČR má v tomto ohledu dobrou pověst. Argument, že máme pomáhat hlavně naším lidem chápu, ale není příliš logický. Pomoc jinde neohrožuje státní sociální politiku."
     },
     {
       "id": "senatni-2022-31-a-165219-32",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes",
       "comment": "Planeta je jen jedna."
     },
     {
       "id": "senatni-2022-31-a-165219-33",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "yes",
       "comment": "Nebál by se toho. Právo na azyl bude mít vždy základní podmínku, a tou je ohrožení uprchlíka v jeho domovině. Navíc se ukazuje, že náš trh práce potřebuje zahraniční zaměstnance. To vám potvrdí každý zaměstnavatel."
     },
     {
       "id": "senatni-2022-31-a-165219-34",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-165219-35",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "Asi každý víte proč."
     },
     {
       "id": "senatni-2022-31-a-165219-36",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know",
       "comment": "Pardon, s tímto tématem se budu teprve muset více seznámit."
     },
     {
       "id": "senatni-2022-31-a-165219-37",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-31-a-165219-38",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know",
       "comment": "To je téma, s kterým se musím více seznámit. Ale vím, že oním centrem nemůže být jen Praha. "
     },
     {
       "id": "senatni-2022-31-a-165219-39",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes",
       "comment": "Rozhodně! Je 21. století."
     },
     {
       "id": "senatni-2022-31-a-165219-40",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Nesmí se to přehánět, ale v některých místech radary možná i zachraňují životy."
     },
     {
       "id": "senatni-2022-31-a-165219-41",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-31-a-165219-42",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-165219-43",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-165219-44",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-165219-45",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no",
       "comment": "Pan Křeček má určitě své kvality. Ale ne pro práci ombudsmana."
     },
     {
       "id": "senatni-2022-31-a-165219-46",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-165219-47",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no",
       "comment": "Snad už se to víckrát nestane."
     },
     {
       "id": "senatni-2022-31-a-165219-48",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Lží a nesmyslů se kolem tohoto dokumentu vyrojilo nebývale mnoho. Fakt nedává smysl otálet s ratifikací."
     },
     {
       "id": "senatni-2022-31-a-165219-49",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "yes",
       "comment": "Dokážu ovšem pochopit, pokud to současná energetická krize neumožní. Budoucnost je ale v obnovitelných zdrojích a v decentralizované výrobě energií."
     },
     {
       "id": "senatni-2022-31-a-165219-50",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes",
       "comment": "Green Dealem se u nás straší. Doporučuji se začíst, neb je to dokument plný racionálních opatření, která samozřejmě vyžadují od vlád dost práce. Tak snad to zvládneme."
     },
     {
       "id": "senatni-2022-31-a-165219-51",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-165219-52",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-165219-53",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes",
       "comment": "Vítejte, severští přátelé."
     },
     {
       "id": "senatni-2022-31-a-165219-54",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes",
       "comment": "Dotace pro velkozemědělce ničí tradiční venkov tím, že po socialistické kolektivizaci znevýhodňují obnovu vrstvy malých a středních sedláků. "
     },
     {
       "id": "senatni-2022-31-a-165219-55",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-31-a-165219-56",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes",
       "comment": "Už k tomu přistupují některá města a dává to smysl."
     },
     {
       "id": "senatni-2022-31-a-165219-57",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-31-a-165219-58",
       "candidate_id": "senatni-2022-31-c-165219",
-      "question_id": "senatni-2022-31-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     }
   ]

--- a/data/kalkulacka/senatni-2022/34.json
+++ b/data/kalkulacka/senatni-2022/34.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-34-c-879839",
       "name": "Svatopluk Holata",
       "type": "person",
-      "description": "Svatopluk Holata - DESCRIPTION",
+      "description": "Svatopluk Holata",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/spdliberecky"
@@ -491,7 +491,7 @@
         {
           "id": "senatni-2022-34-c-879839-p",
           "name": "Svatopluk Holata",
-          "description": "Svatopluk Holata - DESCRIPTION",
+          "description": "Svatopluk Holata",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/spdliberecky"
@@ -504,7 +504,7 @@
       "id": "senatni-2022-34-c-936940",
       "name": "Martina Motshagen",
       "type": "person",
-      "description": "Martina Motshagen - DESCRIPTION",
+      "description": "Martina Motshagen",
       "contacts": {
         "web": [
           {
@@ -524,7 +524,7 @@
         {
           "id": "senatni-2022-34-c-936940-p",
           "name": "Martina Motshagen",
-          "description": "Martina Motshagen - DESCRIPTION",
+          "description": "Martina Motshagen",
           "contacts": {
             "web": [
               {
@@ -548,7 +548,7 @@
       "id": "senatni-2022-34-c-474514",
       "name": "Michael Canov",
       "type": "person",
-      "description": "Michael Canov - DESCRIPTION",
+      "description": "Michael Canov",
       "contacts": {
         "web": [
           {
@@ -572,7 +572,7 @@
         {
           "id": "senatni-2022-34-c-474514-p",
           "name": "Michael Canov",
-          "description": "Michael Canov - DESCRIPTION",
+          "description": "Michael Canov",
           "contacts": {
             "web": [
               {
@@ -600,7 +600,7 @@
       "id": "senatni-2022-34-c-990991",
       "name": "Radka Loučková Kotasová",
       "type": "person",
-      "description": "Radka Loučková Kotasová - DESCRIPTION",
+      "description": "Radka Loučková Kotasová",
       "contacts": {
         "web": [
           {
@@ -619,7 +619,7 @@
         {
           "id": "senatni-2022-34-c-990991-p",
           "name": "Radka Loučková Kotasová",
-          "description": "Radka Loučková Kotasová - DESCRIPTION",
+          "description": "Radka Loučková Kotasová",
           "contacts": {
             "web": [
               {
@@ -643,710 +643,710 @@
     {
       "id": "senatni-2022-34-a-474514-1",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-2",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-3",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-474514-4",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-5",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-6",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-7",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-8",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-9",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-10",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-474514-11",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-12",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-474514-13",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-14",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-15",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-474514-16",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Stejnopohlavní páry by měly mít právo uzavírat sňatek na stejné úrovni, ale s odpovídajícím názvem (nikoli takovým, který implikuje muže a ženu). Muži manmelství (manmel a manmel), ženy ženželství (ženželka a ženželka).  "
     },
     {
       "id": "senatni-2022-34-a-474514-17",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-18",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-19",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-20",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-21",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-474514-22",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-23",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Dosud by byla příliš velká možnost zneužití tohoto způsobu volby (hackeři apod.)  "
     },
     {
       "id": "senatni-2022-34-a-474514-24",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-25",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-26",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no",
       "comment": "Inkluze vede naopak k tomu, že slabší žáky motivuje méně, protože jsou v kolektivu outsidery. Při speciální výuce (zvláštní třídy) naopak mohou vyniknout.  "
     },
     {
       "id": "senatni-2022-34-a-474514-27",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-28",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-29",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-30",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-474514-31",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-474514-32",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-33",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-34",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-35",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-36",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-37",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-38",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-39",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-474514-40",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-41",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-42",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-43",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-44",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-45",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-474514-46",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-47",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-48",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "no",
       "comment": "V ČR je toto ošetřeno dostatečně. "
     },
     {
       "id": "senatni-2022-34-a-474514-49",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-50",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "Mnohem důležitější je, aby směrem k větší ekologii šel cely svět (Indie, Čína atd.). Ostrov uhlíkový neutrality (EU) ve světě, kde by tomu jinde ve světě vůbec nebylo,  by byl svojí efektivitou bezvýznamný a naopak by EU zničil konkureschopnost.    "
     },
     {
       "id": "senatni-2022-34-a-474514-51",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-52",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "dont_know",
       "comment": "Měla by v případě, že to nedokáže EU jako celek. "
     },
     {
       "id": "senatni-2022-34-a-474514-53",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-54",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-55",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-56",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-474514-57",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-474514-58",
       "candidate_id": "senatni-2022-34-c-474514",
-      "question_id": "senatni-2022-34-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-1",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-2",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-3",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-990991-4",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-5",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-6",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes",
       "comment": "Ano, ale s rozmyslem, tedy tam, kde to opravdu dává smysl a pomáhá i při ohrožení například přívalovými dešti či povodněmi."
     },
     {
       "id": "senatni-2022-34-a-990991-7",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-990991-8",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-9",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Měla by být ale stanovena hranice množství, které je pro vlastní potřebu."
     },
     {
       "id": "senatni-2022-34-a-990991-10",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-11",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-12",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-13",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-14",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "dont_know",
       "comment": "Rozhodně by ale mělo veřejnoprávní vysílání poskytovat objektivní a kvalitní obsah, to se nyní neděje!"
     },
     {
       "id": "senatni-2022-34-a-990991-15",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-16",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-17",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-990991-18",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-19",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "Stavět sociální byty má být možnost a ne povinnost. Stát by měl vytvářet podmínky pro  dostupné nájemní bydlení zejména pro mladé, ale také pro nízkopříjmové skupiny."
     },
     {
       "id": "senatni-2022-34-a-990991-20",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-990991-21",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-22",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-23",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Ano, ale musí být dostatečně zabezpečeno proti zneužití."
     },
     {
       "id": "senatni-2022-34-a-990991-24",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-25",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Myslím, že je velmi důležitá práce s talenty."
     },
     {
       "id": "senatni-2022-34-a-990991-26",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-990991-27",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-28",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "Ano, ale ne dříve než v roce 2028."
     },
     {
       "id": "senatni-2022-34-a-990991-29",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-30",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-990991-31",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-990991-32",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-990991-33",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-34",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-35",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-36",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-37",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-38",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-990991-39",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-990991-40",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-41",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-42",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-43",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-44",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-45",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-46",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-47",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-48",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-49",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-50",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-990991-51",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-52",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-34-a-990991-53",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-54",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-34-a-990991-55",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-56",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-57",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-34-a-990991-58",
       "candidate_id": "senatni-2022-34-c-990991",
-      "question_id": "senatni-2022-34-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     }
   ]

--- a/data/kalkulacka/senatni-2022/37.json
+++ b/data/kalkulacka/senatni-2022/37.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-37-c-828456",
       "name": "Tomáš Czernin",
       "type": "person",
-      "description": "Tomáš Czernin - DESCRIPTION",
+      "description": "Tomáš Czernin",
       "contacts": {
         "web": [
           {
@@ -498,7 +498,7 @@
         {
           "id": "senatni-2022-37-c-828456-p",
           "name": "Tomáš Czernin",
-          "description": "Tomáš Czernin - DESCRIPTION",
+          "description": "Tomáš Czernin",
           "contacts": {
             "web": [
               {
@@ -518,7 +518,7 @@
       "id": "senatni-2022-37-c-844780",
       "name": "René Franěk",
       "type": "person",
-      "description": "René Franěk - DESCRIPTION",
+      "description": "René Franěk",
       "contacts": {
         "web": [
           {
@@ -538,7 +538,7 @@
         {
           "id": "senatni-2022-37-c-844780-p",
           "name": "René Franěk",
-          "description": "René Franěk - DESCRIPTION",
+          "description": "René Franěk",
           "contacts": {
             "web": [
               {
@@ -562,7 +562,7 @@
       "id": "senatni-2022-37-c-383315",
       "name": "Václav Ort",
       "type": "person",
-      "description": "Václav Ort - DESCRIPTION",
+      "description": "Václav Ort",
       "contacts": {
         "web": [
           {
@@ -576,7 +576,7 @@
         {
           "id": "senatni-2022-37-c-383315-p",
           "name": "Václav Ort",
-          "description": "Václav Ort - DESCRIPTION",
+          "description": "Václav Ort",
           "contacts": {
             "web": [
               {
@@ -594,7 +594,7 @@
       "id": "senatni-2022-37-c-664833",
       "name": "Marta Martinová",
       "type": "person",
-      "description": "Marta Martinová - DESCRIPTION",
+      "description": "Marta Martinová",
       "contacts": {
         "web": [
           {
@@ -618,7 +618,7 @@
         {
           "id": "senatni-2022-37-c-664833-p",
           "name": "Marta Martinová",
-          "description": "Marta Martinová - DESCRIPTION",
+          "description": "Marta Martinová",
           "contacts": {
             "web": [
               {
@@ -646,7 +646,7 @@
       "id": "senatni-2022-37-c-957667",
       "name": "Jaromír Dědeček",
       "type": "person",
-      "description": "Jaromír Dědeček - DESCRIPTION",
+      "description": "Jaromír Dědeček",
       "contacts": {
         "web": [
           {
@@ -660,7 +660,7 @@
         {
           "id": "senatni-2022-37-c-957667-p",
           "name": "Jaromír Dědeček",
-          "description": "Jaromír Dědeček - DESCRIPTION",
+          "description": "Jaromír Dědeček",
           "contacts": {
             "web": [
               {
@@ -678,7 +678,7 @@
       "id": "senatni-2022-37-c-593846",
       "name": "Eva Kotyzová",
       "type": "person",
-      "description": "Eva Kotyzová - DESCRIPTION",
+      "description": "Eva Kotyzová",
       "contacts": {
         "web": [
           {
@@ -693,7 +693,7 @@
         {
           "id": "senatni-2022-37-c-593846-p",
           "name": "Eva Kotyzová",
-          "description": "Eva Kotyzová - DESCRIPTION",
+          "description": "Eva Kotyzová",
           "contacts": {
             "web": [
               {
@@ -712,7 +712,7 @@
       "id": "senatni-2022-37-c-116316",
       "name": "Dana Kracíková",
       "type": "person",
-      "description": "Dana Kracíková - DESCRIPTION",
+      "description": "Dana Kracíková",
       "contacts": {
         "web": [
           {
@@ -732,7 +732,7 @@
         {
           "id": "senatni-2022-37-c-116316-p",
           "name": "Dana Kracíková",
-          "description": "Dana Kracíková - DESCRIPTION",
+          "description": "Dana Kracíková",
           "contacts": {
             "web": [
               {
@@ -757,1096 +757,1096 @@
     {
       "id": "senatni-2022-37-a-828456-1",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-2",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-3",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-4",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Infrastruktura pro rychlovlaky vyžaduje vysoké pořizovací náklady. Provoz bude náročný na elektrickou energii."
     },
     {
       "id": "senatni-2022-37-a-828456-5",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-6",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-7",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-8",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-9",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-10",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-11",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-12",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-13",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-14",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-15",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-16",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know",
       "comment": "Nepovažuji za úplně důležité, jak se partnerství dvou lidí nazývá. Stejnopohlavní páry by měly mít stejná práva, zejména v otázkách společného jmění, práva na bydlení, partner by měl být každopádně považován za osobu blízkou v otázkách zdravotního stavu, dědictví či rodičovství."
     },
     {
       "id": "senatni-2022-37-a-828456-17",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-18",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-19",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-20",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-21",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-22",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-23",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-24",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-25",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-26",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-27",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-28",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-29",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-30",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-31",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-32",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-33",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know",
       "comment": "Současný způsob udělování azylu nevyžaduje změnu."
     },
     {
       "id": "senatni-2022-37-a-828456-34",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-35",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-36",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-37",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-38",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-39",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "no",
       "comment": "Souhlasím se současnou normou, která zakazuje použití na plodiny pro potravinářské využití. Jsem pro šetrné použití v mezních případech. Při likvidaci vytrvalých plevelů při posklizňové aplikaci zatím glyfosát nemá náhradu. "
     },
     {
       "id": "senatni-2022-37-a-828456-40",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-41",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-42",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-43",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-44",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-45",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-46",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-47",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-48",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-49",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-50",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-51",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-52",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-53",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-54",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-828456-55",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know",
       "comment": "Považoval bych to za logické ve veřejných budovách"
     },
     {
       "id": "senatni-2022-37-a-828456-56",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-828456-57",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no",
       "comment": "Dějiny se nesmí opakovat! V této otázce je jasná paralera s Mnichovskou dohodou. "
     },
     {
       "id": "senatni-2022-37-a-828456-58",
       "candidate_id": "senatni-2022-37-c-828456",
-      "question_id": "senatni-2022-37-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-664833-1",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes",
       "comment": "Výstavba investičních bytů, ve kterých reálně nikdo nebydlí, zvyšuje nájemní bydlení všem."
     },
     {
       "id": "senatni-2022-37-a-664833-2",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Obce by ale měly být výrazně podpořeny v budování vlastních nájemních bytů."
     },
     {
       "id": "senatni-2022-37-a-664833-3",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Ano, petiční právo obecně by mělo být posíleno."
     },
     {
       "id": "senatni-2022-37-a-664833-4",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "dont_know",
       "comment": "Především si zaslouží modernizaci naše stávající síť – je dlouhodobě zanedbávaná a není tak konkurenceschopná vůči automobilové dopravě. Hlavní tratě nemají aktuálně ani kapacitu na další nákladní vlaky.\n"
     },
     {
       "id": "senatni-2022-37-a-664833-5",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Je potřeba adekvátně odměňovat ty, kteří chtějí pracovat i v důchodu: je to výhodné pro stát i seniory. "
     },
     {
       "id": "senatni-2022-37-a-664833-6",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "Přehrady nám se suchem     nepomohou – je třeba zaměřit se na systém vodozádržných a přírodě blízkých opatření v krajině. Prázdné přehrady všude po světě ukazují, že technická řešení nepřinášejí v aktuálním podnebí kýžený výsledek.\n"
     },
     {
       "id": "senatni-2022-37-a-664833-7",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "dont_know",
       "comment": "Mnohem důležitější je, aby se zvýšilo množství odpadu, který se po vytřídění skutečně recykluje v nové materiály a výrobky. "
     },
     {
       "id": "senatni-2022-37-a-664833-8",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "dont_know",
       "comment": "Mělo by dojít ke snížení zdanění nízkopříjmových obyvatel.\n"
     },
     {
       "id": "senatni-2022-37-a-664833-9",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-664833-10",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Problém je ale hlavně v tom, že jsou nyní v trestním řízení udělovány nízké tresty. Je potřeba napravit definici znásilnění tak, aby zahrnovala i situace, kdy oběť nedokáže projevit odpor. "
     },
     {
       "id": "senatni-2022-37-a-664833-11",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Podporuji zavedení globální minimální daně.\n"
     },
     {
       "id": "senatni-2022-37-a-664833-12",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Právní odpovědnost provozovatelů sociálních sítí za obsah jejich uživatelů by vedla k omezování svobody slova."
     },
     {
       "id": "senatni-2022-37-a-664833-13",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": " Boj s fake news je třeba založit na mediální výchově ve školách.\n"
     },
     {
       "id": "senatni-2022-37-a-664833-14",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Ne, rady veřejnoprávních médií by se však měly stát politicky nezávislými a skládat se především ze skutečných mediálních odborníků a odbornic.\n"
     },
     {
       "id": "senatni-2022-37-a-664833-15",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes",
       "comment": "Agenturní zaměstnávání trvale devalvuje pracovní podmínky a pokřivuje trh práce."
     },
     {
       "id": "senatni-2022-37-a-664833-16",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes",
       "comment": "Jsem přesvědčená o tom, že všichni lidé by měli mít stejná práva i povinnosti. A dlouhodobé     průzkumy veřejného mínění potvrzují, že manželství pro všechny chce i většina české společnosti. "
     },
     {
       "id": "senatni-2022-37-a-664833-17",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes",
       "comment": "Zavedením místní příslušnosti se zvýší přezkoumatelnost činnosti exekutorů."
     },
     {
       "id": "senatni-2022-37-a-664833-18",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes",
       "comment": "Jde o efektivní nástroj proti dluhovým pastem.\n"
     },
     {
       "id": "senatni-2022-37-a-664833-19",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "dont_know",
       "comment": "Sociální bydlení by ale být navázáno potřebu v konkrétní lokalitě (tedy nesouhlasím s „musí“ a „vždy“). Obce by měly být motivovány k rozvoji bytového fondu, jehož součástí je sociální bydlení.   "
     },
     {
       "id": "senatni-2022-37-a-664833-20",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes",
       "comment": "V současné době v informování veřejnosti hrají zásadní roli neziskové organizace – stát by měl ale dělat víc v informování občanů o nároku na dávky.\n"
     },
     {
       "id": "senatni-2022-37-a-664833-21",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know",
       "comment": "U vybraných úřadů si to umím představit."
     },
     {
       "id": "senatni-2022-37-a-664833-22",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know",
       "comment": "Výzkum spojený s kolonizací přináší technologie využitelné pro řešení aktuálních problémů. Praktickou realizaci kolonizace Marsu ale považuji ve chvíli, kdy čelíme několika globálním krizím, za skutečně vedlejší."
     },
     {
       "id": "senatni-2022-37-a-664833-23",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Ano, za podmínky, že budou naplněny všechny ústavněprávní požadavky a IT infrastruktura ve stavu, který spolehlivě zajistí bezpečný průběh.\n"
     },
     {
       "id": "senatni-2022-37-a-664833-24",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no",
       "comment": "Vzhledem k rychlému rozvoji technologií a proměnám pracovního trhu už není udržitelný scénář, že se člověk vyučí v oboru, v němž celý život pracuje. Naučit by se tedy měl především všeobecnému přehledu, kritickému myšlení a samotné schopnosti se učit."
     },
     {
       "id": "senatni-2022-37-a-664833-25",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Měla by být možnost zvolit si různé možnosti způsobů vzdělávání, jako je individuální vzdělávání. Vzdělávání by mělo být stále povinné, školní docházka by ale měla být jen jednou z možností jak povinnost splnit."
     },
     {
       "id": "senatni-2022-37-a-664833-26",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "26 V oblasti inkluze se musíme zaměřit především na dobře cílenou podporu přímo školám, dlouhodobé a fungující financování, podporu a profesní rozvoj učitelů.\n"
     },
     {
       "id": "senatni-2022-37-a-664833-27",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-664833-28",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "Ano, ale nejprve je třeba stabilizovat korunu vůči euru."
     },
     {
       "id": "senatni-2022-37-a-664833-29",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-664833-30",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-664833-31",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-664833-32",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-664833-33",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "yes",
       "comment": "Žádost o azyl musí být především zefektivněna. Azylové řízení by samozřejmě nadále mělo splňovat požadavky na bezpečnostní kontrolu příchozích."
     },
     {
       "id": "senatni-2022-37-a-664833-34",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-664833-35",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-37-a-664833-36",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-664833-37",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no",
       "comment": "V konečném důsledku by možnost soukromého připojištění vedla ke zhoršení standardní péče, a rozevírání nůžek v dostupnosti potřebné péče mezi bohatými a chudými."
     },
     {
       "id": "senatni-2022-37-a-664833-38",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know",
       "comment": "S centralizací vysoce specializované péče souhlasím, s tímto krokem ale nesmí dojít k zhoršení dostupnosti běžnější péče."
     },
     {
       "id": "senatni-2022-37-a-664833-39",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes",
       "comment": "U této látky bylo prokázáno, že je zdraví vysoce nebezpečná. Zároveň je ale třeba vyvíjet a testovat přípravky, kterými ho budeme moci efektivně nahradit.\n"
     },
     {
       "id": "senatni-2022-37-a-664833-40",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-664833-41",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes",
       "comment": "Fungování biometrického sledování lze jen obtížně veřejně kontrolovat."
     },
     {
       "id": "senatni-2022-37-a-664833-42",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes",
       "comment": "Ano, pokud splní podmínky vstupu (Kodaňská kritéria)."
     },
     {
       "id": "senatni-2022-37-a-664833-43",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know",
       "comment": "Ukrajina aktuálně o vstup neusiluje, nicméně o vstupu či nevstupu jakéhokoli státu do NATO by neměla rozhodovat žádná autoritářská země mimo NATO, byť jde o jadernou velmoc."
     },
     {
       "id": "senatni-2022-37-a-664833-44",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes",
       "comment": "Ano, současná krize vyžaduje jednotný postup evropského trhu.\n"
     },
     {
       "id": "senatni-2022-37-a-664833-45",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no",
       "comment": "Stanislav Křeček se nechová jako nestranný a nezávislý ombudsman, který má hájit práva všech občanů. "
     },
     {
       "id": "senatni-2022-37-a-664833-46",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes",
       "comment": "Ano, pokud tato otázka znamená odpovědnost za válečné zločiny a platby poválečných reparací. "
     },
     {
       "id": "senatni-2022-37-a-664833-47",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no",
       "comment": "O čem? Podmínky ústupu Ruska z Ukrajiny by měla vyjednat ukrajinská administrativa."
     },
     {
       "id": "senatni-2022-37-a-664833-48",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Ano, bagatelizace domácího násilí musí skončit."
     },
     {
       "id": "senatni-2022-37-a-664833-49",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "yes",
       "comment": "Ano, mělo by skončit co nejdříve, je třeba urychleně podpořit rozvoj obnovitelných zdrojů energie, což ČR dlouhodobě a naprosto zanedbávala (přičemž 2/3 roční spotřeby uhlí ČR dováží).     \n"
     },
     {
       "id": "senatni-2022-37-a-664833-50",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes",
       "comment": "Současná energetická krize není dopadem politik směřujících k uhlíkové neutralitě, ale naopak odrazem naší trvající závislosti na fosilních palivech. Občanky a občany je třeba podpořit v tom, aby své energetické potřeby dokázali naplňovat sami nebo s pomocí obcí a to nejlépe umožňují OZE v kombinaci s efektivními úsporami spotřeby."
     },
     {
       "id": "senatni-2022-37-a-664833-51",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-664833-52",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no",
       "comment": "Ne, fakticky by to znamenalo vazalství vůči autoritářskému režimu, které by se dlouhodobě vymstilo. Je třeba hledat celoevropské řešení krize s plynem."
     },
     {
       "id": "senatni-2022-37-a-664833-53",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-664833-54",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "dont_know",
       "comment": "Otázka špatně položena. Menší zemědělci byli v dotačním systému dlouhodobě diskriminování, to je určitě třeba narovnat. Platby, které zemědělci od společnosti dostávají, by ale hlavně měly kompenzovat úsilí přínosné pro celou společnost, např. opatření na zádrž vody v krajině bránící suchu i povodním. "
     },
     {
       "id": "senatni-2022-37-a-664833-55",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-664833-56",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "dont_know",
       "comment": "Budovat bytový fond by mělo být v kompetenci obcí. Stát by měl zajistit legislativní rámec, metodickou podporu a pomoc efektivnímu fungování trhu s bydlením.     \n"
     },
     {
       "id": "senatni-2022-37-a-664833-57",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-664833-58",
       "candidate_id": "senatni-2022-37-c-664833",
-      "question_id": "senatni-2022-37-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Vleklé vymáhání pohledávek, ve kterých jde často už jen o uměle navyšované náklady za vedení exekucí, neúměrně zatěžují nejen úřady, ale hlavně zaměstnavatele. Dlužníci se pak skrývají v šedé ekonomice nebo jsou zbytečně na dávkách. Tím mrháme nejen penězi, ale i     potřebnou pracovní silou."
     },
     {
       "id": "senatni-2022-37-a-116316-1",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-2",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Regulované nájemné je možné uplatnit u výstavby sociálních bytů obcemi za pomoci dotace, ale obecně regulovat ceny nájemného by pokřivilo tržní prostředí."
     },
     {
       "id": "senatni-2022-37-a-116316-3",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-4",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-5",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-6",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-7",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-8",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-9",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-10",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-11",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-12",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-13",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-14",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-15",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-16",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-17",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-18",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-19",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-20",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-21",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-22",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-23",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-24",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-25",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-26",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-27",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-28",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-29",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-30",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-31",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-32",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-33",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-34",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-35",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-36",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-37",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-38",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-39",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-40",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-41",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-42",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-43",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-44",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-45",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-46",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-47",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-48",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-49",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-50",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-51",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-52",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-53",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-54",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-37-a-116316-55",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-56",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-57",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-37-a-116316-58",
       "candidate_id": "senatni-2022-37-c-116316",
-      "question_id": "senatni-2022-37-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     }
   ]

--- a/data/kalkulacka/senatni-2022/4.json
+++ b/data/kalkulacka/senatni-2022/4.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-4-c-871435",
       "name": "Alena Dernerová",
       "type": "person",
-      "description": "Alena Dernerová - DESCRIPTION",
+      "description": "Alena Dernerová",
       "contacts": {
         "web": [
           {
@@ -497,7 +497,7 @@
         {
           "id": "senatni-2022-4-c-871435-p",
           "name": "Alena Dernerová",
-          "description": "Alena Dernerová - DESCRIPTION",
+          "description": "Alena Dernerová",
           "contacts": {
             "web": [
               {
@@ -516,7 +516,7 @@
       "id": "senatni-2022-4-c-737193",
       "name": "Hana Aulická Jírovcová",
       "type": "person",
-      "description": "Hana Aulická Jírovcová - DESCRIPTION",
+      "description": "Hana Aulická Jírovcová",
       "contacts": {
         "web": [
           {
@@ -532,7 +532,7 @@
         {
           "id": "senatni-2022-4-c-737193-p",
           "name": "Hana Aulická Jírovcová",
-          "description": "Hana Aulická Jírovcová - DESCRIPTION",
+          "description": "Hana Aulická Jírovcová",
           "contacts": {
             "web": [
               {
@@ -552,7 +552,7 @@
       "id": "senatni-2022-4-c-248303",
       "name": "Ivana Turková",
       "type": "person",
-      "description": "Ivana Turková - DESCRIPTION",
+      "description": "Ivana Turková",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/Ivana-Turkov%C3%A1-SPD-102412049180933"
@@ -561,7 +561,7 @@
         {
           "id": "senatni-2022-4-c-248303-p",
           "name": "Ivana Turková",
-          "description": "Ivana Turková - DESCRIPTION",
+          "description": "Ivana Turková",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/Ivana-Turkov%C3%A1-SPD-102412049180933"
@@ -574,7 +574,7 @@
       "id": "senatni-2022-4-c-729274",
       "name": "Michal Moravec",
       "type": "person",
-      "description": "Michal Moravec - DESCRIPTION",
+      "description": "Michal Moravec",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/profile.php?id=100008528281083"
@@ -583,7 +583,7 @@
         {
           "id": "senatni-2022-4-c-729274-p",
           "name": "Michal Moravec",
-          "description": "Michal Moravec - DESCRIPTION",
+          "description": "Michal Moravec",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/profile.php?id=100008528281083"
@@ -596,7 +596,7 @@
       "id": "senatni-2022-4-c-425473",
       "name": "Jan Paparega",
       "type": "person",
-      "description": "Jan Paparega - DESCRIPTION",
+      "description": "Jan Paparega",
       "contacts": {
         "web": [
           {
@@ -610,7 +610,7 @@
         {
           "id": "senatni-2022-4-c-425473-p",
           "name": "Jan Paparega",
-          "description": "Jan Paparega - DESCRIPTION",
+          "description": "Jan Paparega",
           "contacts": {
             "web": [
               {
@@ -629,774 +629,774 @@
     {
       "id": "senatni-2022-4-a-729274-1",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Nelze někomu určovat, jak má zacházet se svým majetkem. Tohle už tu jednou bylo a nepřineslo to nic dobrého. Dodnes se s tím jako stát potýkáme."
     },
     {
       "id": "senatni-2022-4-a-729274-2",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Pokud se jedná o soukromý bytový fond, tak stát nesmí zasahovat do rozhodnutí majitele. Stát může regulovat jenom to, co skutečně vlastní z více než 50%. "
     },
     {
       "id": "senatni-2022-4-a-729274-3",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Referendum je nejvyšší formou demokracie a pokud se k těmto principům chceme hlásit, je referendum nedílnou součástí veřejné politiky."
     },
     {
       "id": "senatni-2022-4-a-729274-4",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Infrastrukturu je třeba řešit komplexně s přihlédnutím k možnostem a potřebám každého regionu. Není možné, aby někde jezdil rychlovlak a jinde nejede ani školní autobus a tím pádem dochází k vylidňování malých obcí."
     },
     {
       "id": "senatni-2022-4-a-729274-5",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Stárnutí populace sice k těmto úvahám přispívá, ale každý nemá to \"štěstí\", aby měl pevné zdraví potřebné k výkonu práce i po 65 - pátém roku života. Nechal bych to na individuálním posouzení každého jednotlivce. Pokud by tak chtěl udělat stát, tak je nutné k tomu přistoupit velice zodpovědně a třeba zákonem o zdravotním přezkumu každého jednotlivce každých 6 měsíců pro posouzení zdravotního stavu. Samozřejmě by náklady na tyto vyšetření v plné ceně hradil stát!"
     },
     {
       "id": "senatni-2022-4-a-729274-6",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know",
       "comment": "Tohle téma je vysoce odborné a mají ho řešit odborníci, kteří se touto problematikou zabývají."
     },
     {
       "id": "senatni-2022-4-a-729274-7",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes",
       "comment": "Je to nejjednodušší způsob, jak snížit dopad na životní prostředí a recyklaci těchto odpadů."
     },
     {
       "id": "senatni-2022-4-a-729274-8",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Pokud je někdo šikovný, tak zájem státu by měl být ten, aby byl i spokojený. Stát by měl být ten, kdo občany k vyšším výdělkům a tím i k větší pracovitosti motivuje a ne, že je bude trestat za úspěch. Daň 15% je nastavená dobře a každý, kdo vychodil ZŠ ví, že z výdělku 10 000,- Kč je daň 1 500,- Kč a ze 100 000,- Kč je daň 15 000,- Kč, takže ten úspěšnější už vyšší daň odvede a nemusím ho trestat za úspěch a pracovitost. "
     },
     {
       "id": "senatni-2022-4-a-729274-9",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "no",
       "comment": "Léčebné účinky už asi nikdo nezpochybňuje, ale rozhodnou úlohu musí mít stát. U alkoholu a tabáku jsou také nastavena pravidla s vůdčí úlohou státu."
     },
     {
       "id": "senatni-2022-4-a-729274-10",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Je ovšem potřeba, aby se změnila právní legislativa. Nelze jenom někoho nařknout a po prokázání účelového obvinění nechat za sebou zlikvidovaného člověka a dělat, že je to OK. Stejný trest by měl být uložen tomu, kdo druhého obviní a obvinění není prokázáno."
     },
     {
       "id": "senatni-2022-4-a-729274-11",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Ano, jsou to globální firmy, které určují trh a oni rozhodují o tom jaký obsah povolí, nebo ne. Za tuto svou téměř monopolní pozici je nutné zaplatit exklusivitu na trhu kdekoliv na světě."
     },
     {
       "id": "senatni-2022-4-a-729274-12",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Jelikož se jedná o firmy , které mají monopol v komunikaci a médiích, měli by zveřejňovat všechen obsah a jeho závadnost, či nezávadnost musí posoudit stát, ve kterém je obsah zveřejněn. Jenom stát, má právo podle platné právní legislativy posoudit, jaký obsah a kdo sdílel, nebo zveřejnil. Nelze udělat z majitelů sociálních sítí tzv. nosiče pravdy a toho jediného správného názoru. Proto by měli platit daň ve všech zemích, kde působí a daný stát určí, jaký obsah je v pořádku, nebo už je v trestněprávní rovině tzv. za hranou."
     },
     {
       "id": "senatni-2022-4-a-729274-13",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "Jelikož se jedná o firmy , které mají monopol v komunikaci a médiích, měli by zveřejňovat všechen obsah a jeho závadnost, či nezávadnost musí posoudit stát, ve kterém je obsah zveřejněn. Jenom stát, má právo podle platné právní legislativy posoudit, jaký obsah a kdo sdílel, nebo zveřejnil. Nelze udělat z majitelů sociálních sítí tzv. nosiče pravdy a toho jediného správného názoru. Proto by měli platit daň ve všech zemích, kde působí a daný stát určí, jaký obsah je v pořádku, nebo už je v trestněprávní rovině tzv. za hranou."
     },
     {
       "id": "senatni-2022-4-a-729274-14",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-4-a-729274-15",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no",
       "comment": "Na pracovní agentury je navázána spousta lidí, kteří z nějakého důvodu nemohou vykonávat klasický pracovní úvazek a tím by přišli o možnost výdělku. Dalo by se možná zpřísnit v tom, že bez toho jaký úvazek brigádník vykonává, by se odváděli odvody na soc. pojištění a zdr. pojištění v minimální výši."
     },
     {
       "id": "senatni-2022-4-a-729274-16",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Manželství je odvozeno od svazku muže a ženy - manžel a manželka, což u stejnopohlavních párů je poměrně složité určit a rozdělit. Instituce k této alternativě už existují, jenom by se měly doladit nějaké právní detaily. Nicméně ani církev nepovoluje sňatek stejnopohlavních párů v kostele a to je také jedna z \"podmínek\" běžného manželství - možnost uzavřít církevní sňatek."
     },
     {
       "id": "senatni-2022-4-a-729274-17",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes",
       "comment": "Určitě by se tím zlepšila vazba dlužník - exekutor a nemohly by být účtovány nesmyslné platby za \"služební cesty\" exekutora, které je velmi obtížné prokázat a další nesmyslné \"náklady\" na exekuci. Těch věcí je spousta, které by to zlepšilo, ale v pár větách se to nedá shrnout."
     },
     {
       "id": "senatni-2022-4-a-729274-18",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes",
       "comment": "Ušetření peněz dlužníkům, kteří tím, že jsou v exekuci už mají takové problémy, že se do ní dostali."
     },
     {
       "id": "senatni-2022-4-a-729274-19",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Určitě. Jenom u soukromé bych to nevyžadoval na 100%, ale spíš nějakou investiční pobídkou. U státní a obecní výstavby bych to uzákonil procenty, nebo počtem bytových jednotek, podle typu výstavby."
     },
     {
       "id": "senatni-2022-4-a-729274-20",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Lidé jsou natolik rozumní, kdy si umí zhodnotit situaci v níž se nachází a sami potom aktivně hledají řešení. Ano, jsou případy imobilních a sociálně vyloučených občanů, ale to se dá zvládnout ve spolupráci s ošetřujícími( obvodními) lékaři a sousedy. Pro lidi bez domova jsou zde neziskové organizace, které za tímto účelem založené a ty potom přistupují k té aktivní formě vyhledávání."
     },
     {
       "id": "senatni-2022-4-a-729274-21",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "V první řadě by to zvýšilo atraktivitu a důležitost regionů a nové pracovní příležitosti pro vysoce kvalifikované odborníky, kteří tím zajistí i snížení odlivu lidí z \"venkova\"."
     },
     {
       "id": "senatni-2022-4-a-729274-22",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-4-a-729274-23",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Zatím pro tuto formu volby nenastal čas. To je otázka pro rok 2035 a výše, jelikož je zde pořád vysoké procento lidí počítačově méně zdatných. Navíc poslední výsledky voleb v zahraničí, kde je zavedena \"jenom\" korespondenční volba, zanechaly zvláštní pachuť regulérnosti voleb."
     },
     {
       "id": "senatni-2022-4-a-729274-24",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "Nelze to brát ovšem jako mantru. Je potřeba rozvíjet VŠ komplexně. Určitě bych ale snížil o nějaké procento obory humanitních studií a směrů."
     },
     {
       "id": "senatni-2022-4-a-729274-25",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Nejdéle do konce prvního stupně, se rozpozná schopnost dětí pro učení a to je asi í moment, kdy by měli mít individuální studijní program, který bude respektovat jejich schopnosti a možnosti. Jakékoliv zbytečné další nároky je frustrují a brzdí v činnostech, které by jim mohli pomoci k lepšímu rozvoji. To je bohužel v \"běžné\" škole, vzhledem k povaze základního školství, nemožné."
     },
     {
       "id": "senatni-2022-4-a-729274-26",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "Ano. Má být motivační, ale jak jsem odpovídal o otázku výše. Od druhého stupně to zatím, vzhledem k povaze našeho školství, považuji spíše za škodu pro všechny zúčastněné."
     },
     {
       "id": "senatni-2022-4-a-729274-27",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "yes",
       "comment": "Ano. Tak jek se EU prezentuje v posledních 5 letech, je členství v této instituci pro naše občany neperspektivní."
     },
     {
       "id": "senatni-2022-4-a-729274-28",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "Jak je patrné, tak státy, které se vzdaly své národní měny, schudly a s nimi i jejich občané."
     },
     {
       "id": "senatni-2022-4-a-729274-29",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes",
       "comment": "NATO neplní už dávno úlohu obranného paktu. A teď se to ukazuje znovu."
     },
     {
       "id": "senatni-2022-4-a-729274-30",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no",
       "comment": "Místo ČR je  v srdci Evropy. Určitě ne v \"jádru\" EU."
     },
     {
       "id": "senatni-2022-4-a-729274-31",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "Ne, dokud nebude mít vyřešeny své domácí problémy."
     },
     {
       "id": "senatni-2022-4-a-729274-32",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes",
       "comment": "Ano u zákonů o klimatu ano, ale jinak by měla brát ohled hlavně na své občany."
     },
     {
       "id": "senatni-2022-4-a-729274-33",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Naopak zpřísnit. Už kvůli bezpečnostní situaci v Evropě."
     },
     {
       "id": "senatni-2022-4-a-729274-34",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "no",
       "comment": "Volný pohyb osob lze vyjednat s každým státem zvlášť. Navíc Německo teď zrovna mluví o zavedení hraničních kontrol s ČR. Fajn udělejme je také. Zvýšíme tím společně s Němci Maďary, Poláky bezpečnost Evropy v otázce nelegální migrace."
     },
     {
       "id": "senatni-2022-4-a-729274-35",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "Ano. Bojeschopná armáda je potřeba. Hlavně v této době, když nás vlastní vláda a ministryně odzbrojili!"
     },
     {
       "id": "senatni-2022-4-a-729274-36",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Je to smutné, když někdo musí podstoupit umělé oplodnění, ale při přirozeném oplodnění ta šance ovlivnění pohlaví také není. A je to dobře! Nehrajme si na \"bohy\" jenom proto, že to umíme!"
     },
     {
       "id": "senatni-2022-4-a-729274-37",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-729274-38",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know",
       "comment": "Nemám úplně jasno. Někdo může brát centralizaci specializací jako zhoršení dostupnosti zdravotní péče a někdo jako posun dopředu, jako možnost mít nejmodernější vybavení, zvýšení kapacit těchto pracovišť, akorát by se musel pacient přepravit třeba na větší vzdálenost. To záleží na tom, kdo jak to uchopí."
     },
     {
       "id": "senatni-2022-4-a-729274-39",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-4-a-729274-40",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "yes",
       "comment": "Tato kompetence by měla patřit jen a pouze polici. Dnes jsou systémy, které i bez finančních sankcí dokáží zajistit dodržení nejvyšší povolené rychlosti. Buď jde o bezpečné silnice, nebo o kšeft."
     },
     {
       "id": "senatni-2022-4-a-729274-41",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-4-a-729274-42",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know",
       "comment": "Ukrajina ať si dělá svou politiku. Mě zajímají občané ČR."
     },
     {
       "id": "senatni-2022-4-a-729274-43",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know",
       "comment": "Jak už jsem psal o otázku výše. Je to jejich rozhodnutí, se všemi plusy i minusy z toho vyplývající. Nejsem kompetentní k tomu, abych dělal Ukrajinskou zahraniční politiku."
     },
     {
       "id": "senatni-2022-4-a-729274-44",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes",
       "comment": "Ano.  Zastropovat jí, ale musíme především my, jako ČR. "
     },
     {
       "id": "senatni-2022-4-a-729274-45",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-729274-46",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-729274-47",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "dont_know",
       "comment": "Proč na Krymu? A o čem?"
     },
     {
       "id": "senatni-2022-4-a-729274-48",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Ano, ale ta směrnice není jenom o tomto problému."
     },
     {
       "id": "senatni-2022-4-a-729274-49",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "V současné situaci a chvíli je to sebevražda."
     },
     {
       "id": "senatni-2022-4-a-729274-50",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "V současné situaci a chvíli je to sebevražda."
     },
     {
       "id": "senatni-2022-4-a-729274-51",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "yes",
       "comment": "Stejně jako ČR uznalo Kosovo jako suverénní stát bez souhlasu Srbska. Situace je i okolnosti jsou stejné a pokud si chceme hrát na morálně a korektně se chovající společenství, tak se tak mělo dávno stát."
     },
     {
       "id": "senatni-2022-4-a-729274-52",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Pokud nemáme jinou alternativu, tak ano. Stejně jako to dělají i naši \"spojenci\" z EU."
     },
     {
       "id": "senatni-2022-4-a-729274-53",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "dont_know",
       "comment": "Je to věc obou těchto suverénních států."
     },
     {
       "id": "senatni-2022-4-a-729274-54",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "dont_know",
       "comment": "Dotace by neměly být vůbec, ale trh v Evropě je tak pokřivený, že odpověď ANO,NE je velice zavádějící."
     },
     {
       "id": "senatni-2022-4-a-729274-55",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "Pak budeme rozdávat ještě boty, kalhoty, košile...... Proboha proberte se! Nejsme ve válce a kdo to tvrdí, tak je válečný štváč a dezinformátor! Premiéra a vládu ČR nevyjímaje."
     },
     {
       "id": "senatni-2022-4-a-729274-56",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "dont_know",
       "comment": "Od toho jsou obce, města. Ty musí vytvořit bytový fond a dát tomu nějaký řád. Včetně sociálního bydlení. Je možné a i dokonce žádoucí přizvat i soukromou sféru."
     },
     {
       "id": "senatni-2022-4-a-729274-57",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no",
       "comment": "Na Ukrajině ale nezáleží. Rozhodne se jinde a každý to ví."
     },
     {
       "id": "senatni-2022-4-a-729274-58",
       "candidate_id": "senatni-2022-4-c-729274",
-      "question_id": "senatni-2022-4-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Kde nic není, ani smrt nebere! Známé pořekadlo."
     },
     {
       "id": "senatni-2022-4-a-737193-1",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-4-a-737193-2",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes",
       "comment": "Cestou zákona o dostupném bydlení. Kde se stát stane konkurentem na trhu "
     },
     {
       "id": "senatni-2022-4-a-737193-3",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-737193-4",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-4-a-737193-5",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Jsem zásadně pro udržení věku 65 let"
     },
     {
       "id": "senatni-2022-4-a-737193-6",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "Současný stav je dle mého názoru dostačující. Je nutné více přemýšlet o zásadní změně využití krajiny."
     },
     {
       "id": "senatni-2022-4-a-737193-7",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no"
     },
     {
       "id": "senatni-2022-4-a-737193-8",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-4-a-737193-9",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "no"
     },
     {
       "id": "senatni-2022-4-a-737193-10",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "no"
     },
     {
       "id": "senatni-2022-4-a-737193-11",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-737193-12",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-737193-13",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-737193-14",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes",
       "comment": "Při aktuálnímu stavu, zcela určitě."
     },
     {
       "id": "senatni-2022-4-a-737193-15",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes",
       "comment": "Stát by měl podporovat klasické zaměstnávání na HP. "
     },
     {
       "id": "senatni-2022-4-a-737193-16",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Je to především lobby některých neziskových organizací."
     },
     {
       "id": "senatni-2022-4-a-737193-17",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-737193-18",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-737193-19",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Ano, ale sociální bydlení musí být vždy doprovázeno sociální prací, doprovázení. Je potřeba především dostupné bydlení."
     },
     {
       "id": "senatni-2022-4-a-737193-20",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Nechápu proč? Pokud chtějí pomoci a zároveň jsou ochotni dodržovat pravidla a povinnosti, vyhledají si pomoc sami."
     },
     {
       "id": "senatni-2022-4-a-737193-21",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-737193-22",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no",
       "comment": "Máme svých starostí dost."
     },
     {
       "id": "senatni-2022-4-a-737193-23",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Velké nebezpečí zneužití a ovlivnění."
     },
     {
       "id": "senatni-2022-4-a-737193-24",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-737193-25",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-737193-26",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no",
       "comment": "Inkluze přijata v současné podobě, přinesla do školství jen velké problémy.  "
     },
     {
       "id": "senatni-2022-4-a-737193-27",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "yes",
       "comment": "Při současné politice EU je to možné řešení pro ČR."
     },
     {
       "id": "senatni-2022-4-a-737193-28",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "ČR není absolutně připravená."
     },
     {
       "id": "senatni-2022-4-a-737193-29",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes",
       "comment": "Současná politika NATO ČR spíše ohrožuje."
     },
     {
       "id": "senatni-2022-4-a-737193-30",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-4-a-737193-31",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "Měli bychom řešit problémy v ČR."
     },
     {
       "id": "senatni-2022-4-a-737193-32",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no"
     },
     {
       "id": "senatni-2022-4-a-737193-33",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-4-a-737193-34",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "dont_know",
       "comment": "Při současné situaci to může ČR přinést problémy."
     },
     {
       "id": "senatni-2022-4-a-737193-35",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no",
       "comment": "Naše armáda není schopná profinancovat 2%HDP. Je to jen odliv financí pro cizí státy."
     },
     {
       "id": "senatni-2022-4-a-737193-36",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Příroda je moudrá."
     },
     {
       "id": "senatni-2022-4-a-737193-37",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no",
       "comment": "Zdravotnictví by mělo být dostupné všem, bez ohledu na stav peněženky"
     },
     {
       "id": "senatni-2022-4-a-737193-38",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes",
       "comment": "Ano, je to díky finanční náročnosti."
     },
     {
       "id": "senatni-2022-4-a-737193-39",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-4-a-737193-40",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-4-a-737193-41",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-737193-42",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no"
     },
     {
       "id": "senatni-2022-4-a-737193-43",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-4-a-737193-44",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "Směšné gesto."
     },
     {
       "id": "senatni-2022-4-a-737193-45",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-737193-46",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "no"
     },
     {
       "id": "senatni-2022-4-a-737193-47",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-4-a-737193-48",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "no",
       "comment": "Tato směrnice přinese daleko více problémů než užitku."
     },
     {
       "id": "senatni-2022-4-a-737193-49",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-4-a-737193-50",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "Zcela nemožné."
     },
     {
       "id": "senatni-2022-4-a-737193-51",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-737193-52",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-737193-53",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "no"
     },
     {
       "id": "senatni-2022-4-a-737193-54",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "Podmínky mají platit pro všechny stejně. "
     },
     {
       "id": "senatni-2022-4-a-737193-55",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "A kdo bude posuzovat potřebu?"
     },
     {
       "id": "senatni-2022-4-a-737193-56",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes",
       "comment": "Zákon o dostupném bydlení."
     },
     {
       "id": "senatni-2022-4-a-737193-57",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-4-a-737193-58",
       "candidate_id": "senatni-2022-4-c-737193",
-      "question_id": "senatni-2022-4-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     }
   ]

--- a/data/kalkulacka/senatni-2022/40.json
+++ b/data/kalkulacka/senatni-2022/40.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-40-c-392078",
       "name": "Bohuslav Procházka",
       "type": "person",
-      "description": "Bohuslav Procházka - DESCRIPTION",
+      "description": "Bohuslav Procházka",
       "contacts": {
         "web": [
           {
@@ -500,7 +500,7 @@
         {
           "id": "senatni-2022-40-c-392078-p",
           "name": "Bohuslav Procházka",
-          "description": "Bohuslav Procházka - DESCRIPTION",
+          "description": "Bohuslav Procházka",
           "contacts": {
             "web": [
               {
@@ -522,7 +522,7 @@
       "id": "senatni-2022-40-c-500322",
       "name": "Jaromír Strnad",
       "type": "person",
-      "description": "Jaromír Strnad - DESCRIPTION",
+      "description": "Jaromír Strnad",
       "contacts": {
         "web": [
           {
@@ -536,7 +536,7 @@
         {
           "id": "senatni-2022-40-c-500322-p",
           "name": "Jaromír Strnad",
-          "description": "Jaromír Strnad - DESCRIPTION",
+          "description": "Jaromír Strnad",
           "contacts": {
             "web": [
               {
@@ -554,7 +554,7 @@
       "id": "senatni-2022-40-c-914940",
       "name": "Kateřina Daczická",
       "type": "person",
-      "description": "Kateřina Daczická - DESCRIPTION",
+      "description": "Kateřina Daczická",
       "contacts": {
         "web": [
           {
@@ -570,7 +570,7 @@
         {
           "id": "senatni-2022-40-c-914940-p",
           "name": "Kateřina Daczická",
-          "description": "Kateřina Daczická - DESCRIPTION",
+          "description": "Kateřina Daczická",
           "contacts": {
             "web": [
               {
@@ -590,7 +590,7 @@
       "id": "senatni-2022-40-c-602069",
       "name": "Jiří Reichel",
       "type": "person",
-      "description": "Jiří Reichel - DESCRIPTION",
+      "description": "Jiří Reichel",
       "contacts": {
         "web": [
           {
@@ -604,7 +604,7 @@
         {
           "id": "senatni-2022-40-c-602069-p",
           "name": "Jiří Reichel",
-          "description": "Jiří Reichel - DESCRIPTION",
+          "description": "Jiří Reichel",
           "contacts": {
             "web": [
               {
@@ -622,7 +622,7 @@
       "id": "senatni-2022-40-c-815996",
       "name": "Luděk Jeništa",
       "type": "person",
-      "description": "Luděk Jeništa - DESCRIPTION",
+      "description": "Luděk Jeništa",
       "contacts": {
         "web": [
           {
@@ -636,7 +636,7 @@
         {
           "id": "senatni-2022-40-c-815996-p",
           "name": "Luděk Jeništa",
-          "description": "Luděk Jeništa - DESCRIPTION",
+          "description": "Luděk Jeništa",
           "contacts": {
             "web": [
               {
@@ -654,7 +654,7 @@
       "id": "senatni-2022-40-c-516282",
       "name": "Antonín Dušek",
       "type": "person",
-      "description": "Antonín Dušek - DESCRIPTION",
+      "description": "Antonín Dušek",
       "contacts": {
         "web": []
       },
@@ -662,7 +662,7 @@
         {
           "id": "senatni-2022-40-c-516282-p",
           "name": "Antonín Dušek",
-          "description": "Antonín Dušek - DESCRIPTION",
+          "description": "Antonín Dušek",
           "contacts": {
             "web": []
           },
@@ -674,7 +674,7 @@
       "id": "senatni-2022-40-c-353870",
       "name": "Jiří Strachota",
       "type": "person",
-      "description": "Jiří Strachota - DESCRIPTION",
+      "description": "Jiří Strachota",
       "contacts": {
         "web": [
           {
@@ -694,7 +694,7 @@
         {
           "id": "senatni-2022-40-c-353870-p",
           "name": "Jiří Strachota",
-          "description": "Jiří Strachota - DESCRIPTION",
+          "description": "Jiří Strachota",
           "contacts": {
             "web": [
               {
@@ -719,1528 +719,1528 @@
     {
       "id": "senatni-2022-40-a-353870-1",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Každá daň musí mít objektivně měřitelný základ a jedinou sazbu. Zda je něco bytem, zda je to dlouhodobě prázdné není objektivně měřitelné."
     },
     {
       "id": "senatni-2022-40-a-353870-2",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Státní regulace jakékoliv ceny deformuje trh, který právě cenou zajišťuje rovnováhu mezi nabídkou a poptávkou. "
     },
     {
       "id": "senatni-2022-40-a-353870-3",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Mám na mysli POUZE LIDOVÉ VETO. To znamená na základě petice s podpisy stanovené části voličů ve stanovené lhůtě hlasovat v referendu o zamítnutí určitého rozhodnutí Poslanecké sněmovny. Jednalo by se o jednoduchý další krok schvalování zákonů (Parlament, president, lid - pokud silně nesouhlasí se svými zvolenými poslanci.) "
     },
     {
       "id": "senatni-2022-40-a-353870-4",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Chápu v otázce \"infrastrukturu pro rychlovlaky\" jako tzv. vysokorychlostní tratě (VRT) umožňující rychlosti nad 200 km/h. Ministerstvo dopravy v Programu rozvoje rychlých železničních spojení v ČR z roku 2016 uvádí dva dostatečné důvody, proč je ekonomicky žádoucí variantou modernizace našich konvenčních tratí na rychlost do 200 km/h: „nižší finanční nároky“ a „rychlejší realizovatelnost jednotlivých projektů ve srovnání s novostavbami vysokorychlostních tratí s výrazně větším stavebním rozsahem“. Finanční nároky byly v roce 2016 uvedeny jako poloviční a od té doby se řada projektů modernizace už uskutečnila.\n\nVRT s dvojnásobnou rychlostí proti konvenční trati vyžaduje osminásobný elektrický příkon a čtyřnásobek energie pro stejnou vzdálenost. Navržené VRT (použitelné pouze pro osobní dopravu) v ČR mají vytvořit ostrov mezi Německem a Rakouskem, které budou navazovat smíšenou dopravou do 200 km/h až do Litoměřic z Německa a do Břeclavi z Rakouska. Rozkrojíme zemi neskutečným způsobem, protože se projektuje s parametry francouzského TGV s minimálním poloměrem oblouku 7 km. Proto navržená trasa dokonce krájí obce. Do 200 km/h stačí poloměr 2 km jako v Japonsku, Číně, Itálii, ČR pro naklápěcí vlaky a dá se využívat pro nákladní dopravu včetně vojenských transportů. Při \"úspěchu\" v plánované třicetileté lhůtě pro novostavbu Praha - Brno  můžeme vybudovat další exponát národního skansenu, ve kterém už máme nikdy nepoužité pevnosti Terezín a Josefov. Není znám žádný investor kromě státu, který už dluží za celý loňský rozpočet a kus předloňského. Podle evropského auditorského dvora pouze malá část vysokorychlostních tratí není ztrátová."
     },
     {
       "id": "senatni-2022-40-a-353870-5",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Věk odchodu do důchodu má být naším svobodným rozhodnutím, protože není možné srovnávat schopnost pracovat do vysokého věku např. ve vědě, kde je práce vášnivým koníčkem, a při dobývání nerostů v hlubinném dole. Státní určení důchodového věku je klasický příklad \"hraní na pánaboha\"."
     },
     {
       "id": "senatni-2022-40-a-353870-6",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-353870-7",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "dont_know",
       "comment": "To je snad svobodné rozhodnutí výrobců a spotřebitelů?"
     },
     {
       "id": "senatni-2022-40-a-353870-8",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Tzv. progresivní zdanění tzv. příjmů (spíš se jedná o \"zisk\") v zákonu o daních z příjmů je další \"krásný\" příklad hraní na pánaboha: jaká nelineární závislost daně na jejím základů má platit? Nejsme spíš v zajetí výroku \"větší příjem má znamenat větší daň\"? To dokonale splňuje daň s jedinou sazbou. Podotýkám, že největší daní z příjmu v ČR tvoří tzv. sociální a zdravotní pojistné, které není pojistným, protože se mu nelze vyhnout. To platí úzká vrstva zaměstnanců a OSVČ. Vůbec neplatí příjemci z kapitálu (60% HDP) ani lidé s velkou či malou mzdou... Bylo by lepší odstranit tuto \"100% degresi\" místo alchymie progrese."
     },
     {
       "id": "senatni-2022-40-a-353870-9",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-353870-10",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-353870-11",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "no",
       "comment": "Bohatě by stačila DPH (která se však přes hranice EU nevybírá)."
     },
     {
       "id": "senatni-2022-40-a-353870-12",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Za obsah zodpovídá autor."
     },
     {
       "id": "senatni-2022-40-a-353870-13",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "Souhlasím s Vašimi uvozovkami."
     },
     {
       "id": "senatni-2022-40-a-353870-14",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "dont_know",
       "comment": "\"Se mělo\" asi znamená zákonnou úpravu. Ať si veřejnost platí podle své potřeby, už existuje velká zkušenost s vysíláním mnoha stanic a technologie dnes umožňují dříve nevídané možnosti volby obsahu i ceny za službu."
     },
     {
       "id": "senatni-2022-40-a-353870-15",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no",
       "comment": "Proč? Co je státu do nich? Máme trestní zákoník."
     },
     {
       "id": "senatni-2022-40-a-353870-16",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Odlišná podmínka je, že spolu nemohou zplodit dítě."
     },
     {
       "id": "senatni-2022-40-a-353870-17",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "no",
       "comment": "Konkurence je dobrá věc, jen náklady exekuce by měl nést věřitel, aby obezřetněji resp. poctivěji půjčoval."
     },
     {
       "id": "senatni-2022-40-a-353870-18",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-353870-19",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "Musí se jen umřít. (Zatím.)"
     },
     {
       "id": "senatni-2022-40-a-353870-20",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Místo sociálních dávek má stát z VYROVNANÉHO ROZPOČTU každému občanovi poskytovat základní příjem zdaněný jedinou sazbou jako všechny ostatní příjmy. Tím státu odpadá problém motivace k práci i mezigenerační solidarity. Protože jedinou funkcí státního sociálního zabezpečení se stane administrace násobku základního příjmu pro občany s fyzickým nebo duševním postižením a náhradní péče o děti, které jsou pro rodiče především zdrojem příjmu, získáme ze správy sociálního zabezpečení ohromné množství kvalifikovaných lidí pro náš napjatý pracovní trh."
     },
     {
       "id": "senatni-2022-40-a-353870-21",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no",
       "comment": "Proč? Jak změřit rovnoměrnost?"
     },
     {
       "id": "senatni-2022-40-a-353870-22",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-353870-23",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Už myšlenka korespondenční volby je nepřijatelné riziko pro tajnost volby a  vyloučení podvodů. Važme si důvěry občanů ve stávající systém. Pokud je někdo líný zvednout zadek nebo si naplánovat své cestování tak, aby méně než jednou ročně mohl volit, tak o to zřejmě nestojí. Kromě toho je nevhodné, aby rozhodovali o našem státu lidé, kteří ho nefinancují a nenesou důsledky zvolení svých zástupců."
     },
     {
       "id": "senatni-2022-40-a-353870-24",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no",
       "comment": "Státem by neměly být podporovány žádné směry středoškolského a vysokoškolského vzdělání více než jiné, leda s výjimkou vojenských a policejních škol. V úvahu by mohly připadnout i právnické školy, pokud by tam poklesla příliš poptávka nebo (nepochopitelně) vzrostly náklady. "
     },
     {
       "id": "senatni-2022-40-a-353870-25",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-353870-26",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-353870-27",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "dont_know",
       "comment": "Stačí se chovat jako suverénní stát. Institut vyloučení z Unie evropské právo nezná :) "
     },
     {
       "id": "senatni-2022-40-a-353870-28",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "Vlastní měnová politika je podstatná pro suverenitu státu."
     },
     {
       "id": "senatni-2022-40-a-353870-29",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no",
       "comment": "Proč ano? S naší současnou obranyschopností? Nebo až budeme jedničky?"
     },
     {
       "id": "senatni-2022-40-a-353870-30",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "dont_know",
       "comment": "Nevím, co je jádro EU."
     },
     {
       "id": "senatni-2022-40-a-353870-31",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know",
       "comment": "Co je rozvojová spolupráce?"
     },
     {
       "id": "senatni-2022-40-a-353870-32",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no",
       "comment": "Vztahy s jinými státy řeší mezinárodní smlouvy. Zákony ČR jsou pravidla hry na našem území."
     },
     {
       "id": "senatni-2022-40-a-353870-33",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-353870-34",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-353870-35",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "Neplnění smluvního závazku v NATO je velmi špatná věc. Pak nemůžeme očekávat plnění smluvních závazků ostatních. Důležité je, mít výdaje efektivní pro naši obranyschopnost."
     },
     {
       "id": "senatni-2022-40-a-353870-36",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know",
       "comment": "Nevznikne riziko módních deformací populace? Nevíme, jak dlouho přirozené oplodnění bude převažovat."
     },
     {
       "id": "senatni-2022-40-a-353870-37",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes",
       "comment": "Lépe bez předpony \"při-\". Zdravotní pojištění by mělo být bez uvozovek vedle nezbytné zdravotní péče zajištěné státem (z daní). Nezbytná péče je léčení při akutním ohrožení života nebo zdraví a ochrana společnosti před akutním ohrožením života a zdraví občanů infekcí."
     },
     {
       "id": "senatni-2022-40-a-353870-38",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know",
       "comment": "Proč?"
     },
     {
       "id": "senatni-2022-40-a-353870-39",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-353870-40",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Proč nevyužít stroj ke kontrole dodržování pravidel hry? (Děláme to i ve sportech.)"
     },
     {
       "id": "senatni-2022-40-a-353870-41",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no",
       "comment": "Jak by se ten zákaz vymáhal?"
     },
     {
       "id": "senatni-2022-40-a-353870-42",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know",
       "comment": "Ukrajina je suverenní stát a nemáme jí říkat, co by měla."
     },
     {
       "id": "senatni-2022-40-a-353870-43",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know",
       "comment": "Ukrajina je suverenní stát a nemáme jí říkat, co by měla."
     },
     {
       "id": "senatni-2022-40-a-353870-44",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "Cena je výsledek shody dvou stran. Já mohu zastropovat cenu místního zmrzlináře pouze tak, že si u něj nekoupím."
     },
     {
       "id": "senatni-2022-40-a-353870-45",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-353870-46",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes",
       "comment": "Poneseme je všichni, proč ne Rusko?"
     },
     {
       "id": "senatni-2022-40-a-353870-47",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "dont_know",
       "comment": "O čem?"
     },
     {
       "id": "senatni-2022-40-a-353870-48",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know",
       "comment": "Násilí je trestné snad ve všech zemích EU. Už se ví, jak ho lépe potírat?"
     },
     {
       "id": "senatni-2022-40-a-353870-49",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Rozhodně NE. Prý \"po 19 letech dekarbonizace se o ní nediskutuje\", jenže naše uhelné elektrárny teď vyrábějí trvale naplno, zhruba o 10% více než v roce 2010. Proto  nemohou vyrovnávat vyšší spotřebu výkonu ve dne a dělají to za ně drahé plynové elektrárny vždy ráno i večer. Nebo celý den, když jim počasí nepřeje. Máme štěstí, že zásoby našeho uhlí stačí na desítky let a jaderné palivo se dá nakoupit z několika zdrojů rovněž na desítky let."
     },
     {
       "id": "senatni-2022-40-a-353870-50",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "Ten pojem je výplod evropského náboženství."
     },
     {
       "id": "senatni-2022-40-a-353870-51",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-353870-52",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "dont_know",
       "comment": "S agresorem bych se moc nebratříčkoval."
     },
     {
       "id": "senatni-2022-40-a-353870-53",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-353870-54",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "dont_know",
       "comment": "Dotace znamenají vzít peníze těm, kdo si to nechají líbit, a dát je těm, kdo mají ostré lokty. Je to vřed na těle naší krásné země. Bohužel ho nemůžeme odstranit v zemědělství uprostřed dotujících sousedů. "
     },
     {
       "id": "senatni-2022-40-a-353870-55",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "Kde by byla hranice, co nejsou povinny poskytovat? A co když neposkytnou? Není ta otázka vtip? "
     },
     {
       "id": "senatni-2022-40-a-353870-56",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-353870-57",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know",
       "comment": "Jde o volbu Ukrajiny, nemáme jí říkat, co má dělat. Ale nesmíme odmítnout sousedovi, u kterého hoří, svou hadici s vodou, když nás požádá. Zvlášť když požár může přeskočit k nám."
     },
     {
       "id": "senatni-2022-40-a-353870-58",
       "candidate_id": "senatni-2022-40-c-353870",
-      "question_id": "senatni-2022-40-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "dont_know",
       "comment": "Pokud ponese náklady exekuce věřitel, tak je pro stát nezajímavé něco (ne)zastavovat."
     },
     {
       "id": "senatni-2022-40-a-500322-1",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-2",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "U bytů, vybudovaných díky dotaci, jsem pro regulaci ceny nájemného. "
     },
     {
       "id": "senatni-2022-40-a-500322-3",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-4",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-5",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-6",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-7",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-8",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-9",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-10",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-11",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-12",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-13",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-14",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-15",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-16",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-17",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-18",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-19",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-20",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-21",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-22",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-23",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-24",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-25",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-26",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-27",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-28",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-29",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-30",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-31",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-32",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-33",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-34",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-35",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-36",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-37",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-38",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-39",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-40",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-41",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-42",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-43",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-44",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-45",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-46",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-47",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-48",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-49",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-50",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-51",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-52",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-53",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-54",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-55",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-56",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-500322-57",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-500322-58",
       "candidate_id": "senatni-2022-40-c-500322",
-      "question_id": "senatni-2022-40-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-815996-1",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Bude se podvádět, vždy lze do bytu někoho nahlásit, těžká kontrola, může to ovlivňovat RUD"
     },
     {
       "id": "senatni-2022-40-a-815996-2",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Pokud jich nebude zoufalý nedostatek"
     },
     {
       "id": "senatni-2022-40-a-815996-3",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no",
       "comment": "V naší společnosti nejsem zastáncem referend na vše, volíme si přece zástupce. Pouze v tak stěžejních otázkách, jako byl např. vstup do EU apod."
     },
     {
       "id": "senatni-2022-40-a-815996-4",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-815996-5",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Vypadá to ovšem, že s důchodovou reformou si tak nějak nikdo neví rady."
     },
     {
       "id": "senatni-2022-40-a-815996-6",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes",
       "comment": "Kvalitní voda bude mít v budoucnu cenu zlata, proto zadržovat, využívat. Vím, je to těžké, každý souhlasí do chvíle, kdy se mluví o jeho lokalitě.  "
     },
     {
       "id": "senatni-2022-40-a-815996-7",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no",
       "comment": "Ne, pokud budeme kvalitně třídit a budou technologie na jejich recyklaci a využití."
     },
     {
       "id": "senatni-2022-40-a-815996-8",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Kolik je 15% ze 40 tisíc a kolik je 15% ze 120 tisíc, nehledě na úlevy a příspěvky. Není už tohle trochu progrese?"
     },
     {
       "id": "senatni-2022-40-a-815996-9",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know",
       "comment": "Jaká je potřeba jednotlivce, co kontrola. Už to dnešní množství \"větší než malé\" je pofidérní."
     },
     {
       "id": "senatni-2022-40-a-815996-10",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Je málo hanebnějších trestných činů...."
     },
     {
       "id": "senatni-2022-40-a-815996-11",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-815996-12",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes",
       "comment": "Těžko lze hledat většího \"ovlivňovatele\" než jsou sociální sítě. Hlavně pro mládež."
     },
     {
       "id": "senatni-2022-40-a-815996-13",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes",
       "comment": "Asi ano, ale po prověření, což bude . . . . "
     },
     {
       "id": "senatni-2022-40-a-815996-14",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-815996-15",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes",
       "comment": "Zejména těch, které mají pod sebou cizince a dost je \"šidí\"!"
     },
     {
       "id": "senatni-2022-40-a-815996-16",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes",
       "comment": "Ano, stejná práva, ale jiný pojem, institutu \"manželství\" bych ponechal historický statut MUŽ-ŽENA"
     },
     {
       "id": "senatni-2022-40-a-815996-17",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-815996-18",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-815996-19",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "dont_know",
       "comment": "Jaká je definice sociálního bytu? Třeba v Praze a v Zadní Lhotě? Jsou byty malé a velké, levné a drahé a také sociální a nesociální? Na které jsou příspěvky na bydlení?"
     },
     {
       "id": "senatni-2022-40-a-815996-20",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Myslím, že Češi si v oblasti sociálních dávek umí poradit."
     },
     {
       "id": "senatni-2022-40-a-815996-21",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know",
       "comment": "Které státní instituce myslíte?"
     },
     {
       "id": "senatni-2022-40-a-815996-22",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "yes",
       "comment": "Ano, ale jen v případě, že to zabrání \"kolonizaci\" naší kvalitní orné půdy."
     },
     {
       "id": "senatni-2022-40-a-815996-23",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Jsme v 21. století...."
     },
     {
       "id": "senatni-2022-40-a-815996-24",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-815996-25",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes",
       "comment": "S výjimkou opravdu mimořádně talentovaných (až geniálních) dětí, jinak úroveň ZŠ upadá."
     },
     {
       "id": "senatni-2022-40-a-815996-26",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "Inkluze ano, ale ne na úkor kvality výuky....Aby na škole nebylo 3x více asistentů než učitelů"
     },
     {
       "id": "senatni-2022-40-a-815996-27",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no",
       "comment": "Jak tohle může někoho vůbec napadnout?"
     },
     {
       "id": "senatni-2022-40-a-815996-28",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "Ne hned, ale v určitém horizontu ano, do roku 2030 určitě, jen chybí politická odvaha"
     },
     {
       "id": "senatni-2022-40-a-815996-29",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no",
       "comment": "Tak to je stejně hloupá otázka jako u EU."
     },
     {
       "id": "senatni-2022-40-a-815996-30",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes",
       "comment": "Jsme v srdci Evropy, nikoli někde na kraji."
     },
     {
       "id": "senatni-2022-40-a-815996-31",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know",
       "comment": "Myslím, že v této oblasti nejsme špatní."
     },
     {
       "id": "senatni-2022-40-a-815996-32",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-815996-33",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Je třeba reagovat na události, které vedou k migraci."
     },
     {
       "id": "senatni-2022-40-a-815996-34",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes",
       "comment": "Jednoznačně."
     },
     {
       "id": "senatni-2022-40-a-815996-35",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "dont_know",
       "comment": "Nesdílel jsem tento názor, ale v zrcadle posledních událostí ho přehodnocuji."
     },
     {
       "id": "senatni-2022-40-a-815996-36",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "A za chvíli ještě IQ, ne?"
     },
     {
       "id": "senatni-2022-40-a-815996-37",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-815996-38",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no",
       "comment": "Možná pouze některé obory, ale za účelem zkvalitňování péče."
     },
     {
       "id": "senatni-2022-40-a-815996-39",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know",
       "comment": "Asi v míře velké než menší ano. "
     },
     {
       "id": "senatni-2022-40-a-815996-40",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Zastavit nikoli, ale používat jako prevenci, nikoli k výběru financí."
     },
     {
       "id": "senatni-2022-40-a-815996-41",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know",
       "comment": "Asi jak kde."
     },
     {
       "id": "senatni-2022-40-a-815996-42",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know",
       "comment": "V tuto chvíli určitě ne, v budoucnu - pokud budou podmínky."
     },
     {
       "id": "senatni-2022-40-a-815996-43",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know",
       "comment": "Alespoň ne v této době. Těžko předpovídat, co bude v blízké budoucnosti...Nejdříve je třeba nastolit MÍR"
     },
     {
       "id": "senatni-2022-40-a-815996-44",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "dont_know",
       "comment": "Protože nevím, zda to vůbec lze, je to spíše přání než možnost, kohouty se zavřou..."
     },
     {
       "id": "senatni-2022-40-a-815996-45",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no",
       "comment": "Člověk s jeho názory by tam být neměl."
     },
     {
       "id": "senatni-2022-40-a-815996-46",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes",
       "comment": "Nic není jen černé a bílé. Ale těžko může něco ospravedlnit napadení sousední země a  rozpoutání války."
     },
     {
       "id": "senatni-2022-40-a-815996-47",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "dont_know",
       "comment": "Jsme EU, o čem bychom my sami vyjednávali?"
     },
     {
       "id": "senatni-2022-40-a-815996-48",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-815996-49",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "dont_know",
       "comment": "Záleží na ekonomické a energetické situaci."
     },
     {
       "id": "senatni-2022-40-a-815996-50",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes",
       "comment": "Ano, ale jen Evropa nestačí, je třeba celosvětový přístup, jsme malá planeta."
     },
     {
       "id": "senatni-2022-40-a-815996-51",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-815996-52",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no",
       "comment": "Koneckonců, kdo by s námi v úrovni vztahů, které s Ruskem máme, vyjednával? Nemáme tu Orbána."
     },
     {
       "id": "senatni-2022-40-a-815996-53",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-815996-54",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes",
       "comment": "Nejlépe správně odstupňovat, což se jeví jako velmi těžký úkol. Také jde o konkurenceschopnost, a to i velkých firem."
     },
     {
       "id": "senatni-2022-40-a-815996-55",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-815996-56",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-815996-57",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no",
       "comment": "Ukončit konflikt ano, vzdát se území nikoli."
     },
     {
       "id": "senatni-2022-40-a-815996-58",
       "candidate_id": "senatni-2022-40-c-815996",
-      "question_id": "senatni-2022-40-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Pokud jde o situace \"vezmi chlup na dlani\", tak ano."
     },
     {
       "id": "senatni-2022-40-a-602069-1",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Byty mohou být prázdné z řady důvodů a plošné vyšší zdanění by mohlo být pro vlastníka likvidační."
     },
     {
       "id": "senatni-2022-40-a-602069-2",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "dont_know",
       "comment": "Obce by měly vlastnit byty s regulovaným nájemným. Soukromý vlastník potom bude muset své ceny hlídat. Celkově neregulované nájemné je v současných podmínkách cesta pod most."
     },
     {
       "id": "senatni-2022-40-a-602069-3",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Referendum i petice ovšem musí mít své mantinely, aby se pak nehlasovalo za housky zdarma."
     },
     {
       "id": "senatni-2022-40-a-602069-4",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Především je zapotřebí dobře zprovoznit stávající infrastrukturu. Naše silnice a tratě jsou samá výluka, objížďka a semafory řízený provoz. Kdo musí cestovat, ví, o čem mluvím."
     },
     {
       "id": "senatni-2022-40-a-602069-5",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Průměrný věk dožití se sice zvyšuje, ale únava, zejména psychická, nastupuje ve stejné době jako v minulosti."
     },
     {
       "id": "senatni-2022-40-a-602069-6",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "Toto je technická otázka pro vodohospodáře a ekology. Jsem toho názoru, že soustava přehrad v České republice je velmi nadstandardní, zejména pak Vltavská kaskáda."
     },
     {
       "id": "senatni-2022-40-a-602069-7",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no",
       "comment": "Běžný spotřebitel by měl další peníze vázané v obalech. Delší čekací doby v obchodech. Věřím lidem, že sami dobře třídí odpad."
     },
     {
       "id": "senatni-2022-40-a-602069-8",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes",
       "comment": "Státní dluh vesele roste, tím pádem stoupají i úroky a dostáváme se do dluhové spirály. Získávat peníze z nízkopříjmových skupin lze jen za cenu jejich bídy."
     },
     {
       "id": "senatni-2022-40-a-602069-9",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know",
       "comment": "Pokud ano, zajistit kontrolu, aby vše bylo pro vlastní potřebu. Pokud ne, zajistit, aby bylo v lékárenském sortimentu."
     },
     {
       "id": "senatni-2022-40-a-602069-10",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Důležité je přesně specifikovat, co je znásilnění, aby zákon nemohl být zneužit. Potom bych byl pro zvýšení spodní hranice."
     },
     {
       "id": "senatni-2022-40-a-602069-11",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "no",
       "comment": "Pokud by tyto firmy platily speciální daň, došlo by ke zpoplatnění služeb a projevilo by se to na peněžence občanů. Ztratili bychom kousek svobody."
     },
     {
       "id": "senatni-2022-40-a-602069-12",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "dont_know",
       "comment": "Sociální sítě částečně jsou zodpovědné za obsah, který zpřístupňují. Pokud na ně budou tlačit další zákony, budou uživatelé velmi omezeni ve svých projevech. Automat vše nevyhodnotí a lidi je třeba zaplatit."
     },
     {
       "id": "senatni-2022-40-a-602069-13",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "Kdo určí, co je falešná zpráva? A na šíření pomluv a poplašných zpráv zákon už pamatuje."
     },
     {
       "id": "senatni-2022-40-a-602069-14",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes",
       "comment": "Pokud by bylo opravdu nestranné a skutečně veřejnoprávní a objektivní, nikým neplacené, pak si dotace zaslouží."
     },
     {
       "id": "senatni-2022-40-a-602069-15",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no",
       "comment": "Sice je názor, že pracovní agentury \"parazitují\" na trhu práce, ovšem řadě lidí práci zajistí. "
     },
     {
       "id": "senatni-2022-40-a-602069-16",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Pro stejnopohlavní páry chci naprosto stejná práva ve všech detailech jako pro manžele. Manželství to však být nemůže, neboť tento výraz přímo označuje muže a ženu. Mal-žen znamená muž - žena. Slovo manželství vzniklo přesmyčkou. Proto je třeba hledat nový název."
     },
     {
       "id": "senatni-2022-40-a-602069-17",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-602069-18",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-602069-19",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Budoucnost a ceny na trhu ukazují, že sociální byty budou stále důležitější."
     },
     {
       "id": "senatni-2022-40-a-602069-20",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes",
       "comment": "Stát má především tvořit takové podmínky, aby lidé sociální dávky nepotřebovali."
     },
     {
       "id": "senatni-2022-40-a-602069-21",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no",
       "comment": "Univerzální pravidlo bych neuvítal, jsou instituce, jejichž rozmístění není reálné. Navíc by to značně zvýšilo náklady. Řešením je spolupráce mezi obecními a státními institucemi. Občan nemusí tolik cestovat ani platit na daních."
     },
     {
       "id": "senatni-2022-40-a-602069-22",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-602069-23",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "I při osobní účasti je velký počet stížností. Navíc nízkopříjmové skupiny a starší lidé by tímto byli znevýhodněni."
     },
     {
       "id": "senatni-2022-40-a-602069-24",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no",
       "comment": "Máme i jiné velmi důležité obory, jako například zdravotnictví, zemědělství a další."
     },
     {
       "id": "senatni-2022-40-a-602069-25",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Pokud je touto otázkou myšlena naše slavná inkluze, pak nesouhlasím. Každá skupina dětí potřebuje jinou péči a možnosti rozvoje. Vzdělávat všechny podle jejich možností. Třída se většinou řídí podle schopností žáka v čele poslední třetiny."
     },
     {
       "id": "senatni-2022-40-a-602069-26",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "dont_know",
       "comment": "Vzdělávací systém má co nejvíce pomáhat VŠEM žákům. "
     },
     {
       "id": "senatni-2022-40-a-602069-27",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "dont_know",
       "comment": "ČR by měla vyhlásit referendum o setrvání v Evropské unii. EU potřebuje změnu, jinak se rozpadne sama."
     },
     {
       "id": "senatni-2022-40-a-602069-28",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "Zatím pro tento krok nejsou vhodné podmínky."
     },
     {
       "id": "senatni-2022-40-a-602069-29",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "dont_know",
       "comment": "V Evropě je válečný stav a proto není vhodné konat zásadní kroky."
     },
     {
       "id": "senatni-2022-40-a-602069-30",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no",
       "comment": "Místo ČR je v jádru Evropy."
     },
     {
       "id": "senatni-2022-40-a-602069-31",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes",
       "comment": "Ano, pokud napřed bude mít dostatek prostředků na své potřebné."
     },
     {
       "id": "senatni-2022-40-a-602069-32",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-602069-33",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Azyl je závažný krok i z hlediska bezpečnosti země. Proto v našem zájmu nemůže být zcela snadný."
     },
     {
       "id": "senatni-2022-40-a-602069-34",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes",
       "comment": "Pokud zůstaneme v EU, pak ano."
     },
     {
       "id": "senatni-2022-40-a-602069-35",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no",
       "comment": "ČR by měla vést politiku tak, aby naše armáda zářila především při přehlídkách a přírodních pohromách."
     },
     {
       "id": "senatni-2022-40-a-602069-36",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-602069-37",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "dont_know",
       "comment": "Tato možnost je, zpravidla ji obsahuje životní pojištění."
     },
     {
       "id": "senatni-2022-40-a-602069-38",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no",
       "comment": "Technické prostředky poskytují široké možnosti i v regionálních podmínkách."
     },
     {
       "id": "senatni-2022-40-a-602069-39",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know",
       "comment": "Zatím se stále zkoumají jeho účinky. "
     },
     {
       "id": "senatni-2022-40-a-602069-40",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "S kontrolou rychlosti musí být spjato i rozumné nastavení omezení. Třicítka po dobu půl roku na rovném úseku svádí k porušení. I toto by se mělo kontrolovat."
     },
     {
       "id": "senatni-2022-40-a-602069-41",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-40-a-602069-42",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know",
       "comment": "Pokud splní všechny podmínky jako ostatní země, může vstoupit jako ostatní země."
     },
     {
       "id": "senatni-2022-40-a-602069-43",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "Nyní pro to není vhodný čas. Do vojenských bloků mohou rozumně přijímat nové členy pouze v době míru. Potom, po splnění všech podmínek, je cesta otevřena."
     },
     {
       "id": "senatni-2022-40-a-602069-44",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes",
       "comment": "Ano, ale věc má dvě strany. EU může zastropovat ceny pouze dotacemi do vlastního trhu. Nákup se řídí dvoustrannými dohodami."
     },
     {
       "id": "senatni-2022-40-a-602069-45",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-602069-46",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "dont_know",
       "comment": "Podporuji co nejrychlejší ukončení konfliktu, aby přestali umírat lidé a přestala se ničit zem."
     },
     {
       "id": "senatni-2022-40-a-602069-47",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no",
       "comment": "V současné době by to pouze zvýšilo napětí v celé oblasti. Je zapotřebí mír."
     },
     {
       "id": "senatni-2022-40-a-602069-48",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Opět je zapotřebí velmi přesná specifikace, aby nedocházelo ke zneužití směrnice."
     },
     {
       "id": "senatni-2022-40-a-602069-49",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Zatím není náhrada"
     },
     {
       "id": "senatni-2022-40-a-602069-50",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know",
       "comment": "Podporuji ekologii v rozumné míře. Kde lze znečišťující prvek nahradit, ať se nahradí. Plán, co vše uděláme do roku 2050, stojí tak trochu na vodě."
     },
     {
       "id": "senatni-2022-40-a-602069-51",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-602069-52",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "dont_know",
       "comment": "Dokud patříme do EU, je to velmi obtížné."
     },
     {
       "id": "senatni-2022-40-a-602069-53",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-602069-54",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-602069-55",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-40-a-602069-56",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-40-a-602069-57",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know",
       "comment": "Na takto postavenou otázku se těžko odpovídá"
     },
     {
       "id": "senatni-2022-40-a-602069-58",
       "candidate_id": "senatni-2022-40-c-602069",
-      "question_id": "senatni-2022-40-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "no"
     }
   ]

--- a/data/kalkulacka/senatni-2022/43.json
+++ b/data/kalkulacka/senatni-2022/43.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-43-c-191288",
       "name": "Milan Bušek",
       "type": "person",
-      "description": "Milan Bušek - DESCRIPTION",
+      "description": "Milan Bušek",
       "contacts": {
         "web": []
       },
@@ -490,7 +490,7 @@
         {
           "id": "senatni-2022-43-c-191288-p",
           "name": "Milan Bušek",
-          "description": "Milan Bušek - DESCRIPTION",
+          "description": "Milan Bušek",
           "contacts": {
             "web": []
           },
@@ -502,7 +502,7 @@
       "id": "senatni-2022-43-c-143881",
       "name": "Martin Charvát",
       "type": "person",
-      "description": "Martin Charvát - DESCRIPTION",
+      "description": "Martin Charvát",
       "contacts": {
         "web": [
           {
@@ -520,7 +520,7 @@
         {
           "id": "senatni-2022-43-c-143881-p",
           "name": "Martin Charvát",
-          "description": "Martin Charvát - DESCRIPTION",
+          "description": "Martin Charvát",
           "contacts": {
             "web": [
               {
@@ -542,7 +542,7 @@
       "id": "senatni-2022-43-c-849519",
       "name": "Jaromír Nosek",
       "type": "person",
-      "description": "Jaromír Nosek - DESCRIPTION",
+      "description": "Jaromír Nosek",
       "contacts": {
         "web": []
       },
@@ -550,7 +550,7 @@
         {
           "id": "senatni-2022-43-c-849519-p",
           "name": "Jaromír Nosek",
-          "description": "Jaromír Nosek - DESCRIPTION",
+          "description": "Jaromír Nosek",
           "contacts": {
             "web": []
           },
@@ -562,7 +562,7 @@
       "id": "senatni-2022-43-c-742106",
       "name": "Miluše Horská",
       "type": "person",
-      "description": "Miluše Horská - DESCRIPTION",
+      "description": "Miluše Horská",
       "contacts": {
         "web": [
           {
@@ -585,7 +585,7 @@
         {
           "id": "senatni-2022-43-c-742106-p",
           "name": "Miluše Horská",
-          "description": "Miluše Horská - DESCRIPTION",
+          "description": "Miluše Horská",
           "contacts": {
             "web": [
               {
@@ -612,7 +612,7 @@
       "id": "senatni-2022-43-c-191858",
       "name": "Vladimír Ninger",
       "type": "person",
-      "description": "Vladimír Ninger - DESCRIPTION",
+      "description": "Vladimír Ninger",
       "contacts": {
         "web": [
           {
@@ -630,7 +630,7 @@
         {
           "id": "senatni-2022-43-c-191858-p",
           "name": "Vladimír Ninger",
-          "description": "Vladimír Ninger - DESCRIPTION",
+          "description": "Vladimír Ninger",
           "contacts": {
             "web": [
               {
@@ -652,7 +652,7 @@
       "id": "senatni-2022-43-c-650117",
       "name": "Svatopluk Pleva",
       "type": "person",
-      "description": "Svatopluk Pleva - DESCRIPTION",
+      "description": "Svatopluk Pleva",
       "contacts": {
         "web": []
       },
@@ -660,7 +660,7 @@
         {
           "id": "senatni-2022-43-c-650117-p",
           "name": "Svatopluk Pleva",
-          "description": "Svatopluk Pleva - DESCRIPTION",
+          "description": "Svatopluk Pleva",
           "contacts": {
             "web": []
           },
@@ -669,5 +669,354 @@
       ]
     }
   ],
-  "answers": []
+  "answers": [
+    {
+      "id": "senatni-2022-43-a-191858-1",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-2",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-3",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-4",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-5",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-6",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-7",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-8",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-9",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-10",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-11",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-11",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-12",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-12",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-13",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-14",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-15",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-16",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-17",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-17",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-18",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-18",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-19",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-20",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-21",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-22",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-23",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-24",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-25",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-26",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-27",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-28",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-29",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-30",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-31",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-32",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-33",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-34",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-35",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-36",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-37",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-38",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-39",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-40",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-41",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-42",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-43",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-44",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-45",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-45",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-46",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-47",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-48",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-49",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-50",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-51",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-52",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-53",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-54",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-55",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-56",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-57",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-43-a-191858-58",
+      "candidate_id": "senatni-2022-43-c-191858",
+      "question_id": "senatni-2022-global-q-58",
+      "answer": "yes"
+    }
+  ]
 }

--- a/data/kalkulacka/senatni-2022/46.json
+++ b/data/kalkulacka/senatni-2022/46.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-46-c-367047",
       "name": "Petr Fiala",
       "type": "person",
-      "description": "Petr Fiala - DESCRIPTION",
+      "description": "Petr Fiala",
       "contacts": {
         "web": [
           {
@@ -501,7 +501,7 @@
         {
           "id": "senatni-2022-46-c-367047-p",
           "name": "Petr Fiala",
-          "description": "Petr Fiala - DESCRIPTION",
+          "description": "Petr Fiala",
           "contacts": {
             "web": [
               {
@@ -524,7 +524,7 @@
       "id": "senatni-2022-46-c-835047",
       "name": "Josef Kopecký",
       "type": "person",
-      "description": "Josef Kopecký - DESCRIPTION",
+      "description": "Josef Kopecký",
       "contacts": {
         "web": []
       },
@@ -532,7 +532,7 @@
         {
           "id": "senatni-2022-46-c-835047-p",
           "name": "Josef Kopecký",
-          "description": "Josef Kopecký - DESCRIPTION",
+          "description": "Josef Kopecký",
           "contacts": {
             "web": []
           },
@@ -544,7 +544,7 @@
       "id": "senatni-2022-46-c-490291",
       "name": "Stanislav Ešner",
       "type": "person",
-      "description": "Stanislav Ešner - DESCRIPTION",
+      "description": "Stanislav Ešner",
       "contacts": {
         "web": []
       },
@@ -552,7 +552,7 @@
         {
           "id": "senatni-2022-46-c-490291-p",
           "name": "Stanislav Ešner",
-          "description": "Stanislav Ešner - DESCRIPTION",
+          "description": "Stanislav Ešner",
           "contacts": {
             "web": []
           },
@@ -565,353 +565,353 @@
     {
       "id": "senatni-2022-46-a-367047-1",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-2",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes",
       "comment": "nájemné by mělo být odpovídající lokalitě a zohledňovat amortizaci"
     },
     {
       "id": "senatni-2022-46-a-367047-3",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-4",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Je potřeba dostavět silnice"
     },
     {
       "id": "senatni-2022-46-a-367047-5",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-6",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-7",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-8",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-9",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-10",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-46-a-367047-11",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-12",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-13",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-14",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-15",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-16",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know",
       "comment": "Měly by mít uzákoněny stejná práva (i povinnosti), název svazku dle mne není až tak zásadní."
     },
     {
       "id": "senatni-2022-46-a-367047-17",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-18",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-19",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-20",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-21",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-22",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-23",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-24",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-25",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-26",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-27",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-28",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "do 5 let"
     },
     {
       "id": "senatni-2022-46-a-367047-29",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-30",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-31",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-46-a-367047-32",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-33",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-46-a-367047-34",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-35",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-36",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-37",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-46-a-367047-38",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-39",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-46-a-367047-40",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-41",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-42",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-43",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-44",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-45",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-46-a-367047-46",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-47",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-48",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-49",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-50",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-51",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-52",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-53",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-54",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-55",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-56",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-46-a-367047-57",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-46-a-367047-58",
       "candidate_id": "senatni-2022-46-c-367047",
-      "question_id": "senatni-2022-46-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     }
   ]

--- a/data/kalkulacka/senatni-2022/49.json
+++ b/data/kalkulacka/senatni-2022/49.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-49-c-631671",
       "name": "Jiří Rokos",
       "type": "person",
-      "description": "Jiří Rokos - DESCRIPTION",
+      "description": "Jiří Rokos",
       "contacts": {
         "web": []
       },
@@ -490,7 +490,7 @@
         {
           "id": "senatni-2022-49-c-631671-p",
           "name": "Jiří Rokos",
-          "description": "Jiří Rokos - DESCRIPTION",
+          "description": "Jiří Rokos",
           "contacts": {
             "web": []
           },
@@ -502,7 +502,7 @@
       "id": "senatni-2022-49-c-770071",
       "name": "Antonín Žirovnický",
       "type": "person",
-      "description": "Antonín Žirovnický - DESCRIPTION",
+      "description": "Antonín Žirovnický",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/zirovnickydosenatu/"
@@ -511,7 +511,7 @@
         {
           "id": "senatni-2022-49-c-770071-p",
           "name": "Antonín Žirovnický",
-          "description": "Antonín Žirovnický - DESCRIPTION",
+          "description": "Antonín Žirovnický",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/zirovnickydosenatu/"
@@ -524,7 +524,7 @@
       "id": "senatni-2022-49-c-523550",
       "name": "Martin Sklář",
       "type": "person",
-      "description": "Martin Sklář - DESCRIPTION",
+      "description": "Martin Sklář",
       "contacts": {
         "web": []
       },
@@ -532,7 +532,7 @@
         {
           "id": "senatni-2022-49-c-523550-p",
           "name": "Martin Sklář",
-          "description": "Martin Sklář - DESCRIPTION",
+          "description": "Martin Sklář",
           "contacts": {
             "web": []
           },
@@ -544,7 +544,7 @@
       "id": "senatni-2022-49-c-229934",
       "name": "Filip Vítek",
       "type": "person",
-      "description": "Filip Vítek - DESCRIPTION",
+      "description": "Filip Vítek",
       "contacts": {
         "web": [
           {
@@ -559,7 +559,7 @@
         {
           "id": "senatni-2022-49-c-229934-p",
           "name": "Filip Vítek",
-          "description": "Filip Vítek - DESCRIPTION",
+          "description": "Filip Vítek",
           "contacts": {
             "web": [
               {
@@ -578,7 +578,7 @@
       "id": "senatni-2022-49-c-439462",
       "name": "Drago Sukalovský",
       "type": "person",
-      "description": "Drago Sukalovský - DESCRIPTION",
+      "description": "Drago Sukalovský",
       "contacts": {
         "web": [
           {
@@ -591,7 +591,7 @@
         {
           "id": "senatni-2022-49-c-439462-p",
           "name": "Drago Sukalovský",
-          "description": "Drago Sukalovský - DESCRIPTION",
+          "description": "Drago Sukalovský",
           "contacts": {
             "web": [
               {
@@ -608,7 +608,7 @@
       "id": "senatni-2022-49-c-744028",
       "name": "Jaromíra Vítková",
       "type": "person",
-      "description": "Jaromíra Vítková - DESCRIPTION",
+      "description": "Jaromíra Vítková",
       "contacts": {
         "web": [
           {
@@ -630,7 +630,7 @@
         {
           "id": "senatni-2022-49-c-744028-p",
           "name": "Jaromíra Vítková",
-          "description": "Jaromíra Vítková - DESCRIPTION",
+          "description": "Jaromíra Vítková",
           "contacts": {
             "web": [
               {
@@ -656,7 +656,7 @@
       "id": "senatni-2022-49-c-882688",
       "name": "Zdeněk Wetter",
       "type": "person",
-      "description": "Zdeněk Wetter - DESCRIPTION",
+      "description": "Zdeněk Wetter",
       "contacts": {
         "web": [
           {
@@ -670,7 +670,7 @@
         {
           "id": "senatni-2022-49-c-882688-p",
           "name": "Zdeněk Wetter",
-          "description": "Zdeněk Wetter - DESCRIPTION",
+          "description": "Zdeněk Wetter",
           "contacts": {
             "web": [
               {
@@ -689,1443 +689,1443 @@
     {
       "id": "senatni-2022-49-a-523550-1",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes",
       "comment": "Vyšším zdaněním bych donutil majitele bytu, aby ho pronajal."
     },
     {
       "id": "senatni-2022-49-a-523550-2",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes",
       "comment": "Ceny nájemného by se měly regulovat u obecních a družstevních bytů, aby na bydlení za únosnou sumu měly hlavně mladé rodiny s dětmi."
     },
     {
       "id": "senatni-2022-49-a-523550-3",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Petici k možnosti celostátního referenda by mělo podepsat nejméně 50 tisíc lidí, což je stejný počet jako u nezávislého kandidáta na prezidenta ČR."
     },
     {
       "id": "senatni-2022-49-a-523550-4",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes",
       "comment": "Výstavba infrastruktury pro rychlovlaky má být upřednostňována oproti výstavbě další dopravní infrastruktury, protože za posledních 50 let se do železniční infrastruktury obecně investoval mnohem menší objem financí než do výstavby silnic a dalších komunikací. Doprava rychlovlaky přitom patří k nejlepším způsobům dopravy v Evropě i ve světě."
     },
     {
       "id": "senatni-2022-49-a-523550-5",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Důchodový věk by se už neměl dál zvyšovat, protože poctivě pracující a podnikající lidé si zaslouží jít v 65 letech do zaslouženého odpočinku a stát (potažmo vláda) by měl už konečně najít vyvážený a rozumný systém penzijního připojištění, v němž by měli být zvýhodněni odpovědní občané, kteří si poctivě šetří na přilepšení k penzi."
     },
     {
       "id": "senatni-2022-49-a-523550-6",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes",
       "comment": "Více nových přehrad znamená víc zadržené vody v krajině, která pomalu ale jistě vysychá a trpí nedostatkem vody a následky změny klimatu. Z nádrží se pak dá voda v případě potřeby upouštět do koryt řek a potoků. A další předností přehrady je její případné rekreační využití všude tam, kde to ráz krajiny dovoluje. Kolem přehrad se pak často dají sázet stromy, které v létě poskytnou stín a dokáží zadržet a využít vodu v krajině."
     },
     {
       "id": "senatni-2022-49-a-523550-7",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes",
       "comment": "PET lahve a nápojové plechovky by měly být zálohované, protože by se tak lidé naučili lépe třídit a nakládat s odpady, které pak lze znovu využít k recyklaci. Například v Norsku to funguje perfektně. "
     },
     {
       "id": "senatni-2022-49-a-523550-8",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes",
       "comment": "Vyšší daně pro lidi s vysokými příjmy jsou důležité už jen proto, že by měl ve společnosti fungovat princip solidárnosti. Například špičkově placení manažeři nebo bohatí podnikatelé by tak (ne)přímo přispívali třeba samoživitelkám s dětmi nebo důchodcům s nízkými penzemi."
     },
     {
       "id": "senatni-2022-49-a-523550-9",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-523550-10",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Tresty za znásilnění by se měly určitě zvýšit, protože znásilněné ženy a dívky často utrpí doživotní psychické trauma a v některých brutálních případech i fyzické následky."
     },
     {
       "id": "senatni-2022-49-a-523550-11",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Google nebo Facebook by měly platit speciální daň ze všech příjmů v ČR, protože jde o globální světové společnosti s vysokými zisky. A jejich vyšší zdanění by navíc oživilo konkurenci."
     },
     {
       "id": "senatni-2022-49-a-523550-12",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-523550-13",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-523550-14",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Na veřejnoprávní vysílání by se nemělo dávat méně peněz, protože například Česká televize má už několik let omezené příjmy z reklamy. Jiná věc je objektivita a vyváženost zpravodajství ve veřejnoprávním vysílání, která v poslední době často pokulhává."
     },
     {
       "id": "senatni-2022-49-a-523550-15",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-523550-16",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes",
       "comment": "Stejnopohlavní páry by měly mít možnost vstupovat do manželství za stejných podmínek jako jiné páry, ale gayové a lesbičky by neměli mít možnost vychovávat adoptované děti."
     },
     {
       "id": "senatni-2022-49-a-523550-17",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-523550-18",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes",
       "comment": "Zavedení pravidla 1 dlužník - 1 exekutor by odstranilo roztříštěnost při vymáhání dluhů."
     },
     {
       "id": "senatni-2022-49-a-523550-19",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Nová obecní, státní nebo soukromá výstavba bytů pro veřejnost musí být vždy tvořena alespoň zčásti sociálními byty, protože by se tak ke slušnému bydlení dostali lidé s nižšími příjmy a matky samoživitelky."
     },
     {
       "id": "senatni-2022-49-a-523550-20",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "dont_know",
       "comment": "K této otázce bych podotkl, že každý svéprávný, odpovědný a normálně uvažující člověk v nouzi, který má nárok na sociální dávky, si dokáže dojít na úřad, kde lze o dávky požádat."
     },
     {
       "id": "senatni-2022-49-a-523550-21",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-523550-22",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no",
       "comment": "Myslím si, že společnost v ČR teď má vzhledem k energetické krizi, vysoké inflaci a válce na Ukrajině úplně jiné starosti než kolonizaci Marsu... :-)"
     },
     {
       "id": "senatni-2022-49-a-523550-23",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Volby online by jednak ušetřily cestu do volebních místností především všem nemocným a starým lidem, ke kterým jinak musí jezdit volební komise s urnou, a jednak by se tak ušetřila spousta peněz, které je nutné vynaložit na odměny členů volebních komisí, kterých by při dobře zabezpečené online volbě rapidně ubylo."
     },
     {
       "id": "senatni-2022-49-a-523550-24",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "Podle mého názoru by se měly podporovat technické obory především na středních školách, protože v posledních desetiletích rapidně ubývá počet řemeslníků a technických profesí."
     },
     {
       "id": "senatni-2022-49-a-523550-25",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-523550-26",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "Vzdělávací systém by měl být spravedlivý a slabší nebo hendikepovaní žáci by měli mít možnost být ve společnosti svých vrstevníků, kteří je spolu s učiteli můžou táhnout k lepším výsledkům a následné integraci do společnosti."
     },
     {
       "id": "senatni-2022-49-a-523550-27",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-523550-28",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-523550-29",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no",
       "comment": "ČR by neměla vystupovat z NATO, protože má malou profesionální armádu a členství v silném vojenském paktu zaručuje lepší obranyschopnost. Jinou otázkou je, proč se ČR nestala hned po roce 1989 neutrální zemí."
     },
     {
       "id": "senatni-2022-49-a-523550-30",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-523550-31",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know",
       "comment": "Větší humanitární pomoc ano, ale vyšší zahraniční rozvojová spolupráce je v současné ekonomické krizi otázkou. Současná vláda Petra Fialy by se měla lépe postarat o vlastní občany a lépe řešit jejich současné problémy a potřeby."
     },
     {
       "id": "senatni-2022-49-a-523550-32",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-523550-33",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Udělení azylu v ČR by se nemělo usnadnit, protože současná vláda už tak dost pomohla uprchlíkům z Ruskem napadené Ukrajiny a snazší získání azylu by mohlo vést k opětovné neúnosné migrační vlně obyvatel Asie či Afriky."
     },
     {
       "id": "senatni-2022-49-a-523550-34",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-523550-35",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "ČR by měla dávat více peněz na armádu, protože by se tak zvýšila obranyschopnost země a snížila by se tak i nezaměstnanost a potažmo i inflace."
     },
     {
       "id": "senatni-2022-49-a-523550-36",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Hrátky s genetikou jsou etickou cestou do pekel."
     },
     {
       "id": "senatni-2022-49-a-523550-37",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes",
       "comment": "Lidé s vyššími příjmy by si tak zaplatili lepší zdravotní péči a přispěli by jednak na větší platy zdravotníků, jednak na zdravotní péči obecně."
     },
     {
       "id": "senatni-2022-49-a-523550-38",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no",
       "comment": "Specializovaná lékařská péče v ČR by měla být stejně dostupná ve všech krajích, aby za ní lidé nemuseli často složitě dojíždět."
     },
     {
       "id": "senatni-2022-49-a-523550-39",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-523550-40",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Radary slouží k vyšší bezpečnosti provozu na silnicích zvláště v obcích a na nebezpečných úsecích. A kdo jezdí neurvale a nedodržuje zákony a vyhlášky, ať platí. Hazardéři za volantem totiž často způsobují nehody s fatálními následky."
     },
     {
       "id": "senatni-2022-49-a-523550-41",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know",
       "comment": "Velmi těžká otázka, související s ochranou osobních údajů. Tyto chytré systémy by se měly využívat jen pro potřeby policie a obecně bezpečnosti."
     },
     {
       "id": "senatni-2022-49-a-523550-42",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes",
       "comment": "EU by totiž mohla Ukrajině jako členské zemi pomoci jak ekonomicky, tak politicky. "
     },
     {
       "id": "senatni-2022-49-a-523550-43",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes",
       "comment": "Zvýšila by se tak její obranyschopnost a možnost vojenské pomoci ze strany dalších členských zemí NATO. Otázkou však je, jak by na to zareagoval ruský prezident Putin, protože při jeho nevyzpytatelnosti by členství Ukrajiny v NATO mohlo vést i k rozpoutání 3. světové války."
     },
     {
       "id": "senatni-2022-49-a-523550-44",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-523550-45",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-523550-46",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-523550-47",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes",
       "comment": "Souhlasím s účastí českých zákonodárců při vyjednávání s Rusy na Krymu, protože každé diplomatické řešení válečného konfliktu je pořád lepší než umírání nevinných lidí."
     },
     {
       "id": "senatni-2022-49-a-523550-48",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Násilí vůči ženám (a dětem) a domácí násilí je nepřípustné, protože často přispívá k rozvratu rodin."
     },
     {
       "id": "senatni-2022-49-a-523550-49",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "dont_know",
       "comment": "Vzhledem k energetické krizi je ukončení spalování uhlí velmi diskutabilní."
     },
     {
       "id": "senatni-2022-49-a-523550-50",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-523550-51",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "dont_know",
       "comment": "I tato otázka je velmi diskutabilní vzhledem k historickým souvislostem, kdy Krym byl už za cara Petra Velikého součástí Ruska a až sovětští komunisté v čele s Chruščovem ho administrativně připojili k Ukrajině."
     },
     {
       "id": "senatni-2022-49-a-523550-52",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Když může o nákupech plynu a ropy jednat s Ruskem Maďarsko a další země, tak proč ne ČR?"
     },
     {
       "id": "senatni-2022-49-a-523550-53",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes",
       "comment": "NATO získá do svých řad důležité severské státy a Finsko tak zabrání další potenciální válce s Ruskem, se kterou má smutno historickou zkušenost ze 40.let 20.století."
     },
     {
       "id": "senatni-2022-49-a-523550-54",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes",
       "comment": "Na malých farmách totiž často hospodaří drobní zemědělci (živnostníci), kteří se na rozdíl od velkých koncernů typu Agrofert chovají ekologicky a udržitelně."
     },
     {
       "id": "senatni-2022-49-a-523550-55",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know",
       "comment": "Myslím, že úřady a státní instituce by v současnosti měly řešit mnohem důležitější věci než jsou vložky a tampony."
     },
     {
       "id": "senatni-2022-49-a-523550-56",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "dont_know",
       "comment": "Spíš než státní bytový fond by měly při výstavbě soukromých developerů vznikat sociální byty - viz moje odpověď na jednu z předchozích otázek, která se tohoto tématu týkala."
     },
     {
       "id": "senatni-2022-49-a-523550-57",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no",
       "comment": "Žádnému agresorovi se nesmí ustupovat, a už vůbec ne Rusku, jehož prezident Putin se chová jako car a Hitler. Po Ukrajině by totiž bylo na řadě Slovensko, Polsko a Česká republika..."
     },
     {
       "id": "senatni-2022-49-a-523550-58",
       "candidate_id": "senatni-2022-49-c-523550",
-      "question_id": "senatni-2022-49-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Na tuhle otázku odpovím příslovím \"Kde nic není, ani smrt nebere!\""
     },
     {
       "id": "senatni-2022-49-a-439462-1",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-2",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-3",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-439462-4",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Důležitá je železniční i silniční infrastruktura. Nelze upřednostňovat jednu před druhou."
     },
     {
       "id": "senatni-2022-49-a-439462-5",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-6",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-7",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-8",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-9",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-10",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-11",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-12",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-13",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "Co je fake news? Kdo o tom rozhodne? Tedy nemazat, nejvýše opatřit upozorněním na kontroverzní obsah."
     },
     {
       "id": "senatni-2022-49-a-439462-14",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-15",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-439462-16",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-439462-17",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-18",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-19",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "dont_know",
       "comment": "Vždy záleží na místních podmínkách a konkrétních projektech."
     },
     {
       "id": "senatni-2022-49-a-439462-20",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-21",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-439462-22",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know",
       "comment": "Tahle otázka je test pozornosti? :-)"
     },
     {
       "id": "senatni-2022-49-a-439462-23",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-24",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-25",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-26",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-27",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-28",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-29",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-30",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-31",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-439462-32",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-33",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-34",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-35",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-36",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-37",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-38",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-39",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-40",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "dont_know",
       "comment": "Tyto systémy by měly být užívány tam, kde mají opodstatnění dané snižování rizik pro ostatní účastníky silničního provozu."
     },
     {
       "id": "senatni-2022-49-a-439462-41",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-42",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no",
       "comment": "Za současného stavu (míněn i stav do ruské agrese) nikoliv, v budoucnu pokud možno ano. "
     },
     {
       "id": "senatni-2022-49-a-439462-43",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "Za současného stavu (míněn i stav do ruské agrese) nikoliv, v budoucnu podle konkrétní geopolitické situace. "
     },
     {
       "id": "senatni-2022-49-a-439462-44",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-439462-45",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-46",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-47",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-48",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-439462-49",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-50",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-51",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-52",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-439462-53",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-439462-54",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "dont_know",
       "comment": "Nejlépe bez dotací, což, bohužel, nelze. Dotace jsou nutné pro farmy všech velikostí, měly by být diferencované."
     },
     {
       "id": "senatni-2022-49-a-439462-55",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-56",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no",
       "comment": "Bytová politika má být věcí obce, stát má k obecní bytové politice vytvořit vhodné legislativní a finanční podmínky"
     },
     {
       "id": "senatni-2022-49-a-439462-57",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-439462-58",
       "candidate_id": "senatni-2022-49-c-439462",
-      "question_id": "senatni-2022-49-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-1",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-2",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-744028-3",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-4",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-744028-5",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-6",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-7",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-8",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-9",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-744028-10",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-11",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-12",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-13",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-14",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-15",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-744028-16",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-17",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-18",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-744028-19",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-20",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-21",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-744028-22",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-744028-23",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-744028-24",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-25",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-26",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-27",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-28",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-744028-29",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-30",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-31",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-32",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-33",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-744028-34",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-35",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-36",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-37",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-38",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-744028-39",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-40",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-41",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-744028-42",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-43",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-44",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-45",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-46",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-47",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-48",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-49",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-50",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-744028-51",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-52",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-53",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-54",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-744028-55",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-744028-56",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-744028-57",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-744028-58",
       "candidate_id": "senatni-2022-49-c-744028",
-      "question_id": "senatni-2022-49-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-1",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-2",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-3",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-4",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-5",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-6",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-7",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-8",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-9",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-10",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-11",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-12",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-13",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-14",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-15",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-16",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-17",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-18",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-19",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-20",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-21",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-22",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-23",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-229934-24",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-25",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-26",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-27",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-28",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-29",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-30",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-31",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-32",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-33",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-34",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-35",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-36",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-37",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-38",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-39",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-40",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-41",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-42",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-43",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-229934-44",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-45",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-46",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-47",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-48",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-49",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-50",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-51",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-52",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-53",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-54",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-49-a-229934-55",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-49-a-229934-56",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-57",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-49-a-229934-58",
       "candidate_id": "senatni-2022-49-c-229934",
-      "question_id": "senatni-2022-49-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     }
   ]

--- a/data/kalkulacka/senatni-2022/52.json
+++ b/data/kalkulacka/senatni-2022/52.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-52-c-787854",
       "name": "Luděk Růžička",
       "type": "person",
-      "description": "Luděk Růžička - DESCRIPTION",
+      "description": "Luděk Růžička",
       "contacts": {
         "web": []
       },
@@ -490,7 +490,7 @@
         {
           "id": "senatni-2022-52-c-787854-p",
           "name": "Luděk Růžička",
-          "description": "Luděk Růžička - DESCRIPTION",
+          "description": "Luděk Růžička",
           "contacts": {
             "web": []
           },
@@ -502,7 +502,7 @@
       "id": "senatni-2022-52-c-975208",
       "name": "Tomáš Nielsen",
       "type": "person",
-      "description": "Tomáš Nielsen - DESCRIPTION",
+      "description": "Tomáš Nielsen",
       "contacts": {
         "web": [],
         "twitter": "https://twitter.com/TomasNielsen1"
@@ -511,7 +511,7 @@
         {
           "id": "senatni-2022-52-c-975208-p",
           "name": "Tomáš Nielsen",
-          "description": "Tomáš Nielsen - DESCRIPTION",
+          "description": "Tomáš Nielsen",
           "contacts": {
             "web": [],
             "twitter": "https://twitter.com/TomasNielsen1"
@@ -524,7 +524,7 @@
       "id": "senatni-2022-52-c-406075",
       "name": "Miloš Vystrčil",
       "type": "person",
-      "description": "Miloš Vystrčil - DESCRIPTION",
+      "description": "Miloš Vystrčil",
       "contacts": {
         "web": [
           {
@@ -539,7 +539,7 @@
         {
           "id": "senatni-2022-52-c-406075-p",
           "name": "Miloš Vystrčil",
-          "description": "Miloš Vystrčil - DESCRIPTION",
+          "description": "Miloš Vystrčil",
           "contacts": {
             "web": [
               {
@@ -558,7 +558,7 @@
       "id": "senatni-2022-52-c-520609",
       "name": "Václav Lhotský",
       "type": "person",
-      "description": "Václav Lhotský - DESCRIPTION",
+      "description": "Václav Lhotský",
       "contacts": {
         "web": []
       },
@@ -566,7 +566,7 @@
         {
           "id": "senatni-2022-52-c-520609-p",
           "name": "Václav Lhotský",
-          "description": "Václav Lhotský - DESCRIPTION",
+          "description": "Václav Lhotský",
           "contacts": {
             "web": []
           },
@@ -578,7 +578,7 @@
       "id": "senatni-2022-52-c-829521",
       "name": "Josef Pavlík",
       "type": "person",
-      "description": "Josef Pavlík - DESCRIPTION",
+      "description": "Josef Pavlík",
       "contacts": {
         "web": [
           {
@@ -591,7 +591,7 @@
         {
           "id": "senatni-2022-52-c-829521-p",
           "name": "Josef Pavlík",
-          "description": "Josef Pavlík - DESCRIPTION",
+          "description": "Josef Pavlík",
           "contacts": {
             "web": [
               {
@@ -608,7 +608,7 @@
       "id": "senatni-2022-52-c-800084",
       "name": "Jana Nagyová",
       "type": "person",
-      "description": "Jana Nagyová - DESCRIPTION",
+      "description": "Jana Nagyová",
       "contacts": {
         "web": []
       },
@@ -616,7 +616,7 @@
         {
           "id": "senatni-2022-52-c-800084-p",
           "name": "Jana Nagyová",
-          "description": "Jana Nagyová - DESCRIPTION",
+          "description": "Jana Nagyová",
           "contacts": {
             "web": []
           },
@@ -629,713 +629,713 @@
     {
       "id": "senatni-2022-52-a-829521-1",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-2",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-3",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-4",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-5",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-6",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-7",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-8",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-9",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-10",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-11",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-12",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-13",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-14",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-15",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-16",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-17",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-18",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-19",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-20",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-21",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-22",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-23",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-24",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-25",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-26",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-27",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "yes",
       "comment": "V případě zrušení práva veta."
     },
     {
       "id": "senatni-2022-52-a-829521-28",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-29",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-30",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-31",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-32",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-52-a-829521-33",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-34",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-35",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-36",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-37",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-38",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-39",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-40",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-52-a-829521-41",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-42",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-43",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-44",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-45",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-46",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-52-a-829521-47",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-52-a-829521-48",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-49",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-50",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-52-a-829521-51",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-52-a-829521-52",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-53",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes",
       "comment": "Je to záležitostí každého suverénního státu."
     },
     {
       "id": "senatni-2022-52-a-829521-54",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-829521-55",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-56",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-829521-57",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-52-a-829521-58",
       "candidate_id": "senatni-2022-52-c-829521",
-      "question_id": "senatni-2022-52-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-1",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Jinak to může být u bytů, které byly vystavěny s pomocí finančních prostředků z veřejného rozpočtu."
     },
     {
       "id": "senatni-2022-52-a-406075-2",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Jinak to může být u bytů, které byly vystavěny s pomocí finančních prostředků z veřejného rozpočtu."
     },
     {
       "id": "senatni-2022-52-a-406075-3",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no",
       "comment": "Dovedu si představit zákonem stanovené výjimky."
     },
     {
       "id": "senatni-2022-52-a-406075-4",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-5",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-406075-6",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-52-a-406075-7",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "dont_know",
       "comment": "Je třeba dělat to, co je ekologičtější. Shoda, které řešení je ekologičtější, zatím není."
     },
     {
       "id": "senatni-2022-52-a-406075-8",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Již je již zvýšená například z důvodu existence odečitatelných položek."
     },
     {
       "id": "senatni-2022-52-a-406075-9",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-52-a-406075-10",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-11",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-12",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-52-a-406075-13",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-14",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-406075-15",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-16",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes",
       "comment": "Nejsem ale pro název manželství."
     },
     {
       "id": "senatni-2022-52-a-406075-17",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-18",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-19",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "Dovedu si představit jako podmínku při poskytnutí státní dotace."
     },
     {
       "id": "senatni-2022-52-a-406075-20",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Jsem pro podporu neziskových organizací, které stát v tomto zastoupí. Stát má mít ale povinnost poradit a pomoci."
     },
     {
       "id": "senatni-2022-52-a-406075-21",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-406075-22",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know",
       "comment": "Nevím, co si představit pod pojmem kolonizace Marsu."
     },
     {
       "id": "senatni-2022-52-a-406075-23",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Jsem však pro zavedení této možnosti pro české občany pobývající v zahraničí."
     },
     {
       "id": "senatni-2022-52-a-406075-24",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-25",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-406075-26",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "Speciální školy je však třeba zachovat.  Všem dětem musí zůstat zachována možnost radovat se z úspěchu."
     },
     {
       "id": "senatni-2022-52-a-406075-27",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-406075-28",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "Při splnění podmínek."
     },
     {
       "id": "senatni-2022-52-a-406075-29",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-406075-30",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-31",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-32",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-33",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-406075-34",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-35",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-36",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-52-a-406075-37",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-38",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-39",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-40",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-406075-41",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-42",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-43",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-44",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-45",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-406075-46",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-47",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-406075-48",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-52-a-406075-49",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-406075-50",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know",
       "comment": "Záleží na situaci ve světě."
     },
     {
       "id": "senatni-2022-52-a-406075-51",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-406075-52",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-406075-53",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-52-a-406075-54",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "Ideální je systém bez dotací, pokud dotovat, tak podle toho, jak se kdo stará o půdu a krajinu a přitom má živočišnou i rostlinnou produkci."
     },
     {
       "id": "senatni-2022-52-a-406075-55",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-52-a-406075-56",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-406075-57",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-52-a-406075-58",
       "candidate_id": "senatni-2022-52-c-406075",
-      "question_id": "senatni-2022-52-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "dont_know",
       "comment": "Je třeba hledat jiné řešení."
     }

--- a/data/kalkulacka/senatni-2022/55.json
+++ b/data/kalkulacka/senatni-2022/55.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-55-c-716101",
       "name": "Petra Rédová Fajmonová",
       "type": "person",
-      "description": "Petra Rédová Fajmonová - DESCRIPTION",
+      "description": "Petra Rédová Fajmonová",
       "contacts": {
         "web": [
           {
@@ -501,7 +501,7 @@
         {
           "id": "senatni-2022-55-c-716101-p",
           "name": "Petra Rédová Fajmonová",
-          "description": "Petra Rédová Fajmonová - DESCRIPTION",
+          "description": "Petra Rédová Fajmonová",
           "contacts": {
             "web": [
               {
@@ -524,7 +524,7 @@
       "id": "senatni-2022-55-c-429934",
       "name": "Radomír Pavlíček",
       "type": "person",
-      "description": "Radomír Pavlíček - DESCRIPTION",
+      "description": "Radomír Pavlíček",
       "contacts": {
         "web": [
           {
@@ -539,7 +539,7 @@
         {
           "id": "senatni-2022-55-c-429934-p",
           "name": "Radomír Pavlíček",
-          "description": "Radomír Pavlíček - DESCRIPTION",
+          "description": "Radomír Pavlíček",
           "contacts": {
             "web": [
               {
@@ -558,7 +558,7 @@
       "id": "senatni-2022-55-c-323222",
       "name": "Pavel Trčala",
       "type": "person",
-      "description": "Pavel Trčala - DESCRIPTION",
+      "description": "Pavel Trčala",
       "contacts": {
         "web": [
           {
@@ -571,7 +571,7 @@
         {
           "id": "senatni-2022-55-c-323222-p",
           "name": "Pavel Trčala",
-          "description": "Pavel Trčala - DESCRIPTION",
+          "description": "Pavel Trčala",
           "contacts": {
             "web": [
               {
@@ -588,7 +588,7 @@
       "id": "senatni-2022-55-c-248878",
       "name": "Bořek Semrád",
       "type": "person",
-      "description": "Bořek Semrád - DESCRIPTION",
+      "description": "Bořek Semrád",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/boreksemraddosenatu",
@@ -598,7 +598,7 @@
         {
           "id": "senatni-2022-55-c-248878-p",
           "name": "Bořek Semrád",
-          "description": "Bořek Semrád - DESCRIPTION",
+          "description": "Bořek Semrád",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/boreksemraddosenatu",
@@ -612,7 +612,7 @@
       "id": "senatni-2022-55-c-240503",
       "name": "Tomáš Kotas",
       "type": "person",
-      "description": "Tomáš Kotas - DESCRIPTION",
+      "description": "Tomáš Kotas",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/Akad-arch-Tom%C3%A1%C5%A1-Kotas-SPD-107950361968546"
@@ -621,7 +621,7 @@
         {
           "id": "senatni-2022-55-c-240503-p",
           "name": "Tomáš Kotas",
-          "description": "Tomáš Kotas - DESCRIPTION",
+          "description": "Tomáš Kotas",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/Akad-arch-Tom%C3%A1%C5%A1-Kotas-SPD-107950361968546"
@@ -634,7 +634,7 @@
       "id": "senatni-2022-55-c-924292",
       "name": "Tomáš Töpfer",
       "type": "person",
-      "description": "Tomáš Töpfer - DESCRIPTION",
+      "description": "Tomáš Töpfer",
       "contacts": {
         "web": [
           {
@@ -652,7 +652,7 @@
         {
           "id": "senatni-2022-55-c-924292-p",
           "name": "Tomáš Töpfer",
-          "description": "Tomáš Töpfer - DESCRIPTION",
+          "description": "Tomáš Töpfer",
           "contacts": {
             "web": [
               {
@@ -674,7 +674,7 @@
       "id": "senatni-2022-55-c-264620",
       "name": "Bohumil Smutný",
       "type": "person",
-      "description": "Bohumil Smutný - DESCRIPTION",
+      "description": "Bohumil Smutný",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/bohumil.smutny"
@@ -683,7 +683,7 @@
         {
           "id": "senatni-2022-55-c-264620-p",
           "name": "Bohumil Smutný",
-          "description": "Bohumil Smutný - DESCRIPTION",
+          "description": "Bohumil Smutný",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/bohumil.smutny"
@@ -697,712 +697,712 @@
     {
       "id": "senatni-2022-55-a-264620-1",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-2",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-3",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-4",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-5",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-6",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-264620-7",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-8",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-9",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-10",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-11",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-12",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-264620-13",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-264620-14",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-15",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-16",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-17",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-18",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-19",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-20",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-21",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-22",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-23",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-24",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-25",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-26",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-264620-27",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-264620-28",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-29",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-30",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-264620-31",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-32",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-264620-33",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-34",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-35",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-36",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-37",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-38",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-264620-39",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-264620-40",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-41",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-42",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-43",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-44",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-45",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-264620-46",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-264620-47",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-48",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-264620-49",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-50",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-51",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-52",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-53",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-264620-54",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-55",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-264620-56",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-264620-57",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-264620-58",
       "candidate_id": "senatni-2022-55-c-264620",
-      "question_id": "senatni-2022-55-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-1",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "dont_know",
       "comment": "Kdo bude vyhodnocovat obsazenost bytů, \"bytový úřad\"? "
     },
     {
       "id": "senatni-2022-55-a-429934-2",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-3",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Je nutné vyřešit petiční podmínky, aby to dávalo smysl. "
     },
     {
       "id": "senatni-2022-55-a-429934-4",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-5",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-6",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes",
       "comment": "Bude ale problém najít vhodné lokality."
     },
     {
       "id": "senatni-2022-55-a-429934-7",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-8",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-9",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-10",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-429934-11",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-12",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-13",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-14",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-15",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-16",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know",
       "comment": "Jsem pro stejná práva ve stejnopohlavních vztazích, ovšem nenazývejme je přímo manželstvím."
     },
     {
       "id": "senatni-2022-55-a-429934-17",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-18",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-19",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "Tento problémy lze řešit lepšími metodami, třeba kombinací seniorského a startovacího bydlení apod. "
     },
     {
       "id": "senatni-2022-55-a-429934-20",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-21",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-22",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know",
       "comment": "Už víme konkrétní termín? "
     },
     {
       "id": "senatni-2022-55-a-429934-23",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-24",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "Je třeba se zaměřit hlavně na řemeslné obory."
     },
     {
       "id": "senatni-2022-55-a-429934-25",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-26",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-27",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-28",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-29",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-30",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-31",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-32",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-55-a-429934-33",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Institut azylu je aktuálně dostačující."
     },
     {
       "id": "senatni-2022-55-a-429934-34",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-35",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-36",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know",
       "comment": "Je to vůbec možné?"
     },
     {
       "id": "senatni-2022-55-a-429934-37",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-38",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-39",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know",
       "comment": "Dle možností by mělo být výrazně omezeno."
     },
     {
       "id": "senatni-2022-55-a-429934-40",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-41",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-42",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes",
       "comment": "Pokud splní přístupové podmínky."
     },
     {
       "id": "senatni-2022-55-a-429934-43",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-44",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-45",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-46",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-47",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-48",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Domácí násilí bychom měli potírat obecně."
     },
     {
       "id": "senatni-2022-55-a-429934-49",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Aktuální energetická situace to neumožňuje."
     },
     {
       "id": "senatni-2022-55-a-429934-50",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-51",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-52",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-53",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-55-a-429934-54",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "Menší farmy a ekologicky hospodařící zemedělci by měli být zvýhodněni. "
     },
     {
       "id": "senatni-2022-55-a-429934-55",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-56",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no",
       "comment": "tyto kompetence bych ponechal obcím a městům."
     },
     {
       "id": "senatni-2022-55-a-429934-57",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-55-a-429934-58",
       "candidate_id": "senatni-2022-55-c-429934",
-      "question_id": "senatni-2022-55-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "no"
     }
   ]

--- a/data/kalkulacka/senatni-2022/58.json
+++ b/data/kalkulacka/senatni-2022/58.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-58-c-381319",
       "name": "Jiří Dušek",
       "type": "person",
-      "description": "Jiří Dušek - DESCRIPTION",
+      "description": "Jiří Dušek",
       "contacts": {
         "web": [
           {
@@ -505,7 +505,7 @@
         {
           "id": "senatni-2022-58-c-381319-p",
           "name": "Jiří Dušek",
-          "description": "Jiří Dušek - DESCRIPTION",
+          "description": "Jiří Dušek",
           "contacts": {
             "web": [
               {
@@ -532,7 +532,7 @@
       "id": "senatni-2022-58-c-296693",
       "name": "Petr Kunc",
       "type": "person",
-      "description": "Petr Kunc - DESCRIPTION",
+      "description": "Petr Kunc",
       "contacts": {
         "web": [
           {
@@ -556,7 +556,7 @@
         {
           "id": "senatni-2022-58-c-296693-p",
           "name": "Petr Kunc",
-          "description": "Petr Kunc - DESCRIPTION",
+          "description": "Petr Kunc",
           "contacts": {
             "web": [
               {
@@ -584,7 +584,7 @@
       "id": "senatni-2022-58-c-663420",
       "name": "Lucie Zajícová",
       "type": "person",
-      "description": "Lucie Zajícová - DESCRIPTION",
+      "description": "Lucie Zajícová",
       "contacts": {
         "web": []
       },
@@ -592,7 +592,7 @@
         {
           "id": "senatni-2022-58-c-663420-p",
           "name": "Lucie Zajícová",
-          "description": "Lucie Zajícová - DESCRIPTION",
+          "description": "Lucie Zajícová",
           "contacts": {
             "web": []
           },
@@ -604,7 +604,7 @@
       "id": "senatni-2022-58-c-995955",
       "name": "Zdeněk Koudelka",
       "type": "person",
-      "description": "Zdeněk Koudelka - DESCRIPTION",
+      "description": "Zdeněk Koudelka",
       "contacts": {
         "web": [
           {
@@ -626,7 +626,7 @@
         {
           "id": "senatni-2022-58-c-995955-p",
           "name": "Zdeněk Koudelka",
-          "description": "Zdeněk Koudelka - DESCRIPTION",
+          "description": "Zdeněk Koudelka",
           "contacts": {
             "web": [
               {
@@ -652,7 +652,7 @@
       "id": "senatni-2022-58-c-630883",
       "name": "Michal Sedláček",
       "type": "person",
-      "description": "Michal Sedláček - DESCRIPTION",
+      "description": "Michal Sedláček",
       "contacts": {
         "web": [
           {
@@ -676,7 +676,7 @@
         {
           "id": "senatni-2022-58-c-630883-p",
           "name": "Michal Sedláček",
-          "description": "Michal Sedláček - DESCRIPTION",
+          "description": "Michal Sedláček",
           "contacts": {
             "web": [
               {
@@ -704,7 +704,7 @@
       "id": "senatni-2022-58-c-260752",
       "name": "Petr Vokřál",
       "type": "person",
-      "description": "Petr Vokřál - DESCRIPTION",
+      "description": "Petr Vokřál",
       "contacts": {
         "web": [
           {
@@ -719,7 +719,7 @@
         {
           "id": "senatni-2022-58-c-260752-p",
           "name": "Petr Vokřál",
-          "description": "Petr Vokřál - DESCRIPTION",
+          "description": "Petr Vokřál",
           "contacts": {
             "web": [
               {
@@ -739,1840 +739,1840 @@
     {
       "id": "senatni-2022-58-a-296693-1",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Dlouhodobě prázdné byty a domy mají pouze města, v Brně je to cca 1000 bytů. Pro soukromou nebo právnickou osobu nedává ekonomický smysl držet prázdné byty, proto je takových případů naprosté minimum. "
     },
     {
       "id": "senatni-2022-58-a-296693-2",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "ČR může regulovat nájemné u obecních domů, v žádném případě však u soukromých. "
     },
     {
       "id": "senatni-2022-58-a-296693-3",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-4",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-5",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "yes",
       "comment": "Z důvodu zachování fungujícího penzijního systému to bude nutnost. "
     },
     {
       "id": "senatni-2022-58-a-296693-6",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know",
       "comment": "Nelze posuzovat všechny záměry stejně."
     },
     {
       "id": "senatni-2022-58-a-296693-7",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes",
       "comment": "Ano, sníží to objem odpadu i nepořádek v ulicích. "
     },
     {
       "id": "senatni-2022-58-a-296693-8",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-9",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-10",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-11",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-12",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-13",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "dont_know",
       "comment": "Vhodný systém využívá Twitter, který \"fake news\" nemaže, ale upozorní na ně. "
     },
     {
       "id": "senatni-2022-58-a-296693-14",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-15",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-16",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes",
       "comment": "Jednoznačně ano. "
     },
     {
       "id": "senatni-2022-58-a-296693-17",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-18",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-19",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "Obecní a státní ano, soukromá ne. "
     },
     {
       "id": "senatni-2022-58-a-296693-20",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-21",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no",
       "comment": "Rozmístění institucí musí splňovat mnohem více kritérií, než jen rovnoměrné rozmístění po ČR. "
     },
     {
       "id": "senatni-2022-58-a-296693-22",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-23",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Za předpokladu zajištění naprosté anonymity při hlasování."
     },
     {
       "id": "senatni-2022-58-a-296693-24",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-25",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-26",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "dont_know",
       "comment": "Tato problematika je příliš složitá a necítím se být v ní dostatečně erudovaný. "
     },
     {
       "id": "senatni-2022-58-a-296693-27",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-28",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-29",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-30",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-31",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-32",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-296693-33",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-296693-34",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-35",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-36",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-37",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-38",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-296693-39",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-40",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-41",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-42",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes",
       "comment": "Ano, za předpokladu provedení nutných reforem. "
     },
     {
       "id": "senatni-2022-58-a-296693-43",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-44",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-296693-45",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-46",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-47",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-48",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-49",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "yes",
       "comment": "Ale je potřeba mít v době ukončení spalování uhlí alternativu k produkci dostatku elektrické energie. "
     },
     {
       "id": "senatni-2022-58-a-296693-50",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-51",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-52",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-53",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-54",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-55",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-296693-56",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no",
       "comment": "Ne, tuto funkci plní a mají plnit obce a městské části. "
     },
     {
       "id": "senatni-2022-58-a-296693-57",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-296693-58",
       "candidate_id": "senatni-2022-58-c-296693",
-      "question_id": "senatni-2022-58-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-1",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-2",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-3",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "dont_know",
       "comment": "Záleží na okruzích, o kterých by se hlasovalo."
     },
     {
       "id": "senatni-2022-58-a-381319-4",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-5",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-381319-6",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-7",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-8",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-9",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-10",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-11",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-12",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes",
       "comment": "Není však možné zavádět cenzuru."
     },
     {
       "id": "senatni-2022-58-a-381319-13",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-14",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-381319-15",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-381319-16",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-381319-17",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-18",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-381319-19",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-20",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-21",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-22",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-381319-23",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-24",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-25",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-26",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-27",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-28",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-381319-29",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-30",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-31",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-32",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-33",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-34",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-35",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-36",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-37",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-38",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-39",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-381319-40",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-41",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-42",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-381319-43",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-44",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-45",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-46",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-47",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-48",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-381319-49",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-50",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-51",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-52",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-381319-53",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-381319-54",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-55",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-381319-56",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-381319-57",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-381319-58",
       "candidate_id": "senatni-2022-58-c-381319",
-      "question_id": "senatni-2022-58-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-663420-1",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-663420-2",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Regulace pouze u obecních bytů a ze sociálních důvodů. \nSoukromé vlastnictví je nedotknutelné v každém smyslu, a je nemyslitelné, že by Stát - ČR někomu, kdo své vydělané peníze vložil investičně do nemovitosti  - třeba k pronájmu na přilepšení v důchodu, nebo dokud nedorostou děti, určoval jeho smluvní ceny. Ty vyřeší tržní prostředí."
     },
     {
       "id": "senatni-2022-58-a-663420-3",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-663420-4",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "ČR není tak velkou zemí, aby se taková obrovská investice vyplatila. Alternativou pro spěchající cestující by mohlo být obnovení vnitrostátní letecké dopravy, kde ceny letenek jsou srovnatelné s cenami jízdenek rychlovlaků."
     },
     {
       "id": "senatni-2022-58-a-663420-5",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Při absenci státního důchodového fondu nemůže být řešena otázka důchodové reformy zaměstnáváním lidí až do smrti..."
     },
     {
       "id": "senatni-2022-58-a-663420-6",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes",
       "comment": "Nejenom retence vody, ale i výroba el. energie."
     },
     {
       "id": "senatni-2022-58-a-663420-7",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-663420-8",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Je absurdní trestat ty, kteří se snaží a pracují více, než ti, kteří by se klidně spokojili s nepodmíněným příjmem - bez práce. Procentuální sazba znamená, že ten, kdo vydělává více, odvádí také více do státního rozpočtu - procentuálně. (Pokud ovšem nedaní v daňovém ráji...- viz zákaz dvojího zdanění))"
     },
     {
       "id": "senatni-2022-58-a-663420-9",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Ale pouze pro osobní spotřebu a to už v malé míře je. Konopí je však také velmi pevný technický materiál - například jako plnivo laminátových kompozitů."
     },
     {
       "id": "senatni-2022-58-a-663420-10",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-663420-11",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-663420-12",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Pouze za obsah, který je v rozporu se zákonem - např. pornografie, pedofilie, cyberterorismus ,  vybízení k násilí a ohrožování života, přístupné dětem a mladistvým. U dospělých se předpokládá, že vědí, co dělají a jsou odpovědní za své konání."
     },
     {
       "id": "senatni-2022-58-a-663420-13",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "I podle zákona je svoboda slova a svoboda názoru v ČR zaručena a naopak jakákoliv cenzura je nepřípustná a antidemokratická. Dodržování zákona je základem právního státu. "
     },
     {
       "id": "senatni-2022-58-a-663420-14",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes",
       "comment": "Veřejnoprávní média, placená ze státního rozpočtu, mají sloužit k nestranné  informaci veřejnosti a obohacování kultury občanstva. Tuto službu již platí každý pracující z daní. Proto by neměli ani občané platit ještě podruhé tuto jednu službu povinnými \"poplatky\" a tato státní media by ani neměla podnikat prodejem vysílacího času pro lukrativní reklamy, na rozdíl od komerčních médií."
     },
     {
       "id": "senatni-2022-58-a-663420-15",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes",
       "comment": "K tomu účelu jsou určeny (a ze státního rozpočtu placeny) Úřady práce. Pokud pracují neefektivně, je třeba to napravit, a ne platit desetitisíce \"neziskovek\", které z této situace mají svůj soukromý byznys.za státní peníze."
     },
     {
       "id": "senatni-2022-58-a-663420-16",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Nevidím k tomu důvod.\nBeru manželství jako přirozený právní rámec k zabezpečení zdravého vývoje a výchovy potomstva, zplozeného (přirozeně) mužem a ženou, a manželství, které takto právně kodifikuje rodinu, je pak, přinejmenším psychologicky, stabilním a bezpečným zázemím rodiny a dětí do doby jejich samostatnosti.\nDlužno dodat, že je  i mnoho rodin s dětmi, kde muž a žena řeší rodinný statut zákonným  institutem  partnerství.\n"
     },
     {
       "id": "senatni-2022-58-a-663420-17",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "dont_know",
       "comment": "Žádná z nabízených odpovědí.\nExekutor by měl být státní úředník, nikoliv podnikatel s chudobou."
     },
     {
       "id": "senatni-2022-58-a-663420-18",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-663420-19",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Ano obecní a státní výstavba, ne soukromá. Soukromá osoba nemá povinnost zajišťovat nebo kompenzovat sociální povinnosti státu."
     },
     {
       "id": "senatni-2022-58-a-663420-20",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Stát má především zajišťovat takové životní podmínky svých občanů preventivní sociální politikou, aby se lidi do nouze nedostali (např. nabídkou pracovních míst, řádnou zdravotní péčí, zákazem lichvy, a především občanskou výchovou už od základní školy)"
     },
     {
       "id": "senatni-2022-58-a-663420-21",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-663420-22",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no",
       "comment": "\"Snaha o kolonizaci Marsu\" je úsměvná za stavu, kdy Mars ještě žádný živý člověk naživo ani neviděl. je to stejně úsměvné, jako jistý \"Mars Architekt\", který představoval svoje projekty obydlí pro Mars na ČT24... "
     },
     {
       "id": "senatni-2022-58-a-663420-23",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Rozhodně ne. Každá elektronika se dá \"hacknout\" a demokratický proces voleb tak ovlivnit dle libosti. (Viz elektronický volební systém Dominion v USA při volbě Prezidenta). \nNaopak v opravdu demokratickém a svobodném státě by člověk neměl mít problém sdělit svoji volbu svých zástupců, kterým důvěřuje, osobně a jmenovitě."
     },
     {
       "id": "senatni-2022-58-a-663420-24",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "Protože jsou potřeba a je jich nedostatek."
     },
     {
       "id": "senatni-2022-58-a-663420-25",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Je nestoudné sakrifikovat talenty kvůli kolektivizaci. To nebylo ani za totality."
     },
     {
       "id": "senatni-2022-58-a-663420-26",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no",
       "comment": "Naopak - děti by se měly vzdělávat v kolektivu podobné úrovně, aby slabší žáci nebyli silnějšími, nebo výrazně schopnějšími dětmi zesměšňováni, a netrpěli pocity méněcennosti. \nŠkola by měla pomáhat tomu, aby každý, podle svých schopností, našel svoje platné místo ve společnosti. Fakt, že někdo nemá na kvantové rovnice neznamená, že nemůže být skvělým kuchařem, nebo zahradníkem, která dělá svoji hodnotnou práci s láskou."
     },
     {
       "id": "senatni-2022-58-a-663420-27",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "yes",
       "comment": "ČR za současného stavu nemá suverenitu rozhodování - viz např. rozhodnutí EU o odmítnutí levného ruského plynu, na kterém je postavena většina průmyslu naší země. "
     },
     {
       "id": "senatni-2022-58-a-663420-28",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "ČR by tak ztratila možnost regulace vlastní měny, a mohla by dopadnout jako Řecko, nebo Itálie."
     },
     {
       "id": "senatni-2022-58-a-663420-29",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes",
       "comment": "ČR, i díky své poloze ve středu Evropy - na rozhraní dvou vlivových pásem, by měla být vojensky neutrální zemí, jako třeba Rakousko, nebo Švýcarsko."
     },
     {
       "id": "senatni-2022-58-a-663420-30",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no",
       "comment": "Místo ČR je v naší zemi - v Čechách, na Moravě a ve Slezsku."
     },
     {
       "id": "senatni-2022-58-a-663420-31",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "ČR musí přede vším ostatním zabezpečit teplo, světlo, potravinovou dostatečnost, zdravotní péči a mír svým občanům. Proto tento stát naši předkové před 100 lety založili."
     },
     {
       "id": "senatni-2022-58-a-663420-32",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no",
       "comment": "Politici ČR musí především chránit zdravé klima v naší zemi."
     },
     {
       "id": "senatni-2022-58-a-663420-33",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Pouze pro opravdu potřebné a prověřené osoby - tak, jak to dělá každý stát v zájmu své bezpečnosti. Je rozdíl mezi prchajícími před válkou nebo pronásledovanými politicky  a ekonomickými přistěhovalci možného kriminálního původu.\nPři aktuálním naředění naší pracující společnosti o téměř 6% naší populace nepracujícími imigranty hrozí kolaps našeho sociálního systému."
     },
     {
       "id": "senatni-2022-58-a-663420-34",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-663420-35",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no",
       "comment": "ČR by měla vyhlásit vojenskou neutralitu. Většina našich občanů jsou mírumilovní lidé, kteří chtějí mír a sami nikoho neohrožují ani nekolonizují."
     },
     {
       "id": "senatni-2022-58-a-663420-36",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-663420-37",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no",
       "comment": "Diskriminační praktiky nepodporuji a naše současné státní zdravotnictví je na dostatečné úrovni i pro ty náročnější."
     },
     {
       "id": "senatni-2022-58-a-663420-38",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-663420-39",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes",
       "comment": "Rozhodně! Je toxický, prokazatelně rakovinotvorný a mutagenní - působí na DNA člověka."
     },
     {
       "id": "senatni-2022-58-a-663420-40",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-663420-41",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes",
       "comment": "Vlastní biometrické údaje jsou osobními údaji, a musí spadat do GDPR."
     },
     {
       "id": "senatni-2022-58-a-663420-42",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no",
       "comment": "ČR by měla vystoupit."
     },
     {
       "id": "senatni-2022-58-a-663420-43",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "Ukrajina tím riskuje otevřenou válku NATO s Ruskem na celém svém území. Dohody o sférách vlivu  po 2WW hovořily o jasném rozdělení pásem v Evropě, a RF má již nyní NATO na téměř celé své západní hranici, a tu, jak sdělil ruský Ministr zahraničí, chce mít v bezpečí."
     },
     {
       "id": "senatni-2022-58-a-663420-44",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "EU by měla zastropovat ceny plynu pro obyvatele EU - členských států na stejné, snesitelné úrovni. \nEU místo toho však chce \"zastropovat\" = určovat RF prodejní ceny plynu do EU. \nDůsledkem tohoto EU \"koumáctví\" je, že RF k 31.8.2022 zastavila přívod plynu do EU plynovodem Nordstream, a prodává plyn podle svých podmínek jinde."
     },
     {
       "id": "senatni-2022-58-a-663420-45",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-663420-46",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "no",
       "comment": "Ukrajinské vedení od počátku otevřeně bojkotovalo plnění Minských dohod pro mír na jihu Ukrajiny, kde do začátku ozbrojeného konfliktu v únoru 2022 již od roku 2014 bylo přes 20.000 obětí, včetně dětí (viz foto v \"Aleji Andělů\") na ruskojazyčném obyvatelstvu. \nZajímavé je, že tyto oběti na Ukrajině např.  Premier Fiala, ani jiní, nikdy nezmínili."
     },
     {
       "id": "senatni-2022-58-a-663420-47",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes",
       "comment": "Diplomatické řešení tohoto konfliktu je jediné možné, aby se předešlo jeho rozšíření do celé Evropy."
     },
     {
       "id": "senatni-2022-58-a-663420-48",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "no",
       "comment": "EU se snaží stále dělat z žen nějaké bezduché chudinky a z mužů tyrany, a s tím, jako žena, nesouhlasím. Nevím, jak to mají třeba v Německu, nebo ve Francii, ale tady u nás si normální žena umí sjednat pořádek, a nenechá se nikým utlačovat, tím spíše, že naše právo takové případné situace řeší i v trestní rovině, a toto je ve všeobecném povědomí."
     },
     {
       "id": "senatni-2022-58-a-663420-49",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Naopak jsem pro znovuotevření uhelných dolů, protože, vzhledem k našemu podnebnému pásmu, pokud nemáme plyn, tak nějak budeme muset topit a vařit.\nUhlí není ani toxické, ani karcinogenní - lidské tělo je převážně složeno z uhlíku.\nMoje babička topila celý život uhlím a dřevem a dožila se 98 let."
     },
     {
       "id": "senatni-2022-58-a-663420-50",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "Co to je \"klimaticky neutrální\"?\nPokud v Radiožurnálu bývalý Ministr ŽP Moldán říká, že \"80 % snížení CO2 je podle něj málo, že on by šel dále (i přes 100%?), tak mu zřejmě nedochází, že by asi musel on a všichni ostatní museli přestat dýchat, navždy."
     },
     {
       "id": "senatni-2022-58-a-663420-51",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "yes",
       "comment": "Už jí je."
     },
     {
       "id": "senatni-2022-58-a-663420-52",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Bilaterálními smlouvami."
     },
     {
       "id": "senatni-2022-58-a-663420-53",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-663420-54",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "Zemědělské dotace EU ničí naše zemědělství .\nNa podrobné vysvětlení zde, bohužel, není dost prostoru (vysvětlení EU Programu MZ Greening), ale ve zkratce to vypadá následovně:  např. dle směrnic EU, pod záminkou „biodiversity“ byly na Mikulovsku vykáceny hektary broskvoní, a půda osázena, tuším, jetelem se štědrými dotacemi EU. Stejný model byl aplikován na „záměnu kultur“, kdy místo naší pšenice se lány polí osely, bohatě z EU dotovanou,  řepkou, a navíc, dle doporučení EU, i geneticky modifikovanou.  Výsledkem této štědré dotační politiky EU dnes je, že v ČR nejsme potravinově soběstační, a kilo broskví z Alžíru si naši občané mohou koupit i za 150,- Kč/kg.\n"
     },
     {
       "id": "senatni-2022-58-a-663420-55",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "Takovou \"ideu\" musel opravdu někdo dlouze vymýšlet!\nŽena většinou menstruuje v produktivním věku, a pokud pracuje, tak snad ty dvě stovky za měsíc na hygienu má.  \nAle fakt, že někteří důchodci musí volit mezi léky a jídlem, evidentně takové myslitele míjí."
     },
     {
       "id": "senatni-2022-58-a-663420-56",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no",
       "comment": "To by se se státními byty spekulovalo ještě více, než dnes.\nBude úplně stačit, když se státní instituce, města a obce, budou starat o svěřené nemovitosti s péčí řádného hospodáře, a nebudou nechávat stovky zchátralých bytů prázdných ladem.\nAno, chce to práci."
     },
     {
       "id": "senatni-2022-58-a-663420-57",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know",
       "comment": "To se uvidí podle toho, kolik a jakých zbraní ještě NATO na Ukrajinu naveze."
     },
     {
       "id": "senatni-2022-58-a-663420-58",
       "candidate_id": "senatni-2022-58-c-663420",
-      "question_id": "senatni-2022-58-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Měl by řešit stát, ne soukromý podnikatel - exekutor."
     },
     {
       "id": "senatni-2022-58-a-630883-1",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-2",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-3",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-4",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-5",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-6",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-7",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-8",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-630883-9",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-10",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-11",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-12",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-630883-13",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-14",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-15",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-16",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-17",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-18",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-19",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-20",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-21",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-22",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-630883-23",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-24",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-25",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-26",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-630883-27",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-28",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-29",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-30",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-31",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-630883-32",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-33",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-630883-34",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-35",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-36",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-37",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-38",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-39",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-40",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-41",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-42",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-43",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-630883-44",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-45",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-46",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-47",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-48",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-49",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-630883-50",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-51",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-52",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-53",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-54",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-55",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-630883-56",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-57",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-630883-58",
       "candidate_id": "senatni-2022-58-c-630883",
-      "question_id": "senatni-2022-58-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-260752-1",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Je na obcích, aby komunikovaly se majiteli. Hlavně musí rozšiřovat a opravovat svůj bytový fond a vhodným systémem jej učinit dostupným pro potřebné."
     },
     {
       "id": "senatni-2022-58-a-260752-2",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Obce musí vytvářet dostatečnou síť ekonomicky i fyzicky dostupného bydlení, který bude zároveň regulátorem výše nájemného. Jako např. Vídeň."
     },
     {
       "id": "senatni-2022-58-a-260752-3",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-260752-4",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes",
       "comment": "Toto by měla být jedna z priorit. Bohužel se tak neděje. Pro transit by bylo zároveň žádoucí dostat nákladní tranzitní dopravu na koleje"
     },
     {
       "id": "senatni-2022-58-a-260752-5",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Je třeba najít jiné způsoby. jak udržet penzijní systém funkční"
     },
     {
       "id": "senatni-2022-58-a-260752-6",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes",
       "comment": "Jsme střecha Evropy, měli bychom si zadržovat vodu na svém území a lépe využívat její energii, podobně jako třeba v Norsku či Rakousku."
     },
     {
       "id": "senatni-2022-58-a-260752-7",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes",
       "comment": "Cirkulární ekonomika je jedním z témat, kde hledat odpovědi nejen o ochraně ŽP, ale i o surovinovém a energetickém využití odpadů"
     },
     {
       "id": "senatni-2022-58-a-260752-8",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Toto je populismus. Daně je třeba hlavně vybírat. Je s podivem, že řada restaurací se zrušením EET zrušila okamžitě platby kartami."
     },
     {
       "id": "senatni-2022-58-a-260752-9",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-260752-10",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Obecně tresty za násilné činy."
     },
     {
       "id": "senatni-2022-58-a-260752-11",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-260752-12",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes",
       "comment": "Je to ale věc, která se napříč zeměmi liší. Proto by tyto úpravy měly být v našem regionu řešeny přes EU"
     },
     {
       "id": "senatni-2022-58-a-260752-13",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes",
       "comment": "Ale v principu jen ty skutečně společensky nebezpečné. Toto je třeba definovat. To, že Pablízek je blbec mne neohrožuje."
     },
     {
       "id": "senatni-2022-58-a-260752-14",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Naopak. Otázkou je, zda kvalita veřejnoprávní televize je skutečně na úrovni veřejnoprávní televize a je vyvážená. tady jsem názoru, že tomu ještě něco chybí a nemá to zlepšující tendenci. S vyjímkou mimořádných událostí."
     },
     {
       "id": "senatni-2022-58-a-260752-15",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes",
       "comment": "Sanují převážně krátkodobé pracovní úvazky. Je třeba dopracovat Zákoník práce, aby se tato situace zlepšila. Peníze vydělané FO musí zůstat u těchto osob."
     },
     {
       "id": "senatni-2022-58-a-260752-16",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes",
       "comment": "Za podobných podmínek. Nelze však akceptovat momentální extrémní přístupy, zejména mladých, kteří často tyto \"módní\" výstřelky používají jako image. Pokud někdo o sobě prohlašuje, že je Lego, s Merkurem bych svazek zcela jistě neschvaloval. Je třeba definovat jasná pravidla."
     },
     {
       "id": "senatni-2022-58-a-260752-17",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-260752-18",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-260752-19",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Je to cesta jak zajistit dostupné bydlení. Jen je třeba odstranit mýtus, že sociální byt j riziko. V takovém bytě může bydlet senior, stejně jako svobodná matka. A ti oba nejsou rizikem, naopak, zde obce musí sehrát zásadní roli.. Z bohaté zkušenosti vím, že to lze a je to velmi pozitivní krok."
     },
     {
       "id": "senatni-2022-58-a-260752-20",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Stát by měl daleko více přenést pravomoce na obce. Ony znají nejlépe situaci a své obyvatele."
     },
     {
       "id": "senatni-2022-58-a-260752-21",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "Je to běžný přístup v řadě zemí. Zvýší se tak i povědomí o regionech, že není jen Praha. Navíc řada úředníků do Prahy dojíždí z celé republiky "
     },
     {
       "id": "senatni-2022-58-a-260752-22",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "yes",
       "comment": "Výzkum obecně je cestou ke zvládnutí civilizačních změn ve spolenosti."
     },
     {
       "id": "senatni-2022-58-a-260752-23",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-260752-24",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "Zcela jistě. Bohužel zatím u nás nejsou dotaženy skutečně funkční modely a málo se pracuje se zahraničními modely"
     },
     {
       "id": "senatni-2022-58-a-260752-25",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes",
       "comment": "Separace dětí vede k dělení i v sociální a společenské oblasti. Za mne toto není žádoucí. Talent rozvíjet po patnáctém roce je dostačující. Navíc, ne každý, takto mlady, individuálně vzdělávaný talent situaci osobně zvládne."
     },
     {
       "id": "senatni-2022-58-a-260752-26",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "Ale nesmí se překlopit do zpomalování výuky většiny. Je třeba daleko lépe posuzovat skutečné možnosti integrace a inkluze."
     },
     {
       "id": "senatni-2022-58-a-260752-27",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no",
       "comment": "Právě dnešní doba ukazuje, jak je to důležité. \\hospodářsky i geopoliticky. A součástí CCCP fakt být po historických a osobních zkušenostech nechci."
     },
     {
       "id": "senatni-2022-58-a-260752-28",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "dont_know",
       "comment": "Jsem zastáncem Eura, ale vše musí být ve správnou chvíli. Ta teď ale za mne není."
     },
     {
       "id": "senatni-2022-58-a-260752-29",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no",
       "comment": "\nPrávě dnešní doba ukazuje, jak je to důležité. Hospodářsky i geopoliticky. Je to jedna z mála cest, jak se pokusit zabránit diktátorským režimům v expanzivní a agresivní politice. A součástí CCCP fakt být po historických a osobních zkušenostech nechci.\n"
     },
     {
       "id": "senatni-2022-58-a-260752-30",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-260752-31",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes",
       "comment": "Ano, ale obecně jsem názoru, že přístup České republiky je velmi příkladný."
     },
     {
       "id": "senatni-2022-58-a-260752-32",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes",
       "comment": "V opačném případě budeme čelit dalším sociálním, či válečným krizím v těchto oblastech a to je prostě špatně. Bohužel tato řešení zatím neumí vyspělé země uchopit skutečně globálně."
     },
     {
       "id": "senatni-2022-58-a-260752-33",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "yes",
       "comment": "Zejména u vybraných zemí je to i z hlediska pracovního trhu žádoucí."
     },
     {
       "id": "senatni-2022-58-a-260752-34",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-260752-35",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "ČR musí již z principu dodržovat závazky k mezinárodním organizacím, a to znamená i zvýšení výdajů na armádu."
     },
     {
       "id": "senatni-2022-58-a-260752-36",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-260752-37",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-260752-38",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes",
       "comment": "Co ale chybí je jasná definice a pravidla, jakou péči které zařízení poskytují. Zrovna Brno toho je s 5 nemocnicemi ve veřejných rukách a několika soukromými zařízeními, zářným případem. Drahý a ne plně funkční systém například v urgentních příjmech. Pacient nemůže jezdit a hledat umístění."
     },
     {
       "id": "senatni-2022-58-a-260752-39",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-58-a-260752-40",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-260752-41",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no",
       "comment": "Otázka bezpečnosti je mi bližší nad anonymitou. A pokud si někdo myslí, že je mimo to zcela anonymní, tak ať nám to napíše na své sociální sítě:-)"
     },
     {
       "id": "senatni-2022-58-a-260752-42",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes",
       "comment": "Ale ve správnou dobu. Po splnění požadavků, stejně jako tomu bylo např. u Chorvatska."
     },
     {
       "id": "senatni-2022-58-a-260752-43",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes",
       "comment": "Bohužel to je otázka vzdálenější budoucnosti. Lze ale začlenit Ukrajinu do spolupracujících zemí."
     },
     {
       "id": "senatni-2022-58-a-260752-44",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes",
       "comment": "K omezení příjmu Ruska na financování války. V energiích se ale musí učinit řada dalších opatření. Strop cen, ještě neznamená schopnost řady rodin platit zálohy na energie, které často nevychází z reálné ceny, která za rok bude, ale z \"předpokladů\". A těch energetičtí distributoři často zneužívají."
     },
     {
       "id": "senatni-2022-58-a-260752-45",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-260752-46",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes",
       "comment": "V plné míře sankcemi vůči Rusku a formou válečných reparací vůči Ukrajině po skončení války. "
     },
     {
       "id": "senatni-2022-58-a-260752-47",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no",
       "comment": "Pro mne nepřijatelné"
     },
     {
       "id": "senatni-2022-58-a-260752-48",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-260752-49",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "dont_know",
       "comment": "Momentální situace může leccos změnit. Obecně však co nejdříve, pokud to bude možné."
     },
     {
       "id": "senatni-2022-58-a-260752-50",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-260752-51",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no",
       "comment": "Celistvost států by neměla být měněna a již vůbec ne válečným způsobem"
     },
     {
       "id": "senatni-2022-58-a-260752-52",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-260752-53",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-58-a-260752-54",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes",
       "comment": "Podpora lokálních producentů je potřebná. Bohužel ceny netvoří výrobci, ale řetězce a ty své pozice zásadním způsobem zneužívají."
     },
     {
       "id": "senatni-2022-58-a-260752-55",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-260752-56",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no",
       "comment": "Toto je věcí místních samospráv. Stát je daleko a vedlo by to k nekoncepčnímu a mnohdy korupčnímu prostředí."
     },
     {
       "id": "senatni-2022-58-a-260752-57",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-58-a-260752-58",
       "candidate_id": "senatni-2022-58-c-260752",
-      "question_id": "senatni-2022-58-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Je však třeba definovat, kdy, jak a za jakých podmínek,"
     }

--- a/data/kalkulacka/senatni-2022/61.json
+++ b/data/kalkulacka/senatni-2022/61.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-61-c-131643",
       "name": "Ctirad Musil",
       "type": "person",
-      "description": "Ctirad Musil - DESCRIPTION",
+      "description": "Ctirad Musil",
       "contacts": {
         "web": [
           {
@@ -500,7 +500,7 @@
         {
           "id": "senatni-2022-61-c-131643-p",
           "name": "Ctirad Musil",
-          "description": "Ctirad Musil - DESCRIPTION",
+          "description": "Ctirad Musil",
           "contacts": {
             "web": [
               {
@@ -522,7 +522,7 @@
       "id": "senatni-2022-61-c-504062",
       "name": "Petr Vrána",
       "type": "person",
-      "description": "Petr Vrána - DESCRIPTION",
+      "description": "Petr Vrána",
       "contacts": {
         "web": []
       },
@@ -530,7 +530,7 @@
         {
           "id": "senatni-2022-61-c-504062-p",
           "name": "Petr Vrána",
-          "description": "Petr Vrána - DESCRIPTION",
+          "description": "Petr Vrána",
           "contacts": {
             "web": []
           },
@@ -542,7 +542,7 @@
       "id": "senatni-2022-61-c-330603",
       "name": "Michal Malacka",
       "type": "person",
-      "description": "Michal Malacka - DESCRIPTION",
+      "description": "Michal Malacka",
       "contacts": {
         "web": [
           {
@@ -568,7 +568,7 @@
         {
           "id": "senatni-2022-61-c-330603-p",
           "name": "Michal Malacka",
-          "description": "Michal Malacka - DESCRIPTION",
+          "description": "Michal Malacka",
           "contacts": {
             "web": [
               {
@@ -598,7 +598,7 @@
       "id": "senatni-2022-61-c-290618",
       "name": "Milan Brázdil",
       "type": "person",
-      "description": "Milan Brázdil - DESCRIPTION",
+      "description": "Milan Brázdil",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/milanbrazdil2022",
@@ -608,7 +608,7 @@
         {
           "id": "senatni-2022-61-c-290618-p",
           "name": "Milan Brázdil",
-          "description": "Milan Brázdil - DESCRIPTION",
+          "description": "Milan Brázdil",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/milanbrazdil2022",
@@ -622,7 +622,7 @@
       "id": "senatni-2022-61-c-836627",
       "name": "Lumír Kantor",
       "type": "person",
-      "description": "Lumír Kantor - DESCRIPTION",
+      "description": "Lumír Kantor",
       "contacts": {
         "web": [
           {
@@ -645,7 +645,7 @@
         {
           "id": "senatni-2022-61-c-836627-p",
           "name": "Lumír Kantor",
-          "description": "Lumír Kantor - DESCRIPTION",
+          "description": "Lumír Kantor",
           "contacts": {
             "web": [
               {
@@ -672,7 +672,7 @@
       "id": "senatni-2022-61-c-146752",
       "name": "Václav Ranc",
       "type": "person",
-      "description": "Václav Ranc - DESCRIPTION",
+      "description": "Václav Ranc",
       "contacts": {
         "web": [
           {
@@ -690,7 +690,7 @@
         {
           "id": "senatni-2022-61-c-146752-p",
           "name": "Václav Ranc",
-          "description": "Václav Ranc - DESCRIPTION",
+          "description": "Václav Ranc",
           "contacts": {
             "web": [
               {
@@ -712,7 +712,7 @@
       "id": "senatni-2022-61-c-405277",
       "name": "Čestmír Neoral",
       "type": "person",
-      "description": "Čestmír Neoral - DESCRIPTION",
+      "description": "Čestmír Neoral",
       "contacts": {
         "web": [
           {
@@ -731,7 +731,7 @@
         {
           "id": "senatni-2022-61-c-405277-p",
           "name": "Čestmír Neoral",
-          "description": "Čestmír Neoral - DESCRIPTION",
+          "description": "Čestmír Neoral",
           "contacts": {
             "web": [
               {
@@ -754,7 +754,7 @@
       "id": "senatni-2022-61-c-202876",
       "name": "Zuzana Majerová",
       "type": "person",
-      "description": "Zuzana Majerová - DESCRIPTION",
+      "description": "Zuzana Majerová",
       "contacts": {
         "web": [
           {
@@ -778,7 +778,7 @@
         {
           "id": "senatni-2022-61-c-202876-p",
           "name": "Zuzana Majerová",
-          "description": "Zuzana Majerová - DESCRIPTION",
+          "description": "Zuzana Majerová",
           "contacts": {
             "web": [
               {
@@ -807,1491 +807,1491 @@
     {
       "id": "senatni-2022-61-a-146752-1",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-146752-2",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Tržní nájemné by státem být regulováno nemělo. Pokud budou obce disponovat bytovým fondem, pak bude na nich, jak si výši nájemného stanoví. Proto je důležité, aby byl obecní bytový fond dostatečný."
     },
     {
       "id": "senatni-2022-61-a-146752-3",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Piráti podporují uzákonění celostátního referenda od svého počátku"
     },
     {
       "id": "senatni-2022-61-a-146752-4",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-146752-5",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Je zásadnější  adekvátně odměňovat ty, co se dobrovolně rozhodnou do důchodu neodcházet, protože to je výhodné jak pro stát, tak i pro seniory."
     },
     {
       "id": "senatni-2022-61-a-146752-6",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "Vodu je potřeba zadržovat především v samotné půdě a přirozeně v krajině. Výstavbu megalomanských přehrad tedy nepodporuji."
     },
     {
       "id": "senatni-2022-61-a-146752-7",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no",
       "comment": "Zálohování PET láhví je dobrovolně na výrobci, což považuji za správné."
     },
     {
       "id": "senatni-2022-61-a-146752-8",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes",
       "comment": "Progrese by však nejprve měla být vytvořena snížením daňové zátěže nízkopříjmových obyvatel. Další danění lidí s vyššími příjmy je na další debatu."
     },
     {
       "id": "senatni-2022-61-a-146752-9",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-146752-10",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Problém v tuto chvíli není v přímo v rozsahu trestů vymezených zákonem, ale obecně v praxi, kdy jsou v rámci trestních řízení udělovány nízké tresty. Za důležitou též považuji nápravu definice znásilnění tak, aby zahrnovala i situace, kdy oběť nedokáže projevit odpor, nebo zažívá paralýzu."
     },
     {
       "id": "senatni-2022-61-a-146752-11",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Dlouhodobě podporuji zavedení globální minimální daně na úrovni EU."
     },
     {
       "id": "senatni-2022-61-a-146752-12",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Zavedení této povinnosti by vedlo k omezení svobody slova a k právním nejistotám. Nicméně sítě mají již nyní povinnost nezákonný obsah na podnět soudu odstraňovat."
     },
     {
       "id": "senatni-2022-61-a-146752-13",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-146752-14",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Další snížení financování veřejnoprávního vysílání není dle mého názoru správnou cestou."
     },
     {
       "id": "senatni-2022-61-a-146752-15",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no",
       "comment": "Problém nevidím v působnosti, jako takové, ale spíše v kontrole jejich činností."
     },
     {
       "id": "senatni-2022-61-a-146752-16",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes",
       "comment": "Rovné manželství pomůže tisícům párů a jejich dětem, neohrozí nikoho"
     },
     {
       "id": "senatni-2022-61-a-146752-17",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-146752-18",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-146752-19",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "Sociální bydlení by mělo být svázáno s potřebou v konkrétní lokalitě a rozhodovat o něm by tedy měly jednotlivé obce."
     },
     {
       "id": "senatni-2022-61-a-146752-20",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-146752-21",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know",
       "comment": "Je stále diskutabilní, jestli by decentralizace měla na regiony efekt. Z dostupných dat to není zcela jasné."
     },
     {
       "id": "senatni-2022-61-a-146752-22",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "yes",
       "comment": "Nicméně prioritou by měl být nejprve měsíc. "
     },
     {
       "id": "senatni-2022-61-a-146752-23",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Zásadní je však realizace a technické provedení, které musí být jednoduché a zcela spolehlivé."
     },
     {
       "id": "senatni-2022-61-a-146752-24",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no",
       "comment": "Nejsem pro, aby stát silově určoval prioritu jednotlivých oborů. Vyšší potřeba technických oborů by však měla být lépe propagována."
     },
     {
       "id": "senatni-2022-61-a-146752-25",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes",
       "comment": "Jsem pro individualizaci talentovaných dětí, pokud o to projeví zájem. Ale ne v současném systému, který nahrává spíše dětem z rodin s lepším ekonomickým zázemím. "
     },
     {
       "id": "senatni-2022-61-a-146752-26",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "dont_know",
       "comment": "Obecně ano, ale je potřeba současný systém redefinovat a opravit jeho nedostatky. "
     },
     {
       "id": "senatni-2022-61-a-146752-27",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-146752-28",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-146752-29",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-146752-30",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-146752-31",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-146752-32",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes",
       "comment": "Určitě ano."
     },
     {
       "id": "senatni-2022-61-a-146752-33",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "yes",
       "comment": "Žádost o azyl musí být zefektivněna tak, abychom byli schopni vyřídit větší množství žádostí o azyl bez vyvolání humanitární krize."
     },
     {
       "id": "senatni-2022-61-a-146752-34",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-146752-35",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "V případě navyšování výdajů na obranu je potřeba postupovat dle racionálních kapacit s cílem zajistit co nejvyšší efektivitu vynaložených prostředků."
     },
     {
       "id": "senatni-2022-61-a-146752-36",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Tohle zcela odmítám. Výběr pohlaví dítěte je za hranicí toho, co by měl člověk ovlivňovat."
     },
     {
       "id": "senatni-2022-61-a-146752-37",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes",
       "comment": "Podporuji možnost soukromého pojištění, kde si každý bude moct vybrat produkt dle svých zájmů."
     },
     {
       "id": "senatni-2022-61-a-146752-38",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes",
       "comment": "Podporuji centralizaci, která by mohla vést k vyšší úspěšnosti léčby a zároveň k vyšší efektivitě zdravotní péče."
     },
     {
       "id": "senatni-2022-61-a-146752-39",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes",
       "comment": "Existují i jiné prostředky, které nedevastují půdu a nejsou toxické."
     },
     {
       "id": "senatni-2022-61-a-146752-40",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-146752-41",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes",
       "comment": "S používáním hromadného biometrického sledování jsou spojena jednoznačná rizika v podobě zvýšené mocenské nerovnováhy, diskriminace, rasismu, nerovností a autoritářské společenské kontroly."
     },
     {
       "id": "senatni-2022-61-a-146752-42",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes",
       "comment": "Vstup Ukrajiny do EU podpořím hned, jakmile bude plnit podmínky vstupu, tzv. Kodaňská kritéria."
     },
     {
       "id": "senatni-2022-61-a-146752-43",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-146752-44",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-146752-45",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no",
       "comment": "Ombudsman má především chránit lidská práva bez rozdílů, což bohužel dlouhodobě nečiní. "
     },
     {
       "id": "senatni-2022-61-a-146752-46",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-146752-47",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no",
       "comment": "Podmínky ústupu Ruska z Ukrajiny, vč. Krymu, by měla vyjednávat především ukrajinská strana."
     },
     {
       "id": "senatni-2022-61-a-146752-48",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Istanbulská úmluva od jednotlivých států vyžaduje silnější ochranu obětí a efektivní stíhání pachatelů. Přijetím úmluvy symbolizujeme a zároveň se i zavazujeme k potírání těchto forem násilí."
     },
     {
       "id": "senatni-2022-61-a-146752-49",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "yes",
       "comment": "Zároveň je však potřeba zásadně investovat do obnovitelných zdrojů energie."
     },
     {
       "id": "senatni-2022-61-a-146752-50",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-146752-51",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-146752-52",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-146752-53",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-146752-54",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "dont_know",
       "comment": "Prosazuji princip “veřejné peníze za veřejné statky”. Platby, které zemědělci v rámci dotací dostávají, by měly kompenzovat zvýšené úsilí, které investují do aktivit výrazně nad rámec zákona. Typicky jde o péči o životní prostředí a lepší podmínky pro zvířata."
     },
     {
       "id": "senatni-2022-61-a-146752-55",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-146752-56",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no",
       "comment": "Obce mají ten nejlepší předpoklad k tomu tuto situaci zvládnou. Obce znají potřeby obyvatel a výstavba městských bytů by tedy měla být v jejich režii. Stát by měl zajistit funkční legislativní rámec, případně metodickou podporu a pomoc k zajištění efektivního fungování trhu s bydlením."
     },
     {
       "id": "senatni-2022-61-a-146752-57",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-146752-58",
       "candidate_id": "senatni-2022-61-c-146752",
-      "question_id": "senatni-2022-61-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "dont_know",
       "comment": "Nejprve by měl existovat funkční právní rámec, který zajistí, že možnost zastavení exekuce nepovede ke zneužívání."
     },
     {
       "id": "senatni-2022-61-a-330603-1",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Není definována dlouhodobost, může se jednat o dlouhodobý pracovní pobyt v zahraničí apod. Jiný režim by měl být zaveden k vlastníkům nemovitostí, kteří si je drží s ohledem na jejich investiční záměr a nepronajímají je. Ale i zde je nutno definovat pojem dlouhodobosti. "
     },
     {
       "id": "senatni-2022-61-a-330603-2",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Lepší je cílená výstavba nízkometrážních sociálních nájemních bytů prostřednictvím obcí a obdobně družstevního bydlení."
     },
     {
       "id": "senatni-2022-61-a-330603-3",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-330603-4",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "dont_know",
       "comment": "Za předpokladu, že se bude jednat o hlavní komunikační tratě spojené se strategií udržitelnosti ČR, tak ano. "
     },
     {
       "id": "senatni-2022-61-a-330603-5",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Stát by měl účinnými nástroji podporovat růst demografické křivky a zabezpečovat udržitelný trend v rámci produktivní populace. "
     },
     {
       "id": "senatni-2022-61-a-330603-6",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes",
       "comment": "Předložené materiály týkající se systémových opatření vláda ČR již 10 let nevykonávala  opatření proti suchu. Nejedná se jen o přehrady, ale o systém zavlažovacích kanálů a běžně dostupných standardních opatření proti vysychání vody v krajině. ČR je územím, ze kterého se voda odtéká, takže tato otázka a opatření s ní spojené jsou pro naši krajinu velmi důležité. "
     },
     {
       "id": "senatni-2022-61-a-330603-7",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-330603-8",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Český daňový systém je nastaven poměrně úspěšně, což není případ daní z nemovitosti a systému soc. zabezpečení. "
     },
     {
       "id": "senatni-2022-61-a-330603-9",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-330603-10",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "dont_know",
       "comment": "Je nutno upravit otázku souhlasu či nesouhlasu s pohlavním stykem. Lze uvažovat o zvýšení dolní hranice trestní sazby. "
     },
     {
       "id": "senatni-2022-61-a-330603-11",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Daňový systém je jedním z nejdůležitějších příjmů státu. Tyto společnosti na našem území dosahují svou činností nezanedbatelných zisků, což je nutno zohlednit. "
     },
     {
       "id": "senatni-2022-61-a-330603-12",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-330603-13",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes",
       "comment": "V současnosti je vedena informační válka, je nutno jí zamezit. "
     },
     {
       "id": "senatni-2022-61-a-330603-14",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-330603-15",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-330603-16",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know",
       "comment": "Jsem pro zrovnoprávnění instituce manželství v otázce majetkových a jiných práv, ale s ohledem na institut církevního sňatku, kde pravděpodobně nikdy nedojde k prosazení této myšlenky, je problematické garantovat tuto možnost.  "
     },
     {
       "id": "senatni-2022-61-a-330603-17",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-330603-18",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-330603-19",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Je to nástroj, který podporuji místo regulaci nájmů. "
     },
     {
       "id": "senatni-2022-61-a-330603-20",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Stát musí přesně specifikovat osoby, které v této nouzi jsou. Zákon musí přesně definovat okruh těchto oprávněných osob. "
     },
     {
       "id": "senatni-2022-61-a-330603-21",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "Tuto problematiku bych spojil s revizí reformy organizace krajů v ČR. "
     },
     {
       "id": "senatni-2022-61-a-330603-22",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no",
       "comment": "Nejdřív musíme zajistit, aby fungovala Česká republika. "
     },
     {
       "id": "senatni-2022-61-a-330603-23",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Toto opatření je nutno spojit s adekvátním zabezpečením a zašifrováním jednotlivých hlasů tak, aby nedocházelo k falšování volebních výsledků a aby byla zajištěna ochrana jednotlivých voličů. Tento nástroj je potřebný nejen z hlediska posílení demokracie, ale i s ohledem na řešení pandemických situací a obdobných krizí. "
     },
     {
       "id": "senatni-2022-61-a-330603-24",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "Byť tato problematika souvisí s činností krajů, musí jít krajská aktivita ruku v ruce s politikou státu. "
     },
     {
       "id": "senatni-2022-61-a-330603-25",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-330603-26",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "Asistenti a asistentky mají pomáhat slabším, ale výborné a talentované děti nesmí být ve svém růstu omezovány, právě naopak. "
     },
     {
       "id": "senatni-2022-61-a-330603-27",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no",
       "comment": "Přes některé výhrady je členství v EU pro ČR nevyhnutelné. "
     },
     {
       "id": "senatni-2022-61-a-330603-28",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "Po náležitém přípravném procesu a přechodném období. Česká republika se k přijetí eura zavázala již v minulosti. Tento postup je nutné realizovat plánovaně. Ale toto téma nelze upřednostňovat před řešením jiných aktuálních palčivých problémů.  "
     },
     {
       "id": "senatni-2022-61-a-330603-29",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no",
       "comment": "V současné bezpečnostní krizi by se jednalo o šílenství. "
     },
     {
       "id": "senatni-2022-61-a-330603-30",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes",
       "comment": "Pokud v EU, tak v jejím jádru. Dvourychlostní EU nemá význam. "
     },
     {
       "id": "senatni-2022-61-a-330603-31",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-330603-32",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-330603-33",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Usnadnit v případě uprchlické krize v rámci Ukrajiny jako krátkodobý nástroj, ale jinak musíme zachovávat bezpečnostní kritéria a dbát na ochranu zájmů občanů ČR a jejich bezpečí. "
     },
     {
       "id": "senatni-2022-61-a-330603-34",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-330603-35",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "Lze spojit s přínosem armády pro státní správu, bojem proti živelným pohromám, pandemickým situacím atp. "
     },
     {
       "id": "senatni-2022-61-a-330603-36",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "yes",
       "comment": "Při současné krizi demografické křivky je nutno podpořit konstruktivním způsobem nástroje, které ji můžou změnit. "
     },
     {
       "id": "senatni-2022-61-a-330603-37",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes",
       "comment": "Zdravý životní styl by měl být benefitem při stanovení výše povinného zdravotního pojištění a naopak při nezdravém zdravotním stylu a sebedestruktivním chování by mělo být přistoupeno k vyššímu zdravotnímu pojištění. "
     },
     {
       "id": "senatni-2022-61-a-330603-38",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-330603-39",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-330603-40",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Jedná se mj. o významný příjem obcí. Je potřeba dbát na bezpečnostní a preventivní dopad. "
     },
     {
       "id": "senatni-2022-61-a-330603-41",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no",
       "comment": "Ne, dokud jsou potřebné tyto nástroje v boji proti terorismu. "
     },
     {
       "id": "senatni-2022-61-a-330603-42",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes",
       "comment": "Jakmile splní všechna ekonomická a právní kritéria. Ne jako politický benefit - s ohledem na to, že je napadna nelze ustoupit těmto kritériím. "
     },
     {
       "id": "senatni-2022-61-a-330603-43",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes",
       "comment": "Jiný než bezpečnostní obranný systém není zárukou obrany proti agresivitě Ruska. "
     },
     {
       "id": "senatni-2022-61-a-330603-44",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes",
       "comment": "Jedná se o opatření řešení energetické krize. Zároveň iniciaci nutnosti systému dodávek z jiných států. Zastropováním také zajistíme, že agresor nebude mít dostatek finančních prostředků k vedení války. "
     },
     {
       "id": "senatni-2022-61-a-330603-45",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-330603-46",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes",
       "comment": "Jako každá jiná země, která se dopustí takového jednání, které odporuje mezinárodnímu právu. "
     },
     {
       "id": "senatni-2022-61-a-330603-47",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "dont_know",
       "comment": "Je rozdíl mezi vyjednáváním o zrušení anexe Krymu a navazováním standardních diplomatických vztahů."
     },
     {
       "id": "senatni-2022-61-a-330603-48",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Boj proti domácímu násilí je podceňovaným, ale nesmírně důležitým tématem. "
     },
     {
       "id": "senatni-2022-61-a-330603-49",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Fosilní paliva je přechodně nutno využít k řešení energetické krize. "
     },
     {
       "id": "senatni-2022-61-a-330603-50",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-330603-51",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no",
       "comment": "Tento akt agrese není možno uznat, výjimečně se ztotožňuji s tureckým prezidentem Erdoganem. "
     },
     {
       "id": "senatni-2022-61-a-330603-52",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no",
       "comment": "Systém individuálního postupu a zabezpečení finančních zdrojů pro vedení války pro Rusko se jeví z dlouhodobého hlediska jako velmi rizikový. Přistoupit k tomuto kroku lze až jako k poslední možnosti. "
     },
     {
       "id": "senatni-2022-61-a-330603-53",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes",
       "comment": "Jedná se o posílení evropské bezpečnostní platformy. "
     },
     {
       "id": "senatni-2022-61-a-330603-54",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-330603-55",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-330603-56",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes",
       "comment": "Je to jedno z řešení, jak vytvořit systém záchytného a sociálního bydlení. "
     },
     {
       "id": "senatni-2022-61-a-330603-57",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no",
       "comment": "Historie se opakuje, nezapomínejme na Protektorát Čechy a Morava. "
     },
     {
       "id": "senatni-2022-61-a-330603-58",
       "candidate_id": "senatni-2022-61-c-330603",
-      "question_id": "senatni-2022-61-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Souvisí s racionálním systémem oddlužení. "
     },
     {
       "id": "senatni-2022-61-a-836627-1",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-2",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-836627-3",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-4",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-5",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-6",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-7",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-8",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-9",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-836627-10",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-11",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-12",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-13",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-836627-14",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-15",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-836627-16",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-836627-17",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-18",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-836627-19",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-20",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-21",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-836627-22",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-836627-23",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-24",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-25",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-26",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-27",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-28",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-29",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-30",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-31",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-32",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-33",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-836627-34",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-35",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-36",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-37",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-38",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know",
       "comment": "Jak v kterém medicinském oboru..."
     },
     {
       "id": "senatni-2022-61-a-836627-39",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-40",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-41",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-836627-42",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-43",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-44",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-45",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-46",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-47",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-48",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-836627-49",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-50",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-51",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-52",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-53",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-54",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-55",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-836627-56",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-836627-57",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-836627-58",
       "candidate_id": "senatni-2022-61-c-836627",
-      "question_id": "senatni-2022-61-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-1",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "V ČR musí vznikat minimálně 30 tisíc nových bytů ročně. Vše ostatní je populismus a vede k dalšímu navyšování cen, nebo dokonce kriminalizaci bytového hospodářství a trhu s byty."
     },
     {
       "id": "senatni-2022-61-a-131643-2",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Bez výstavby nových bytů je nesmysl regulovat ceny toho, co tu zbylo po komunistech. Taky můžeme dojít do stadia, kdy budeme pro 10 milionů lidí regulovat cenu posledních pěti bytů. "
     },
     {
       "id": "senatni-2022-61-a-131643-3",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Povinnost mocenských složek jednat na základě přání lidu je základní předpoklad demokracie. Bylo by vhodné po století slibů už tu demokracii zavést."
     },
     {
       "id": "senatni-2022-61-a-131643-4",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Rychlovlaky jsou dobré, ale určitě bych kvůli nim neupozadil vše ostatní."
     },
     {
       "id": "senatni-2022-61-a-131643-5",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-131643-6",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-7",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no",
       "comment": "Už to tu bylo a nefungovalo to."
     },
     {
       "id": "senatni-2022-61-a-131643-8",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-9",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-10",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "no",
       "comment": "V ČR řádově převyšují falešná obvinění ze znásilnění skutečné znásilnění. Navyšování trestů za znásilnění povede k plnění vězení nevinnými oběťmi křivých obvinění. Obvinění ze znásilnění je hojně využívaný nástroj k vydírání. "
     },
     {
       "id": "senatni-2022-61-a-131643-11",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-12",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Pokud budou mít sociální sítě zodpovědnost za obsah svých profilů, tak budou mazat cokoliv je napadne a to je princip cenzury. Lidé by neměli žít ve skleníku a i nehezká témata patří k životu. Za přístup k špatnostem na webu u dětí mají zodpovídat rodiče a ne státní cenzor."
     },
     {
       "id": "senatni-2022-61-a-131643-13",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-131643-14",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Problém není ve financích pro televizi, ale v její manipulaci s lidmi a neobjektivním zpravodajství a publicistice. To není otázka peněz."
     },
     {
       "id": "senatni-2022-61-a-131643-15",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes",
       "comment": "Pracovní agentury se změnily na trh s otroky. Nepodporovat je!"
     },
     {
       "id": "senatni-2022-61-a-131643-16",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "V době, kdy otcové nemají právo na své dítě a děti nemají právo na otce, je starost o stejnopohlavní páry trapná. "
     },
     {
       "id": "senatni-2022-61-a-131643-17",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-18",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-19",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-131643-20",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-131643-21",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-22",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-23",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Volba po internetu nezaručuje tajnou volbu, protože většina lidí bude mít v době volby někoho za zády, třeba svoje rodiče, nebo děti. Navíc elektronické sčítání umožňuje falšování aniž by to hlasující mohl zkontrolovat. Argument o ušetření financí a jednoduchosti provedení je sice pravdivý, ale kvůli úspoře peněz vzniknou nesvobodné volby. To za peníze nestojí."
     },
     {
       "id": "senatni-2022-61-a-131643-24",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-25",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-131643-26",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no",
       "comment": "Společnost zoufale potřebuje tahouny a talenty. Zničit jejich rozvoj pod záminkou soucitu s netalentovanými dětmi je likvidace celé společnosti. Ti méně nadaní totiž budou v životě potřebovat produkci z práce těch talentovaných a pokud je budou brzdit už od dětství, tak nedostanou nic."
     },
     {
       "id": "senatni-2022-61-a-131643-27",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-28",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-131643-29",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-30",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-131643-31",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-61-a-131643-32",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-131643-33",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-131643-34",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-35",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-131643-36",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-131643-37",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-38",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no",
       "comment": "Specializovaná péče v ČR je už centralizovaná příliš."
     },
     {
       "id": "senatni-2022-61-a-131643-39",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "no",
       "comment": "Zákaz ne, ale řízení jeho použití ano."
     },
     {
       "id": "senatni-2022-61-a-131643-40",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Úplné zrušení měření rychlosti není vhodné, ale mělo by se zrušit zneužívání měření  rychlosti k těžbě peněz. Řada měst si z toho udělala zlatý důl a měří před výjezdy z města, nebo postaví značku omezení rychlosti a měří rychlost u ní. Toto by mělo být zrušeno."
     },
     {
       "id": "senatni-2022-61-a-131643-41",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-42",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no",
       "comment": "Válka na Ukrajině začala Euromajdanem, což byl konflikt mezi zastánci vstupu do EU a jejími odpůrci. Ukrajina, kde kvůli otázce vstupu do EU vznikla válka, není způsobilá vstupu do EU, protože tam zavleče své problémy včetně války samotné."
     },
     {
       "id": "senatni-2022-61-a-131643-43",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "Přijetí nacistického státu do tak agresivního spolku jako je NATO by bylo velmi symbolické, ale ne."
     },
     {
       "id": "senatni-2022-61-a-131643-44",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "Jak může EU zastropovat cenu ruského plynu?"
     },
     {
       "id": "senatni-2022-61-a-131643-45",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-131643-46",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "no",
       "comment": "Na rozpoutání války na Ukrajině pracovala mimo jiné i ČR už mnoho let. Kolik občanů je ochotno nést následky toho, že ČR podporovala desetiletí nacismus na Ukrajině? "
     },
     {
       "id": "senatni-2022-61-a-131643-47",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-48",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "no",
       "comment": "Problém je především s falešnými obviněními a vydíráním falešně obviněných mužů. Už jen diskuse na toto téma je kriminalizována, což naznačuje, že otázka domácího násilí je velmi podobná středověkému honu na čarodějnice."
     },
     {
       "id": "senatni-2022-61-a-131643-49",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-131643-50",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-131643-51",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-52",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-53",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "no"
     },
     {
       "id": "senatni-2022-61-a-131643-54",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-55",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "A mají mít místní úřady zákonnou povinnost poskytovat toaletní papír bezplatně každému, kdo je potřebuje? A proč vložky ano a toaletní papír ne?"
     },
     {
       "id": "senatni-2022-61-a-131643-56",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-61-a-131643-57",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "yes",
       "comment": "Otázka reálně stojí jinak, protože Rusko nevtrhlo na Ukrajinu kvůli rozšiřování území, ale kvůli ohrožení, které mu z území Ukrajiny hrozilo od NATO. To s odevzdáním jakéhokoliv území Ukrajiny Rusku nesouvisí."
     },
     {
       "id": "senatni-2022-61-a-131643-58",
       "candidate_id": "senatni-2022-61-c-131643",
-      "question_id": "senatni-2022-61-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "dont_know"
     }
   ]

--- a/data/kalkulacka/senatni-2022/64.json
+++ b/data/kalkulacka/senatni-2022/64.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-64-c-337974",
       "name": "Ladislav Šupina",
       "type": "person",
-      "description": "Ladislav Šupina - DESCRIPTION",
+      "description": "Ladislav Šupina",
       "contacts": {
         "web": [
           {
@@ -496,7 +496,7 @@
         {
           "id": "senatni-2022-64-c-337974-p",
           "name": "Ladislav Šupina",
-          "description": "Ladislav Šupina - DESCRIPTION",
+          "description": "Ladislav Šupina",
           "contacts": {
             "web": [
               {
@@ -514,7 +514,7 @@
       "id": "senatni-2022-64-c-188030",
       "name": "Pavla Löwenthalová",
       "type": "person",
-      "description": "Pavla Löwenthalová - DESCRIPTION",
+      "description": "Pavla Löwenthalová",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/PavlaLowenthalovaKandidat64"
@@ -523,7 +523,7 @@
         {
           "id": "senatni-2022-64-c-188030-p",
           "name": "Pavla Löwenthalová",
-          "description": "Pavla Löwenthalová - DESCRIPTION",
+          "description": "Pavla Löwenthalová",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/PavlaLowenthalovaKandidat64"
@@ -536,7 +536,7 @@
       "id": "senatni-2022-64-c-419952",
       "name": "Luděk Šarman",
       "type": "person",
-      "description": "Luděk Šarman - DESCRIPTION",
+      "description": "Luděk Šarman",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/ludek.sarman.7"
@@ -545,7 +545,7 @@
         {
           "id": "senatni-2022-64-c-419952-p",
           "name": "Luděk Šarman",
-          "description": "Luděk Šarman - DESCRIPTION",
+          "description": "Luděk Šarman",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/ludek.sarman.7"
@@ -558,7 +558,7 @@
       "id": "senatni-2022-64-c-542456",
       "name": "Miroslava Hustáková",
       "type": "person",
-      "description": "Miroslava Hustáková - DESCRIPTION",
+      "description": "Miroslava Hustáková",
       "contacts": {
         "web": [
           {
@@ -572,7 +572,7 @@
         {
           "id": "senatni-2022-64-c-542456-p",
           "name": "Miroslava Hustáková",
-          "description": "Miroslava Hustáková - DESCRIPTION",
+          "description": "Miroslava Hustáková",
           "contacts": {
             "web": [
               {
@@ -590,7 +590,7 @@
       "id": "senatni-2022-64-c-298500",
       "name": "Ladislav Václavec",
       "type": "person",
-      "description": "Ladislav Václavec - DESCRIPTION",
+      "description": "Ladislav Václavec",
       "contacts": {
         "web": [
           {
@@ -608,7 +608,7 @@
         {
           "id": "senatni-2022-64-c-298500-p",
           "name": "Ladislav Václavec",
-          "description": "Ladislav Václavec - DESCRIPTION",
+          "description": "Ladislav Václavec",
           "contacts": {
             "web": [
               {
@@ -630,7 +630,7 @@
       "id": "senatni-2022-64-c-419215",
       "name": "Antonín Staněk",
       "type": "person",
-      "description": "Antonín Staněk - DESCRIPTION",
+      "description": "Antonín Staněk",
       "contacts": {
         "web": [
           {
@@ -648,7 +648,7 @@
         {
           "id": "senatni-2022-64-c-419215-p",
           "name": "Antonín Staněk",
-          "description": "Antonín Staněk - DESCRIPTION",
+          "description": "Antonín Staněk",
           "contacts": {
             "web": [
               {
@@ -671,1094 +671,1094 @@
     {
       "id": "senatni-2022-64-a-419215-1",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes",
       "comment": "Nicméně je třeba upozornit i na fakt, že zdánlivě bohulibý záměr bude dál komplikovat český daňový systém a také na problematickou kontrolu obsazenosti bytů"
     },
     {
       "id": "senatni-2022-64-a-419215-2",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-3",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-4",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-5",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-6",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-7",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no",
       "comment": "Souhlasím s názorem, že v současnosti občané ČR velmi zodpovědně třídí odpad a případné zálohování PET lahví nevyřeší situaci, kdy nedochází k recyklaci, ale plasty jsou spalovány. Je třeba zajistit dohled nad recyklací separovaného plastového odpadu, případně vybudovat ekologické provozy na jeho zpracování a tak vytvořit nová pracovní místa například v regionech jako je právě můj volební obvod č. 64 Bruntálsko."
     },
     {
       "id": "senatni-2022-64-a-419215-8",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-9",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-10",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-11",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-12",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-13",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-14",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-15",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-16",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes",
       "comment": "Stejnopohlavní páry vstupující do registrovaného partnerství by měly mít stejná práva a povinnosti jako páry vstupující do manželství. Nicméně pokud jde o pojmenování takového soužití jsem konzervativní a považuji rozdílné označení takového soužití za správné. Termín manželství by měl zůstat vyhrazen pro svazek muže a ženy, termín registrované partnerství nechť pojmenovává svazek stejnopohlavních párů."
     },
     {
       "id": "senatni-2022-64-a-419215-17",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-18",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-19",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-20",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-21",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-22",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-23",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Rozhodně nejsem zastáncem volby online po internetu neboť tato forma negarantuje přímou volbu (tj. volbu bez zprostředkovatele), nezajišťuje tajnost volby, nezajišťuje ani to, že volba bude osobní a nebude případně možné spojit voliče s jím odevzdaným hlasem."
     },
     {
       "id": "senatni-2022-64-a-419215-24",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-25",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-26",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no",
       "comment": "Doposud neexistují relevantní studie, které by potvrzovaly nebo vyvracely domněnku, že čím více inkluzivní školství bude, tím více to bude pomáhat slabším žáků zapojit se do kolektivu a motivovat je k učení. Osobně se domnívám, že aktuální pojetí inkluzivního školství je spíše kontraproduktivní a demotivující jak pro slabé žáky tak i pro průměrné a nadané žáky. "
     },
     {
       "id": "senatni-2022-64-a-419215-27",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no",
       "comment": "Otázka vystoupení ČR z EU není na místě, nicméně sama EU a její nadnárodní orgány by měly více respektovat své vlastní motto \"Jednotná v rozmanitosti\" a tak respektovat odlišnosti jednotlivých členských států. Bez toho respektu k rozmanitosti bude EU jen novým žalářem národů.  "
     },
     {
       "id": "senatni-2022-64-a-419215-28",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-29",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-30",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-31",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "Jsem přesvědčen, že ČR má podporovat zahraniční rozvojovou spolupráci a humanitární pomoc v takovém rozsahu a výši, která odpovídá jejím možnostem po té, co zabezpečí nezbytné potřeby svých občanů."
     },
     {
       "id": "senatni-2022-64-a-419215-32",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no",
       "comment": "Na tuto otázku neumím jednoznačně odpovědět, neboť ne vždy je možné zajistit nezbytné potřeby občanů ČR a současně brát ohled na rozvojové země."
     },
     {
       "id": "senatni-2022-64-a-419215-33",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Současné azylové zákony jsou dostačující a není potřeba je více liberalizovat."
     },
     {
       "id": "senatni-2022-64-a-419215-34",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-35",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "Ani na tuto otázku není jednoznačná odpověď. Resort obrany je na jedné straně dlouhodobě podfinancovaný a zastaralá technika ohrožuje zejména zdraví a životy našich vojáků.  I proto by měla mít armáda dostatečné finanční prostředky na svou modernizaci. Je však také pravdou, že značné prostředky jsou vynakládány nesystémově a tudíž i nehospodárně, a to je třeba změnit. "
     },
     {
       "id": "senatni-2022-64-a-419215-36",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-37",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-38",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes",
       "comment": "Opět - pokud jde o centralizaci specializované lékařské péče, pak je zřejmě na místě tam, kde jde o mimořádně nákladnou nebo velmi individuální specifickou léčbu - tedy je potřeba v takovém případě jasně vymezit co je touto specializovanou léčbou myšleno. "
     },
     {
       "id": "senatni-2022-64-a-419215-39",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-40",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-41",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-42",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes",
       "comment": "Podmínkou by však mělo být splnění standardních přístupových podmínek, které si EU v minulosti stanovila a jejich splnění striktně vyžadovala od kandidátských zemí."
     },
     {
       "id": "senatni-2022-64-a-419215-43",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "Případné rozšiřování NATO o nové evropské státy zásadním způsobem mění rozložení sil v Evropě a mohlo by se stát bezpečnostním rizikem. Bez jednání a vyjednávání s těmi státy, které by se takovou politikou mohly cítit ohroženy, je případné rozšiřování NATO velmi rizikové."
     },
     {
       "id": "senatni-2022-64-a-419215-44",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-45",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-46",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes",
       "comment": "Otázkou ale bude vymahatelnost takových reparací - viz historie."
     },
     {
       "id": "senatni-2022-64-a-419215-47",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-48",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-49",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-50",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-51",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-52",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-53",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes",
       "comment": "Případné rozšiřování NATO o nové evropské státy zásadním způsobem mění rozložení sil v Evropě a mohlo by se stát bezpečnostním rizikem. Bez jednání a vyjednávání s těmi státy, které by se takovou politikou mohly cítit ohroženy, je případné rozšiřování NATO velmi rizikové."
     },
     {
       "id": "senatni-2022-64-a-419215-54",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "Zemědělské dotace mají být poskytovány tak, aby zajistily schopnost českých zemědělců obstát jak v konkurenci se zahraničním, tak i s ohledem na rostoucí ceny energií a dalších vstupních surovin - tedy bez ohledu na velikost."
     },
     {
       "id": "senatni-2022-64-a-419215-55",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "To je věc místních samospráv a stát by do tohoto problému vůbec neměl vstupovat."
     },
     {
       "id": "senatni-2022-64-a-419215-56",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-419215-57",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-419215-58",
       "candidate_id": "senatni-2022-64-c-419215",
-      "question_id": "senatni-2022-64-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-1",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-2",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-3",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-4",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-188030-5",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-6",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-7",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-8",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-9",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-10",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-11",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-188030-12",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-188030-13",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-188030-14",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-188030-15",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-188030-16",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "zachovat stávající stav manželství x registrované partnerství"
     },
     {
       "id": "senatni-2022-64-a-188030-17",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-188030-18",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-19",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-20",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-21",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-188030-22",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-188030-23",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-188030-24",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-188030-25",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "nutnost podchytit včas nadané děti"
     },
     {
       "id": "senatni-2022-64-a-188030-26",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-27",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-28",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-29",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-30",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-31",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-32",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-33",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-188030-34",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-35",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-36",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-37",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-38",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-39",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know",
       "comment": "není adekvátní náhrada"
     },
     {
       "id": "senatni-2022-64-a-188030-40",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-188030-41",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-42",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-188030-43",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-44",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-45",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-46",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-47",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-48",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know",
       "comment": "je to věcí jednotlivých států EU"
     },
     {
       "id": "senatni-2022-64-a-188030-49",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "dont_know",
       "comment": "řešit přednostně snížení závislosti na Rusku(fosilní paliva)"
     },
     {
       "id": "senatni-2022-64-a-188030-50",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-188030-51",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-52",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-53",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-188030-54",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "dont_know",
       "comment": "co jsou malé farmy, kde je hranice? Je fakt,že farmy nad 1000 ha profitují ze své velikosti..."
     },
     {
       "id": "senatni-2022-64-a-188030-55",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "nevidím jako důležité téma"
     },
     {
       "id": "senatni-2022-64-a-188030-56",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-57",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-188030-58",
       "candidate_id": "senatni-2022-64-c-188030",
-      "question_id": "senatni-2022-64-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-337974-1",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes",
       "comment": "Bytový fond by se měl rozvíjet, neměl by však stagnovat. Měl by být nějaký parametr, jak volné byty pronajmout."
     },
     {
       "id": "senatni-2022-64-a-337974-2",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Myslím, že regulace není zapotřebí. Je-li poptávka po bytech, cena je vyšší. Pokud města mají svůj bytový fond, je to jen dobře. Lidé si mohou vybrat."
     },
     {
       "id": "senatni-2022-64-a-337974-3",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no",
       "comment": "Od toho máme právě ty petice a zákony, které to řeší."
     },
     {
       "id": "senatni-2022-64-a-337974-4",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Neměli bychom podlehnout zájmům jednotlivce."
     },
     {
       "id": "senatni-2022-64-a-337974-5",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Nemůžeme chtít po lidech, aby dělali do úplného vyčerpání jen proto, že stát nehodlá řešit důchodovou reformu už desetiletí. Prodloužení odchodu do důchodu přece není řešení."
     },
     {
       "id": "senatni-2022-64-a-337974-6",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-337974-7",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes",
       "comment": "Plastový odpad je dnes velký problém. Pokud společnosti prodejem získávají značné prostředky, je v pořádku, že by měly řešit i odpadové hospodářství."
     },
     {
       "id": "senatni-2022-64-a-337974-8",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-9",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-10",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Veškeré násilí páchané na druhých by mělo být velmi trestáno, aby si každý rozmyslel důsledky svých činů."
     },
     {
       "id": "senatni-2022-64-a-337974-11",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-337974-12",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-337974-13",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-337974-14",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Každopádně by mělo být objektivní."
     },
     {
       "id": "senatni-2022-64-a-337974-15",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-16",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-17",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-337974-18",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes",
       "comment": "Následně by měly být i snížené náklady na exekuce. Ne, že si každý úkon vyúčtuje zvlášť."
     },
     {
       "id": "senatni-2022-64-a-337974-19",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes",
       "comment": "Každá obec by měla mít sociální byty jako jistotu pro své sociálně slabé občany. Ti by toho neměli zneužívat."
     },
     {
       "id": "senatni-2022-64-a-337974-20",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-21",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-22",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-23",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-24",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-25",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Nemůžeme házet všechny do jednoho pytle, v případě, že je někdo talentovaný nebo naopak, potřebuje více pozornosti, nemůžeme tyto věci řešit paušálně."
     },
     {
       "id": "senatni-2022-64-a-337974-26",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-27",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-28",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "Jsem určitě proti zavedení eura!! Máme vlastní korunu a je třeba si ji hájit."
     },
     {
       "id": "senatni-2022-64-a-337974-29",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no",
       "comment": "Měli bychom mít právo rozhodnout se, na jakém misi se budou naše vojska podílet."
     },
     {
       "id": "senatni-2022-64-a-337974-30",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-31",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "Máme dost svých problémů."
     },
     {
       "id": "senatni-2022-64-a-337974-32",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-33",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "V žádném případě."
     },
     {
       "id": "senatni-2022-64-a-337974-34",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-337974-35",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no",
       "comment": "ČR by měla zeštíhlit aparát vedení armády."
     },
     {
       "id": "senatni-2022-64-a-337974-36",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Myslím, že pokud má někdo problémy s početím, měl by být vděčný za to, že se početí vůbec povede a za to, že dítě je zdravé."
     },
     {
       "id": "senatni-2022-64-a-337974-37",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-64-a-337974-38",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-39",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-40",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Každopádně na tyto měřiče by mělo být s dostatečným předstihem upozorněno."
     },
     {
       "id": "senatni-2022-64-a-337974-41",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-337974-42",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-43",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "Myslím si, že Ukrajina má už dost svých problémů. Nevidím důvod proč situaci přiostřovat."
     },
     {
       "id": "senatni-2022-64-a-337974-44",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-337974-45",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-46",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "no",
       "comment": "Ne, protože tam žádná válka není. Vymlouvat se na stav války a nechtít řešení tím, že si představitelé obou zemí sednou za jeden stůl, je pro mě víc než všechny komentáře."
     },
     {
       "id": "senatni-2022-64-a-337974-47",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no",
       "comment": "Čeští zákonodárci mají řešit problémy v naší České republice."
     },
     {
       "id": "senatni-2022-64-a-337974-48",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-337974-49",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-50",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-51",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "dont_know",
       "comment": "ČR by se mělo zajímat pouze o sebe a tyto otázky nechat těm. kteří mají právo o těchto věcech rozhodovat."
     },
     {
       "id": "senatni-2022-64-a-337974-52",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Konečně pořádná otázka."
     },
     {
       "id": "senatni-2022-64-a-337974-53",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-54",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-64-a-337974-55",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "Doufejme, že zvítězí zdravý rozum."
     },
     {
       "id": "senatni-2022-64-a-337974-56",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-64-a-337974-57",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know",
       "comment": "Nevím, díky jednostranné informovanosti si myslím, že o těchto závažných věcech by měli rozhodovat ti, kterých se to týká - dva svrchované státy - a určitě ne my."
     },
     {
       "id": "senatni-2022-64-a-337974-58",
       "candidate_id": "senatni-2022-64-c-337974",
-      "question_id": "senatni-2022-64-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "no",
       "comment": "Když si každý bude dělat svou práci tak jak má, nebudou bezvýsledné."
     }

--- a/data/kalkulacka/senatni-2022/67.json
+++ b/data/kalkulacka/senatni-2022/67.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-67-c-965702",
       "name": "Jaromír Radkovský",
       "type": "person",
-      "description": "Jaromír Radkovský - DESCRIPTION",
+      "description": "Jaromír Radkovský",
       "contacts": {
         "web": [
           {
@@ -495,7 +495,7 @@
         {
           "id": "senatni-2022-67-c-965702-p",
           "name": "Jaromír Radkovský",
-          "description": "Jaromír Radkovský - DESCRIPTION",
+          "description": "Jaromír Radkovský",
           "contacts": {
             "web": [
               {
@@ -512,7 +512,7 @@
       "id": "senatni-2022-67-c-301471",
       "name": "Jan Mužík",
       "type": "person",
-      "description": "Jan Mužík - DESCRIPTION",
+      "description": "Jan Mužík",
       "contacts": {
         "web": [
           {
@@ -532,7 +532,7 @@
         {
           "id": "senatni-2022-67-c-301471-p",
           "name": "Jan Mužík",
-          "description": "Jan Mužík - DESCRIPTION",
+          "description": "Jan Mužík",
           "contacts": {
             "web": [
               {
@@ -556,7 +556,7 @@
       "id": "senatni-2022-67-c-775013",
       "name": "Petr Orel",
       "type": "person",
-      "description": "Petr Orel - DESCRIPTION",
+      "description": "Petr Orel",
       "contacts": {
         "web": [
           {
@@ -574,7 +574,7 @@
         {
           "id": "senatni-2022-67-c-775013-p",
           "name": "Petr Orel",
-          "description": "Petr Orel - DESCRIPTION",
+          "description": "Petr Orel",
           "contacts": {
             "web": [
               {
@@ -596,7 +596,7 @@
       "id": "senatni-2022-67-c-405244",
       "name": "Ivana Váňová",
       "type": "person",
-      "description": "Ivana Váňová - DESCRIPTION",
+      "description": "Ivana Váňová",
       "contacts": {
         "web": [
           {
@@ -615,7 +615,7 @@
         {
           "id": "senatni-2022-67-c-405244-p",
           "name": "Ivana Váňová",
-          "description": "Ivana Váňová - DESCRIPTION",
+          "description": "Ivana Váňová",
           "contacts": {
             "web": [
               {
@@ -638,7 +638,7 @@
       "id": "senatni-2022-67-c-745404",
       "name": "Pavel Liška",
       "type": "person",
-      "description": "Pavel Liška - DESCRIPTION",
+      "description": "Pavel Liška",
       "contacts": {
         "web": []
       },
@@ -646,7 +646,7 @@
         {
           "id": "senatni-2022-67-c-745404-p",
           "name": "Pavel Liška",
-          "description": "Pavel Liška - DESCRIPTION",
+          "description": "Pavel Liška",
           "contacts": {
             "web": []
           },
@@ -658,7 +658,7 @@
       "id": "senatni-2022-67-c-175924",
       "name": "Dana Váhalová",
       "type": "person",
-      "description": "Dana Váhalová - DESCRIPTION",
+      "description": "Dana Váhalová",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/dana.vahalova/"
@@ -667,7 +667,7 @@
         {
           "id": "senatni-2022-67-c-175924-p",
           "name": "Dana Váhalová",
-          "description": "Dana Váhalová - DESCRIPTION",
+          "description": "Dana Váhalová",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/dana.vahalova/"
@@ -680,7 +680,7 @@
       "id": "senatni-2022-67-c-129902",
       "name": "Leo Luzar",
       "type": "person",
-      "description": "Leo Luzar - DESCRIPTION",
+      "description": "Leo Luzar",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/leo.luzar"
@@ -689,7 +689,7 @@
         {
           "id": "senatni-2022-67-c-129902-p",
           "name": "Leo Luzar",
-          "description": "Leo Luzar - DESCRIPTION",
+          "description": "Leo Luzar",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/leo.luzar"
@@ -703,1174 +703,1522 @@
     {
       "id": "senatni-2022-67-a-129902-1",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes",
       "comment": "Jedná se o daň určovanou samosprávou obcí a měst a tak by to mělo zůstat, aby mohli regulovat bytové potřeby, které sami nejlépe znají. Nesouhlasím s plošným zdaněním v rámci ČR"
     },
     {
       "id": "senatni-2022-67-a-129902-2",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes",
       "comment": "Ale to již v rámci obecního bytového fondu funguje a pomáhá to řešit tíživou ekonomickou situaci mnohých rodin."
     },
     {
       "id": "senatni-2022-67-a-129902-3",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Už dnes je pozdě na všeobecné referendum! To by řešilo otázky typu, manželství pro všechny, euro ano/ne a kdy, vícepohlavní identitu nebo znásilnění či adopci dětí, ale i trest smrt, eutanázii nebo naše členství v EU a NATO. Je velmi mnoho otázek, které čím dál více rozdělují společnost a bez referenda a znalosti většinového názoru rozdělovat budou."
     },
     {
       "id": "senatni-2022-67-a-129902-4",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes",
       "comment": "Pokud opravdu chceme chránit životní prostředí musíme umožnit lidem efektivní a kvalitní hromadnou dopravu! Investice do potřebné infrastruktury také pomůže ekonomice ČR a nabídne různorodou práci za dobrou odměnu po mnoho let. "
     },
     {
       "id": "senatni-2022-67-a-129902-5",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Pokud nebude důchodový věk reflektovat fyzickou nebo psychickou náročnost povolání, je jednotný a prodlužující se věk nástupu penze pouze útěk od zodpovědnosti za kvalitní a důstojný život seniorů.    "
     },
     {
       "id": "senatni-2022-67-a-129902-6",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know",
       "comment": "Otázka není jednoznačná v účelu výstavby a dosaženého efektu. Protipovodňové poldry nebo přehrady ochraňující vodu a obydlí občanů podporuji. Vodu jako byznys  odmítám."
     },
     {
       "id": "senatni-2022-67-a-129902-7",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no",
       "comment": "Třídění plastů v ČR zatím funguje právě díky zájmu o výkup PET láhví, když budou vratné nebude o ostatní plasty zájem pro ekonomickou neefektivitu. Souhlasil bych pokud by se k systému odpadového hospodářství a cirkulární ekonomice přistoupilo komplexně. Nesouhlasím s vyzobáním zlatých zrnek pro někoho a zbytek ať řeší někdo jiný! "
     },
     {
       "id": "senatni-2022-67-a-129902-8",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes",
       "comment": "Ale pouze v rámci minimálně 5 daňových pásem zohledňujících nízké příjmy a životní náklady pro důstojný život a mzdu ve výši, která umožní život bez dávek a podpor."
     },
     {
       "id": "senatni-2022-67-a-129902-9",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know",
       "comment": "Je rozdíl mezi pěstováním a užitím. Proč má být legalizováno pěstování?"
     },
     {
       "id": "senatni-2022-67-a-129902-10",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "dont_know",
       "comment": "Trest stanoví soudy a pokud se soudy nebo lidé v referendu shodnou na nutnosti tuto oblast zpřísnit potom podpořím tuto iniciativu."
     },
     {
       "id": "senatni-2022-67-a-129902-11",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Proč jen tyto dvě nadnárodní společnosti, je jich přece více a proč by se nemělo progresívní zdanění týkat i právnických osob? Další a důležitější pro ekonomiku je potírání daňových rájů a různých optimalizací znamenajících pouze vyhnutí se daňové povinnosti na úkor států."
     },
     {
       "id": "senatni-2022-67-a-129902-12",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Nesouhlasím z jakoukoliv cenzurou názorů, myšlenek a postojů. Nechť každý jedinec-uživatel zodpovídá za své chování na síti."
     },
     {
       "id": "senatni-2022-67-a-129902-13",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "Nesouhlasím z jakoukoliv cenzurou názorů, myšlenek a postojů. Nechť každý jedinec-uživatel zodpovídá za své chování na síti. Zneužívání \"zprav\" nelze zabránit jejich nálepkováním, že jsou falešné. Jen a pouze pluralita, vysvětlování a důkazy jsou schopny řešit faleš, polopravdy a lži."
     },
     {
       "id": "senatni-2022-67-a-129902-14",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Že je ČT přikloněna k jednomu názoru neznamená, že ČRo nebo ČTK má být postiženo finančně. Zde pouze pluralita informací a návrat k seriózní novinařině může změnit veřejné mínění.  "
     },
     {
       "id": "senatni-2022-67-a-129902-15",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes",
       "comment": "Šmejdi pronikli do různých oborů kde cítí šanci rychle získat prachy. Práce musí zůstat zdrojem příjmu k důstojnému životu pracujících a ne rychlému zbohatnutí zprostředkovatelům!"
     },
     {
       "id": "senatni-2022-67-a-129902-16",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know",
       "comment": "Stejné podmínky. To by znamenalo i uzavřít manželství v kostele, synagoze nebo mešitě? Je to již vyjasněná otázka? A jakých dalších pohlaví se to má týkat?  To je otázka pro celostátní referendum nemyslíte? "
     },
     {
       "id": "senatni-2022-67-a-129902-17",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes",
       "comment": "Podporuji zrušení soukromých exekutorů a navrácením exekučních činností pod soudní moc."
     },
     {
       "id": "senatni-2022-67-a-129902-18",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes",
       "comment": "Když budou zrušeni soukromí exekutoři bude i tato otázka řešena soudem a bude zcela jednoznačná dle již platného zákona."
     },
     {
       "id": "senatni-2022-67-a-129902-19",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "Pokud není definováno sociální bydlení není možné ani určit parametry sociálního bytu. Je nutná státní bytová výstavby prostřednictvím neziskových stavebních firem nebo družstevní bytová výstavba, vše v masovém měřítku. Tím dojde k uvolnění stávajících již dávno \"zaplacených\" bytů 30 až 70 let starých, a spolu s řešením danění více bytů nesloužících k vlastnímu uspokojení potřeb rodiny na bydlení přinese rychlé řešení i sociálního bydlení. Bydlení není investice, ale základní lidské právo!"
     },
     {
       "id": "senatni-2022-67-a-129902-20",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes",
       "comment": "To je způsob objektivizace ekonomické i životní úrovně občanů a politici začnou díky tomu velice rychle hledat řešení problému. To je dnes příliš nezajíma a tisíce lidí díky tomu končí v exekucích, bez střech nad hlavou nebo i sebevraždou."
     },
     {
       "id": "senatni-2022-67-a-129902-21",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "Decentralizace sídel státních institucí přinese kvalitativní změnu a povede k lepší státní správě spolu z pomůže s rozvojem regionům."
     },
     {
       "id": "senatni-2022-67-a-129902-22",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "yes",
       "comment": "Kolonizace oblasti mezi Seinou a Rýnem potažmo Labem je prvořadá úkol každého Marťana z Čech, Moravy a Slezska - howgh."
     },
     {
       "id": "senatni-2022-67-a-129902-23",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Volit se musí \"nohama\" a osobně za plentou, pokud chceme mít zachovánu aspoň minimální míru důvěry ve volební proces. Měly by nás varovat události posledních let v zemích, kde tato  procedura vyhovují lenochům je zavedena. "
     },
     {
       "id": "senatni-2022-67-a-129902-24",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "Investice do vzdělávání v technických směrech je jednoznačně nákladnější než v rámci humanitních oborů. Chceme li pozvednout úroveň ekonomiky musíme být také připraveni i na investice do těchto technických oborů. Výsledky dosavadního směřování školství a následného kolapsu úrovně vzdělávání v ČR již vidíme."
     },
     {
       "id": "senatni-2022-67-a-129902-25",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes",
       "comment": "Diskuse mezi reálnými odborníky o víceletých gymnáziích a o další budoucnosti paralelního školství poukazují na chybné předpoklady a \"elitářství\" vedoucí k přesvědčivým negatívním  výsledkům pro společnost."
     },
     {
       "id": "senatni-2022-67-a-129902-26",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "dont_know",
       "comment": "Termín inkluze byl zdiskreditován a zneužit ke zrušení fungujícího systému, který byl sice hlavně náš, ale dlouhodobě se osvědčil. To ale neznamená, že se nebude pomáhat  slabším žákům zapojit se do kolektivu a motivovat je k učení!"
     },
     {
       "id": "senatni-2022-67-a-129902-27",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "dont_know",
       "comment": "To by neměli rozhodovat politici, ale občané. Každopádně pokud nebude na stole k jednání rekonstrukce EU a návrat zpět ke společnému ekonomickému prostoru, potom dojde v brzké době k rozpadu Evropské únie. O všem, ale musí rozhodnout celostátní referendum! A to podporuji spolu s jeho brzkým vyhlášením."
     },
     {
       "id": "senatni-2022-67-a-129902-28",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "dont_know",
       "comment": "To by neměli rozhodovat politici, ale občané. Záleží na podmínkách a výhodách pro naše občany. Opět se jedná o otázku celospolečenského významu a měly by o ní rozhodnout občané v referendu. Jeho vypsání podporuji. "
     },
     {
       "id": "senatni-2022-67-a-129902-29",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "dont_know",
       "comment": "To by neměli rozhodovat politici, ale občané v celostátním referendu!"
     },
     {
       "id": "senatni-2022-67-a-129902-30",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no",
       "comment": "Z pohledu starých členů jsme osina a rádi by tak upravili hlasovací proces jednomyslnosti v základních věcech rozhodování EU."
     },
     {
       "id": "senatni-2022-67-a-129902-31",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "Naše zahraniční pomoc je již nyní velmi štědrá a spíše bychom se měli zaměřit na efektivitu protože mnoho finanční pomoci končí v nesprávných rukou a nedorazí k potřebným."
     },
     {
       "id": "senatni-2022-67-a-129902-32",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no",
       "comment": " Máme reciproční mezinárodní smlouvy s drtivou většinou států světa i rozvojových zemí. Tam se tyto věci řeší. Nyní uzavíráme tyto smlouvy v rámci EU jako celek a nejsem si vědom nějakého neohleduplného zákonodárství."
     },
     {
       "id": "senatni-2022-67-a-129902-33",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Udělení azylu je jednoduché a jsme tomu svědky. Jednodušší snad už ani nemůže být protože je na našem území desetitisíce lidí o kterých nic nevíme ani kde nyní jsou. "
     },
     {
       "id": "senatni-2022-67-a-129902-34",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes",
       "comment": "Jedna z výhod EU, kterou občané jednoznačně oceňují."
     },
     {
       "id": "senatni-2022-67-a-129902-35",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no",
       "comment": "Pokud armáda nedokáže smysluplně realizovat nákupy, jak jsme nyní svědky (transportéry, houfnice, tanky, stíhačky, drogy) a provází tato akvizice jeden problém za druhým, nemám důvěru, že více peněz znamená lepší armádu. "
     },
     {
       "id": "senatni-2022-67-a-129902-36",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "To snad nikdo nemyslí vážně?"
     },
     {
       "id": "senatni-2022-67-a-129902-37",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no",
       "comment": "Nesouhlasím, aby si někdo mohl koupit léčení a druhý umřel jen proto, že nemá dost peněz! Proto jsem pro všeobecné a solidární zdravotní pojištění! "
     },
     {
       "id": "senatni-2022-67-a-129902-38",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know",
       "comment": "Neorientuji se v této problematice a dám na radu odborníků."
     },
     {
       "id": "senatni-2022-67-a-129902-39",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know",
       "comment": "Neorientuji se v této otázce a je na zemědělských odbornících, aby dodali fakta a argumenty.."
     },
     {
       "id": "senatni-2022-67-a-129902-40",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "yes",
       "comment": "Pokud to bude sloužit ke zlepšení financování obcí na úkor řidičů mnohdy s nesmyslným umístěním radarů jen s cílem vybrat peníze. Ale ji to otázka opět pro referendum a třeba i v rámci obcí."
     },
     {
       "id": "senatni-2022-67-a-129902-41",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes",
       "comment": "Bohužel vždy bude mít stát a tajné služby \"výjimku\" a tak je vaše otázka bezpředmětná. Vždyť už dnes se mají mazat náhodné odposlechy pořízené mimo soudní povolení a nikdo neví zda se tak děje a kde potom tyto odposlechy končí."
     },
     {
       "id": "senatni-2022-67-a-129902-42",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know",
       "comment": "Až splní všechny podmínky pro členství, a sami občané Ukrajiny v referendu tak rozhodnou, ale nesouhlasím s žádnými výjimkami. "
     },
     {
       "id": "senatni-2022-67-a-129902-43",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know",
       "comment": "Pokud občané Ukrajiny rozhodnou v referendu pak ano, ale stále je tu riziko dalších konfliktu stejně jako kdyby třeba Mexiko po referendu uzavřelo s Ruskem vojenskou dohodu. Já podporuji jednoznačně mír a je mi bujno ze všech, kteří vidí řešení problémů v jakékoliv válce!"
     },
     {
       "id": "senatni-2022-67-a-129902-44",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes",
       "comment": "Ne jen Ruského, ale veškerého plynu a energií na evropském trhu (ten Ruský plyn je snad zatím nejlevnější ze všech, ne?). Ale stejně pokud Evropa neuzná jadernou energetiku za ekologickou a nepřestane odstavovat stávající elektrárny bez technického a ekonomického zdůvodnění, jen dle přání politiků a také nezačne řešit spekulace s emisními povolenkami je takto položená otázka hloupá a nic neříkající. U nás musí stát rychle získat zpět  100% ČEZu a zabezpečit tím levnou energii pro ČR a pouze nadbytek prodávat, to je otázka dní a týdnů. Vládo ukaž se zda vládneš ty, nebo ti vládne ČEZ! "
     },
     {
       "id": "senatni-2022-67-a-129902-45",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know",
       "comment": "Nesleduji práci úřadu ombudsmana a tak nevím zda jsou lidé s jejich prací spokojeni. Já hodnotím oficiální výstupy a zatím nemám osobně důvod kritizovat nebo chválit."
     },
     {
       "id": "senatni-2022-67-a-129902-46",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes",
       "comment": "Jsem odpůrce všech válek a ti co je vyvolali by vždy měli být potrestání a nést následky, bez rozdílu. A Rusko už následky nese a bude tímto poznamenáno na dlouhá léta minimálně na Ukrajině, ale i doma, protože smrt lidí nikdy není bez následků. A jak známe z nedávné historie, válka nikdy nepřinesla mír, ale jen utrpení. Bohužel se ale i na válkách dá dělal kšeft."
     },
     {
       "id": "senatni-2022-67-a-129902-47",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "dont_know",
       "comment": "Nás nikdo k nějakému vyjednávání nepotřebuje, jsme jen stát střední velikosti pod kuratelou velkých a vlivných států v EU a měli by jsme si uvědomit, že až nám zavedli tak holt půjdeme tam, kde nám řeknou. Samostatnou Českou zahraniční politiku už velmi dlouho neděláme a snad jen za první republiky jsme tyto tendence měli. "
     },
     {
       "id": "senatni-2022-67-a-129902-48",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know",
       "comment": "Neznám ji tak nevím."
     },
     {
       "id": "senatni-2022-67-a-129902-49",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Ano jen za předpokladu, že bude k dispozici dost levné a alternativní elektrické energie a taky tepla. Stále se zapomíná, že statisíce lidí jsou závislí na centralizovaném zásobování teplem! "
     },
     {
       "id": "senatni-2022-67-a-129902-50",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "Rád bych aby tomu tak bylo, ale to co EU předvádí poslední roky mě překvapuje, že dělá vše proto, aby naštvala své občany a pohřbila všechny naděje na technologický rozvoj. Pokud neuvidím technické a ekonomické podklady, tak mě pouze zbožná přání nemohou přesvědčit pro podporu. "
     },
     {
       "id": "senatni-2022-67-a-129902-51",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "yes",
       "comment": "Když jsem uznali Kosovo tak nám nic jiného nezbývá na rozdíl třeba od Slovenska. Jsem zastáncem práva na sebeurčení a sice se nám to nemusí líbit, ale i Katalánci mají právo na svou zem nebo třeba Baskové či Skotové, podmínkou je ovšem referendum! My bychom  měli spíše spitovat svědomí za rozdělení Masarykova dítěte Československa bez referenda, se kterým jsem se nikdy nesmířil. "
     },
     {
       "id": "senatni-2022-67-a-129902-52",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Stejně jako ostatní státy EU závislé na plynu z Ruska s ním jednají tak i my buď získáme tentýž Ruský plyn od těchto státu, ale bohužel za jinou spekulatívní cenu, nebo si jej nakoupíme sami. Je pokrytecké a vůči vlastním občanům zločinné nutit je kupovat tentýž plyn, jen z jiné trubky a dráž. A nebo využít voleb a uspořádat referendum k těmto otázkám."
     },
     {
       "id": "senatni-2022-67-a-129902-53",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes",
       "comment": "Pokud to chtějí občané Finska a Švédska."
     },
     {
       "id": "senatni-2022-67-a-129902-54",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "dont_know",
       "comment": "Nejsem odborník na zemědělství, jen budu rád za efektivní využití podpory a schopnost uživit co nejvíce našich občanů z produkce naší země."
     },
     {
       "id": "senatni-2022-67-a-129902-55",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know",
       "comment": "To jsme opravdu na tak bídné sociální úrovni v 21.století??? Státe styď se!!!"
     },
     {
       "id": "senatni-2022-67-a-129902-56",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes",
       "comment": "Proč ne, ale hlavní je aby je stát stavěl prostřednictvím státní a neziskové výstavby. To vše spolu s podporou družstevní výstavby."
     },
     {
       "id": "senatni-2022-67-a-129902-57",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know",
       "comment": "Je věcí Ukrajiny jak se rozhodne ukončit tuto válku, ale rozhodně by neměli poslouchat lidi sedící v cizině a bezpečí vládních rezidencí. "
     },
     {
       "id": "senatni-2022-67-a-129902-58",
       "candidate_id": "senatni-2022-67-c-129902",
-      "question_id": "senatni-2022-67-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Už dávno tak má stát činit, ale zastavovat je hlavně na úkor těch institucí, které i po prověření dlužníka a zjištění, že dluží kde se podívá mu přesto půjčí. Ty bych naopak sankcionoval, jsou to totiž šmejdi snažící se vydělat na neštěstí lidí."
     },
     {
       "id": "senatni-2022-67-a-301471-1",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Nejsem pro zbytečné zasahování státu do volného trhu, který má řídit nabídka a poptávka. Jsem odpůrce mnohých regulací, nadbytečného zdanění všeho a dalších legislativních marasmů, které k nám přicházejí ze všech stran a zejména z EU."
     },
     {
       "id": "senatni-2022-67-a-301471-2",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Nejsem pro zbytečné zasahování státu do volného trhu, který má řídit nabídka a poptávka. Jsem odpůrce mnohých regulací, nadbytečného zdanění všeho a dalších legislativních marasmů, které k nám přicházejí ze všech stran a zejména z EU."
     },
     {
       "id": "senatni-2022-67-a-301471-3",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Souhlasím, ale pouze v případě počtu více jak 50% počtu občanů způsobilých k volbám. Petiční podpisy musí být řádně, či digitálně překontrolovány (např. blockchain) a až na základě výsledků této ověřené petice, která projevuje většinový pohled na situaci v naší zemi zahájit referendum o tom, či onom problému, který národ trápí."
     },
     {
       "id": "senatni-2022-67-a-301471-4",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Nejsem odborník na dopravu, ale jeden aspekt by neměl být upřednostňován na úkor druhého. Výstavba dopravní infrastruktury by měla být kontinuální, navzájem navazující na další projekty a hlavně řádně a transparentně vysoutěžená včetně ekonomicky udržitelné a vysoutěžené následné správy."
     },
     {
       "id": "senatni-2022-67-a-301471-5",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Nemyslím si, občané v tomto věku by již měli mít nárok za své odvody do solidárního důchodového systému spočinout v důchodu a stát by se o ně postarat tak, aby měli důstojné stáří. Náš důchodový systém je založen na takovém zvláštním sytému přerozdělování financí a reformu tohoto systému nám slibuje každá vláda, která je a přijde."
     },
     {
       "id": "senatni-2022-67-a-301471-6",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know",
       "comment": "Bohužel nejsem profesionální vodohospodář, ale je mi jasné, že tato problematika má dvě strany jako mince. Na jednu stranu přehrady zadržují vodu v krajině a dokážeme takto vodu a její kapacity uměle korigovat v nezávislosti na počasí a delším suchům. Druhá strana je ale v stále se zvyšující se ztrátě přirozené krajiny, živočichů, kteří nemohou migrovat, vylidňování  a ztrátě obydlí v zatopených oblastech, což nese s sebou i zásah do životů obyvatel. Je to podle mě komplexní téma a mělo by se k němu přistupovat velice obezřetně a vyhodnocovat všechny dopady na nově vznikající přehrady a přehradní systémy na našich řekách."
     },
     {
       "id": "senatni-2022-67-a-301471-7",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes",
       "comment": "V tomto případě jsem pro zálohování a hlavně využívání ekologických a volně rozložitelných materiálů v přírodě. Jakákoliv záloha na obal motivuje koncového spotřebitele ten obal navrátit do oběhu za své peníze a nedovoluje mu ho jen tak někde pohodit a následně devastovat naši krajinu a životní prostředí."
     },
     {
       "id": "senatni-2022-67-a-301471-8",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes",
       "comment": "Vždy jsem zastával progresivní zdanění. Samozřejmě je diskutabilní limit a výše, ale tohle bych nechal na odbornících, nebo se s nimi rád i pobavil, jaké dopady to bude mít na mnoho aspektů ekonomiky, jak už makro, tak lokální ve spojitosti s kraji a jejich příjmy. Na všechno existují matematické a statistické modely, takže bych vybíral bod zvratu, který určí ty správné výše a limity pro progresivní zdanění v daném čase a hospodářské kondici naší země."
     },
     {
       "id": "senatni-2022-67-a-301471-9",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Zastávám tezi, že svobodné rozhodování o své léčbě a jejích dopadech je na každém z nás a proti THC, CBD, CBG a dalším kanabinoidům nemám žádné výhrady, pokud se užívají pro vlastní potřebu."
     },
     {
       "id": "senatni-2022-67-a-301471-10",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Tresty zvýšit a hlavně jasně definovat co to \"znásilnění\" je, takže změna trestněprávního výkladu jdoucí ruku v ruce s legislativními parametry tohoto paragrafu."
     },
     {
       "id": "senatni-2022-67-a-301471-11",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Nadnárodní korporace tohoto typu by měli odvádět určitě více financí do rozpočtu naší země, když už je z ní vytahují. Jsem pro tyto speciální daně nadnárodních koncernů všude ve světě."
     },
     {
       "id": "senatni-2022-67-a-301471-12",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes",
       "comment": "Určitě ano a ty technologie na to mají!"
     },
     {
       "id": "senatni-2022-67-a-301471-13",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no",
       "comment": "Určitě ne, neboť kdo bude rozhodovat o tom v dnešním divokém světě naší civilizace, co je pravda, co je lež, co je relevantní a ověřený zdroj informací a co už je fakenews. Nechal bych tomu prostor, nic necenzuroval a už vůbec nezasahoval do svobody projevu, kdekoliv a kdykoliv a konečný čtenář, nebo uživatel dané sítě ať si udělá obrázek sám. Jsem proti jakékoliv cenzuře a filtrování informací ve všech médiích po celém světě."
     },
     {
       "id": "senatni-2022-67-a-301471-14",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes",
       "comment": "Veřejnoprávní média totálně selhávají, informují tendenčně na základě politické objednávky a jejich produkce je nedostačující v poměru příjmů z veřejného rozpočtu, kterým disponují."
     },
     {
       "id": "senatni-2022-67-a-301471-15",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no",
       "comment": "Jsem pro volný trh práce i institucí, které se na něm podílí."
     },
     {
       "id": "senatni-2022-67-a-301471-16",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Manželství a z tohoto stavu plynoucí práva a povinnosti jsou určeny pouze pro Muže a Ženu, tak jak to je zařízeno v přírodě, prostě existují jen dvě pohlaví a pak už jen hermafroditi na jiné evoluční úrovni, než je člověk."
     },
     {
       "id": "senatni-2022-67-a-301471-17",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes",
       "comment": "Určitě ano a zabránilo by to tak obchodování s chudobou a prohlubování dluhové spirály."
     },
     {
       "id": "senatni-2022-67-a-301471-18",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-301471-19",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-301471-20",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Na vojně se říká \"Voják se stará, voják má\", takže každý ať se stará!"
     },
     {
       "id": "senatni-2022-67-a-301471-21",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "Určitě ano, v rámci možností a hlavně ekonomické udržitelnosti."
     },
     {
       "id": "senatni-2022-67-a-301471-22",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "yes",
       "comment": "Nemám s tím problém, naše vědce a AV považuji za světové pracoviště, které by mělo dostávat více z veřejných rozpočtů a pomáhat tak svým dílem k celosvětové progresi naší civilizace do vesmíru a tamních objevů. Nepovažuji to však za prioritu, neboť v naší zemi máme více než dost problémů sami se sebou, než kolonizovat Mars. Prvně si stabilizovat naši Českou republiku a až pak vzhlížet ke hvězdám a planetám."
     },
     {
       "id": "senatni-2022-67-a-301471-23",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Určitě ano, formou decentralizované databáze (blockchain) s jasným ověřovacím tokenem a volby by byly dokonale transparentní ve všech směrech."
     },
     {
       "id": "senatni-2022-67-a-301471-24",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no",
       "comment": "Jsem pro \"rovnoprávnost\" mezi jednotlivými akademickými obory a neupřednostňoval bych jeden před druhým."
     },
     {
       "id": "senatni-2022-67-a-301471-25",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes",
       "comment": "Určitě ano!"
     },
     {
       "id": "senatni-2022-67-a-301471-26",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no",
       "comment": "Jsem odpůrce inkluze, zejména v našem školství a pojetí."
     },
     {
       "id": "senatni-2022-67-a-301471-27",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no",
       "comment": "Ale určitě bych velmi důrazně korigoval její legislativu a jsem zastáncem toho, že v mnoha směrech nemáme a neměli bychom podléhat bruselským nařízením a tu naši krásnou zem si spravovat sami, dle racionality a kulturních hodnot, ne diktátem bezdětných a úplatných elitních politiků EU."
     },
     {
       "id": "senatni-2022-67-a-301471-28",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "Určitě ne, jsem zastáncem české koruny a vlastní měny."
     },
     {
       "id": "senatni-2022-67-a-301471-29",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no",
       "comment": "Určitě ne. Akorát jsem odpůrce vojenské logistické základny v Mošnově, neboť je to velmi zbytečný projekt a Letiště Leoše Janáčka Ostrava má sloužit k civilním účelům, zejména cargo privátní přepravě. Je to komplexnější téma a kdyby někdo chtěl, rád se k němu také komplexně vyjádřím."
     },
     {
       "id": "senatni-2022-67-a-301471-30",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes",
       "comment": "Ano, už geologicky tam minimálně je."
     },
     {
       "id": "senatni-2022-67-a-301471-31",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "Nevidím důvod, proč by měla."
     },
     {
       "id": "senatni-2022-67-a-301471-32",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no",
       "comment": "Neumíme se postarat o náš stát a český národ, tak nevím proč bychom se měli více starat o klima. Pojďme stabilizovat naši Českou republiku a až posléze se zaobírat opatřeními zabraňujícímu změně klimatu, které se stejně mění samovolně už přes několik miliard let co je planeta Země našim domovem."
     },
     {
       "id": "senatni-2022-67-a-301471-33",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Určitě ne, tyhle azyly se zneužívají a stejně se už nyní rozdávají na počkání."
     },
     {
       "id": "senatni-2022-67-a-301471-34",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes",
       "comment": "Určitě ano."
     },
     {
       "id": "senatni-2022-67-a-301471-35",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "Určitě ano, bezpečnostní situace v celém světě je napjatá a musíme se alespoň bránit, ale ne s tou paní Černochovou v čele!"
     },
     {
       "id": "senatni-2022-67-a-301471-36",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Jsem proti genetickým úpravám embrya v jakémkoliv stádiu. Zastávám tezi, že příroda ví co je správné a člověk by si neměl hrát na Boha."
     },
     {
       "id": "senatni-2022-67-a-301471-37",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes",
       "comment": "Může být, ale ta následná péče musí být dostupná a vymahatelná."
     },
     {
       "id": "senatni-2022-67-a-301471-38",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no",
       "comment": "Nevidím důvod."
     },
     {
       "id": "senatni-2022-67-a-301471-39",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know",
       "comment": "Nejsem ekolog a ani biolog, takže Vám na tohle nedokážu odpovědět."
     },
     {
       "id": "senatni-2022-67-a-301471-40",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Určitě ne, je to výborný nástroj na neslušné řidiče porušujíc dopravní předpisy při provozu svých vozidel na pozemních komunikacích."
     },
     {
       "id": "senatni-2022-67-a-301471-41",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no",
       "comment": "Je to nutné zlo budoucnosti a evoluce lidské populace. Jen zastávám názor, že kontrola, monitorování a shromažďování těchto dat by měla být pod přísným dohledem, nezneužitelná a neměla by zasahovat do soukromí jedince, jako občana."
     },
     {
       "id": "senatni-2022-67-a-301471-42",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no",
       "comment": "Bohužel nejsem zastáncem vstupu této země do EU. Nepovažuji ji za plnohodnotnou evropskou zemi s dostatečně vyvinutou ekonomikou, nekorupční vládou a netendenční zahraniční politikou."
     },
     {
       "id": "senatni-2022-67-a-301471-43",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "Určitě ne, nepatří do \"severoatlantické aliance\", měla by směřovat do \"východní aliance\", kde vždy patřila a patří."
     },
     {
       "id": "senatni-2022-67-a-301471-44",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "Nevidím důvod proč by stát, nebo EU měli někomu diktovat ceny. Jsem pro neviditelnou ruku trhu, kdy se cena odvíjí jako bod zvratu při střetu nabídky s poptávkou."
     },
     {
       "id": "senatni-2022-67-a-301471-45",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no",
       "comment": "Určitě ne, nekoná a úřad je v rozkladu z důvodů neshod ombudsmana s jeho asistentkou."
     },
     {
       "id": "senatni-2022-67-a-301471-46",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "dont_know",
       "comment": "Tole je komplexní geopolitické téma, mám na to svůj názor, ale je to na delší elaborát."
     },
     {
       "id": "senatni-2022-67-a-301471-47",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no",
       "comment": "Možná nerozumím otázce, ale proč by čeští zákonodárci měli o něčem jednat a ještě na Krymu? Nevidím důvod proč by měli jezdit na Krym."
     },
     {
       "id": "senatni-2022-67-a-301471-48",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Určitě ano."
     },
     {
       "id": "senatni-2022-67-a-301471-49",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Bohužel není na to naše země ještě připravena."
     },
     {
       "id": "senatni-2022-67-a-301471-50",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "Nejdříve bych stabilizoval Českou republiku jako takovou, eliminoval její energetické a soběstačné problémy uvnitř a až pak bych se staral o klima a neutralitu."
     },
     {
       "id": "senatni-2022-67-a-301471-51",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "dont_know",
       "comment": "Tole je komplexní geopolitické téma, mám na to svůj názor, ale je to na delší elaborát."
     },
     {
       "id": "senatni-2022-67-a-301471-52",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Určitě ano, aby zabezpečilo plyn pro své občany, podniky a infrastrukturu v dostatečném množství a za přijatelnou cenu."
     },
     {
       "id": "senatni-2022-67-a-301471-53",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes",
       "comment": "Určitě ano, tyto země považuji za \"severoatlantické\"."
     },
     {
       "id": "senatni-2022-67-a-301471-54",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes",
       "comment": "Ano, nyní jsou bohužel dotace zneužívány velkými zemědělci, respektive jejich podniky a není to správné. Dotace, když už jsou v jakémkoliv ekonomickém odvětví by měli být efektivní, účelové a věcné, nikoliv zneužitelné, tendenční a plošné."
     },
     {
       "id": "senatni-2022-67-a-301471-55",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "Nevidím důvod. Stát by neměl suplovat nějakou drogerii. Pokud na to žena finančně nemá, existují další alternativní způsoby, které využívali ženy odjakživa a není tomu tak dávno, kdy v naší zemi nebyly vložky a tampony. Nijak nesnižuji tyto ženské hygienické potřeby, dámy prominou, ale opravdu nevidím důvod proč by úřady se měli zaobírat touto problematikou."
     },
     {
       "id": "senatni-2022-67-a-301471-56",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no",
       "comment": "Určitě ne, je a má to být volný trh, ekonomicky udržitelný a tímto krokem bychom se vraceli do reálného socialismu s plánovaným hospodářstvím a to určitě nechci."
     },
     {
       "id": "senatni-2022-67-a-301471-57",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know",
       "comment": "Tole je komplexní geopolitické téma, mám na to svůj názor, ale je to na delší elaborát."
     },
     {
       "id": "senatni-2022-67-a-301471-58",
       "candidate_id": "senatni-2022-67-c-301471",
-      "question_id": "senatni-2022-67-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Ano, aby člověk měl ještě nějakou šanci v životě uspět, druhý pokus a svou produktivitou alespoň přispět společnosti. Tato legislativa by měla být ale důkladně vypracovaná proti zneužití a \"oddlužení\" každého dlužníka, který by se jen spekulativně vyhnul zaplacení svých dluhů."
     },
     {
       "id": "senatni-2022-67-a-175924-1",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "dont_know",
       "comment": "Krize s energiemi  a příliv lidí dotčených válkou, byla příležitostí k opatření pro dostupnější bydlení pro mladé rodiny, samoživitele a seniory. Obce mají přispívat na tržní nájemné pro tyto skupiny lidí a vytvářet fond bydlení, nebo obecní byty. Ten kdo podniká pronájmem bytů musí vše řádně danit."
     },
     {
       "id": "senatni-2022-67-a-175924-2",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes",
       "comment": "V této době především zastropovat ceny energií."
     },
     {
       "id": "senatni-2022-67-a-175924-3",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-175924-4",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-5",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-67-a-175924-6",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes",
       "comment": "Především malých přehrad s přečerpávacími vodními elektrárnami. Řeší problém s vodou i energií."
     },
     {
       "id": "senatni-2022-67-a-175924-7",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-175924-8",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes",
       "comment": "Nízkopříjmové skupiny mají vysoké zdanění práce a tím zatěžujeme strukturálně znevýhodněné regiony kde lidé chudnou."
     },
     {
       "id": "senatni-2022-67-a-175924-9",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-10",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Není možné, aby za krádeže byly větší tresty než za násilné TČ "
     },
     {
       "id": "senatni-2022-67-a-175924-11",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-175924-12",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-175924-13",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-175924-14",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-15",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-175924-16",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know",
       "comment": "Institut manželství byl právně ukotven za účelem  vytváření rodiny, jako jednotky  společenství, národa a státu. Pokud jakýkoliv pár splňuje tyto podmínky nemám námitek.  "
     },
     {
       "id": "senatni-2022-67-a-175924-17",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes",
       "comment": "Jsem pro návrat exekutorů pod soudní moc. Nyní dlužník platí víc exekutorovi než věřiteli."
     },
     {
       "id": "senatni-2022-67-a-175924-18",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-175924-19",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-175924-20",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Stát by měl především vytvářet podmínky, aby občan v nouzi nebyl. "
     },
     {
       "id": "senatni-2022-67-a-175924-21",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-175924-22",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-23",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-24",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-25",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Dítě by mělo mít šanci rozvíjet svůj talent např. hudební či sportovní.  "
     },
     {
       "id": "senatni-2022-67-a-175924-26",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-27",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-67-a-175924-28",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "dont_know",
       "comment": "Otázka ke které by se měli vyjádřit občané."
     },
     {
       "id": "senatni-2022-67-a-175924-29",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-30",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes",
       "comment": "Tato otázka je na rozhodnutí občanů."
     },
     {
       "id": "senatni-2022-67-a-175924-31",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-175924-32",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-33",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-67-a-175924-34",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-175924-35",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-36",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-37",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes",
       "comment": " V případě že lékařská péče bude dostupná všem stejně a bude se jednat o nadstandard."
     },
     {
       "id": "senatni-2022-67-a-175924-38",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-67-a-175924-39",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-40",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-67-a-175924-41",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-42",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no"
     },
     {
       "id": "senatni-2022-67-a-175924-43",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-67-a-175924-44",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-45",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-175924-46",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-47",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-67-a-175924-48",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-175924-49",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-67-a-175924-50",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-51",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-52",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-67-a-175924-53",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-54",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes",
       "comment": "Podporuji dotace do českého zemědělství  které zajišťuje potraviny,   tvoří krajinu,  podporuje rozšíření služeb na venkově a zamezuje vylidňování. Konkurenceschopnost a zajištění potravinové soběstačnosti je velmi důležité téma ať se jedná o malé či velké zemědělské a potravinářské  podniky."
     },
     {
       "id": "senatni-2022-67-a-175924-55",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-56",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no",
       "comment": "Bytová politika by měla být realizována na úrovni obcí."
     },
     {
       "id": "senatni-2022-67-a-175924-57",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-67-a-175924-58",
       "candidate_id": "senatni-2022-67-c-175924",
-      "question_id": "senatni-2022-67-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-1",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-2",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-3",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-4",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-5",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-6",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-7",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-8",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-9",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-10",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-11",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-12",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-13",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-14",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-15",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-15",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-16",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-16",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-17",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-18",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-18",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-19",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-20",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-21",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-21",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-22",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-22",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-23",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-23",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-24",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-25",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-26",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-27",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-28",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-29",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-30",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-31",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-32",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-33",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-33",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-34",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-35",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-36",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-37",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-38",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-38",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-39",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-40",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-41",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-41",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-42",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-43",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-44",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-45",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-46",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-47",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-48",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-49",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-50",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-51",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-52",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-53",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-54",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-55",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-55",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-56",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-57",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-67-a-405244-58",
+      "candidate_id": "senatni-2022-67-c-405244",
+      "question_id": "senatni-2022-global-q-58",
+      "answer": "yes"
     }
   ]
 }

--- a/data/kalkulacka/senatni-2022/7.json
+++ b/data/kalkulacka/senatni-2022/7.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-7-c-883400",
       "name": "Jiří Valenta",
       "type": "person",
-      "description": "Jiří Valenta - DESCRIPTION",
+      "description": "Jiří Valenta",
       "contacts": {
         "web": [
           {
@@ -506,7 +506,7 @@
         {
           "id": "senatni-2022-7-c-883400-p",
           "name": "Jiří Valenta",
-          "description": "Jiří Valenta - DESCRIPTION",
+          "description": "Jiří Valenta",
           "contacts": {
             "web": [
               {
@@ -534,7 +534,7 @@
       "id": "senatni-2022-7-c-401024",
       "name": "Jan Kůrka",
       "type": "person",
-      "description": "Jan Kůrka - DESCRIPTION",
+      "description": "Jan Kůrka",
       "contacts": {
         "web": [
           {
@@ -548,7 +548,7 @@
         {
           "id": "senatni-2022-7-c-401024-p",
           "name": "Jan Kůrka",
-          "description": "Jan Kůrka - DESCRIPTION",
+          "description": "Jan Kůrka",
           "contacts": {
             "web": [
               {
@@ -566,7 +566,7 @@
       "id": "senatni-2022-7-c-519910",
       "name": "Pavel Šrámek",
       "type": "person",
-      "description": "Pavel Šrámek - DESCRIPTION",
+      "description": "Pavel Šrámek",
       "contacts": {
         "web": [
           {
@@ -586,7 +586,7 @@
         {
           "id": "senatni-2022-7-c-519910-p",
           "name": "Pavel Šrámek",
-          "description": "Pavel Šrámek - DESCRIPTION",
+          "description": "Pavel Šrámek",
           "contacts": {
             "web": [
               {
@@ -610,7 +610,7 @@
       "id": "senatni-2022-7-c-801538",
       "name": "Václav Chaloupek",
       "type": "person",
-      "description": "Václav Chaloupek - DESCRIPTION",
+      "description": "Václav Chaloupek",
       "contacts": {
         "web": [
           {
@@ -625,7 +625,7 @@
         {
           "id": "senatni-2022-7-c-801538-p",
           "name": "Václav Chaloupek",
-          "description": "Václav Chaloupek - DESCRIPTION",
+          "description": "Václav Chaloupek",
           "contacts": {
             "web": [
               {
@@ -644,7 +644,7 @@
       "id": "senatni-2022-7-c-582714",
       "name": "Daniela Kovářová",
       "type": "person",
-      "description": "Daniela Kovářová - DESCRIPTION",
+      "description": "Daniela Kovářová",
       "contacts": {
         "web": [
           {
@@ -667,7 +667,7 @@
         {
           "id": "senatni-2022-7-c-582714-p",
           "name": "Daniela Kovářová",
-          "description": "Daniela Kovářová - DESCRIPTION",
+          "description": "Daniela Kovářová",
           "contacts": {
             "web": [
               {
@@ -694,7 +694,7 @@
       "id": "senatni-2022-7-c-161426",
       "name": "Josef Váňa",
       "type": "person",
-      "description": "Josef Váňa - DESCRIPTION",
+      "description": "Josef Váňa",
       "contacts": {
         "web": [
           {
@@ -708,7 +708,7 @@
         {
           "id": "senatni-2022-7-c-161426-p",
           "name": "Josef Váňa",
-          "description": "Josef Váňa - DESCRIPTION",
+          "description": "Josef Váňa",
           "contacts": {
             "web": [
               {
@@ -726,7 +726,7 @@
       "id": "senatni-2022-7-c-189360",
       "name": "Karel Naxera",
       "type": "person",
-      "description": "Karel Naxera - DESCRIPTION",
+      "description": "Karel Naxera",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/naxerakarel",
@@ -736,7 +736,7 @@
         {
           "id": "senatni-2022-7-c-189360-p",
           "name": "Karel Naxera",
-          "description": "Karel Naxera - DESCRIPTION",
+          "description": "Karel Naxera",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/naxerakarel",
@@ -751,2155 +751,2155 @@
     {
       "id": "senatni-2022-7-a-883400-1",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-2",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-3",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-4",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-5",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-6",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-7",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-883400-8",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-9",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-10",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-11",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-12",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-13",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-14",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-15",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-16",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-17",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-883400-18",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-19",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-20",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-21",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-22",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-23",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-24",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-25",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-26",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-27",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-883400-28",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-29",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-30",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-31",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-32",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-33",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-34",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-35",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-36",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-37",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-38",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-39",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-883400-40",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-41",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-42",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-43",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-44",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-45",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-46",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-47",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-48",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-49",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-50",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-51",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-52",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-53",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-883400-54",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-55",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-883400-56",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-883400-57",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-883400-58",
       "candidate_id": "senatni-2022-7-c-883400",
-      "question_id": "senatni-2022-7-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-1",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-2",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-3",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-4",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-5",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-6",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-7",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-8",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-9",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-10",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-11",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-12",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-13",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-14",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-15",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-16",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-17",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-18",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-19",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-20",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-21",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-22",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-23",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-24",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-25",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-26",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-27",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-28",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-29",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-30",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-31",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-32",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-33",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-34",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-35",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-36",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-37",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-38",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-39",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-40",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-41",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-42",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-43",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-44",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-45",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-46",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-47",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-48",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-49",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-50",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-51",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-52",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-53",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-54",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-55",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-56",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-582714-57",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-582714-58",
       "candidate_id": "senatni-2022-7-c-582714",
-      "question_id": "senatni-2022-7-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-161426-1",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Podporu daň z mimořádného zisku, která se týká bank, energetického průmyslu a zpracovatelů paliv"
     },
     {
       "id": "senatni-2022-7-a-161426-2",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Klíčem je stavět více bytů a ne regulovat nájemné, pokud se nejedná o sociální bydlení"
     },
     {
       "id": "senatni-2022-7-a-161426-3",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "dont_know",
       "comment": "Jsem pro diskusi o tomto tématu, ale bez diskuse není možné tak zásadní otázku rozhodnout"
     },
     {
       "id": "senatni-2022-7-a-161426-4",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Pojďme odvézt auta z center měst a pak řešit rychlovlaky"
     },
     {
       "id": "senatni-2022-7-a-161426-5",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-161426-6",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-161426-7",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-161426-8",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "V tuto chvíli jsem proti jakémukoliv zvyšování daní mimo daně z mimořádného zisku"
     },
     {
       "id": "senatni-2022-7-a-161426-9",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Léčebné účinky jsou prokázané, takže pokud by šlo o léčebné důvody, jsem pro "
     },
     {
       "id": "senatni-2022-7-a-161426-10",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Jakékoliv násilí páchané na bezbranných skupinách obyvatel by mělo být trestané přísněji "
     },
     {
       "id": "senatni-2022-7-a-161426-11",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Ano, je to podobné dani z nečekaného zisku"
     },
     {
       "id": "senatni-2022-7-a-161426-12",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes",
       "comment": " "
     },
     {
       "id": "senatni-2022-7-a-161426-13",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes",
       "comment": "Zejména v době války jsou kybernetické hrozby a dezinformace velmi nebezpečné"
     },
     {
       "id": "senatni-2022-7-a-161426-14",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Méně ale ani více, současná výše je v pořádku"
     },
     {
       "id": "senatni-2022-7-a-161426-15",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-161426-16",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-161426-17",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-161426-18",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-161426-19",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-161426-20",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-161426-21",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "Jsem pro to, aby vše nebylo centralizované jenom v Praze a zatím se dobrovolné snahy míjeli účinkem"
     },
     {
       "id": "senatni-2022-7-a-161426-22",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-161426-23",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-161426-24",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-161426-25",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes",
       "comment": "jsem pro rovné možnosti všech dětí"
     },
     {
       "id": "senatni-2022-7-a-161426-26",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-161426-27",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-161426-28",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-161426-29",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-161426-30",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-161426-31",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-161426-32",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-161426-33",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-161426-34",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-161426-35",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "Měli bychom být připraveni na hrozby, které se v Evropě v poslední době objevují"
     },
     {
       "id": "senatni-2022-7-a-161426-36",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-161426-37",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no",
       "comment": "Jsem pro dostupné zdravotnictví pro všechny "
     },
     {
       "id": "senatni-2022-7-a-161426-38",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no",
       "comment": "Specializovaná pomoc musí být dostupná v každém krajském městě včetně Plzně"
     },
     {
       "id": "senatni-2022-7-a-161426-39",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-161426-40",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-161426-41",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no",
       "comment": "V době hrozeb v podobě války nebo teroristických útoků by to byl krok zpět v bezpečnosti"
     },
     {
       "id": "senatni-2022-7-a-161426-42",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-161426-43",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-161426-44",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes",
       "comment": "Hlavně se musíme stát nezávislými na ruském plynu"
     },
     {
       "id": "senatni-2022-7-a-161426-45",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know",
       "comment": "Nevím, chybí prezentace jeho práce "
     },
     {
       "id": "senatni-2022-7-a-161426-46",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-161426-47",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-161426-48",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-161426-49",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "V současné době jsem spíše pro benevolentnější přístup, protože nikdo neví, kam se ceny energií budou ubírat"
     },
     {
       "id": "senatni-2022-7-a-161426-50",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-161426-51",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-161426-52",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no",
       "comment": "Hlavně se ČR musí stát nezávislou na ruském plynu "
     },
     {
       "id": "senatni-2022-7-a-161426-53",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes",
       "comment": "Finsko i Švédsko má velmi vyspělé a dobře vyzbrojené armády, podpoří to větší bezpečnost ČR "
     },
     {
       "id": "senatni-2022-7-a-161426-54",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "Podporuji rovná přístup pro všechny"
     },
     {
       "id": "senatni-2022-7-a-161426-55",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-161426-56",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes",
       "comment": "Dokud se nezačne stavět více bytů pomůže jakákoliv snaha poskytovat dostupné bydlení"
     },
     {
       "id": "senatni-2022-7-a-161426-57",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-161426-58",
       "candidate_id": "senatni-2022-7-c-161426",
-      "question_id": "senatni-2022-7-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "no",
       "comment": "Opět - jsme pro rovný přístup pro všechny"
     },
     {
       "id": "senatni-2022-7-a-189360-1",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-2",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-3",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-4",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Chápu nutnost dobudování dálniční sítě, ale též považuji za nutné zrychlení železničního spojení Plzeň - Praha, Plzeň - Německo"
     },
     {
       "id": "senatni-2022-7-a-189360-5",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-6",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "Vodu v krajině zadržovat jinými opatřeními"
     },
     {
       "id": "senatni-2022-7-a-189360-7",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-8",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-9",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-10",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-11",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-12",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-13",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-14",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-15",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-16",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-17",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-18",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-19",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "Výjimku by mohly tvořit stavby dotačně podporované"
     },
     {
       "id": "senatni-2022-7-a-189360-20",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-21",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-22",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-189360-23",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-24",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-25",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-26",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-27",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-28",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-29",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-30",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-31",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-32",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-33",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-189360-34",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-35",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-36",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-37",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-38",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-39",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-40",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-41",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-42",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-43",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-44",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-45",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-46",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-47",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-48",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-49",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-50",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-51",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-52",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-53",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-54",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-189360-55",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-189360-56",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-57",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-189360-58",
       "candidate_id": "senatni-2022-7-c-189360",
-      "question_id": "senatni-2022-7-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-1",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Měly by být plně využity např. pro mladé lidi zakládající rodinu nebo pro samoživitelky."
     },
     {
       "id": "senatni-2022-7-a-519910-2",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-3",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Klíčové otázky země by měly být předmětem referenda, aby nebylo rozhodováno \"o nás bez nás\"."
     },
     {
       "id": "senatni-2022-7-a-519910-4",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Dálnice i rychlovlaky jsou stejně důležité."
     },
     {
       "id": "senatni-2022-7-a-519910-5",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-6",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no",
       "comment": "ČR by měla stavět více malých vodních nádrží, rybníky popř. mokřady, to pomůže zadržování vody v krajině a dalším přírodě prospěšným věcem."
     },
     {
       "id": "senatni-2022-7-a-519910-7",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-8",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes",
       "comment": "Zrušením superhrubé mzdy byl nesmysl, politici pomohli jen těm bohatým, to byla velká chyba."
     },
     {
       "id": "senatni-2022-7-a-519910-9",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-10",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-11",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-12",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-13",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-14",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Stávající podpora je dostatečná, všichni musíme teď šetřit, tak i ČT musí šetřit."
     },
     {
       "id": "senatni-2022-7-a-519910-15",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-16",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-17",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-18",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-19",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-20",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-21",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "Praha není pupek světa a ani pupek ČR."
     },
     {
       "id": "senatni-2022-7-a-519910-22",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "yes",
       "comment": "Máme skvělé vědce, tedy určitě ano ve spolupráci s velkými státy."
     },
     {
       "id": "senatni-2022-7-a-519910-23",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Potom budę volit více mladých lidí, a to je dobře. "
     },
     {
       "id": "senatni-2022-7-a-519910-24",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "Jsme průmyslovou zemí, vždy to tak v minulosti bylo a chci, aby to tak bylo i v budoucnosti."
     },
     {
       "id": "senatni-2022-7-a-519910-25",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes",
       "comment": "Ano, protože nejde jen o vzdělání, ale i budování kontaktů dětí z různých sociálních skupin. "
     },
     {
       "id": "senatni-2022-7-a-519910-26",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-27",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-28",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-29",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-30",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-31",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "Současná pomoc je dostatečná."
     },
     {
       "id": "senatni-2022-7-a-519910-32",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no",
       "comment": "ČR bere ohled na změnu klimatu, ale musí používat hlavně zdravý selský rozum."
     },
     {
       "id": "senatni-2022-7-a-519910-33",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Stávající systém je dobrý, není třeba měnit."
     },
     {
       "id": "senatni-2022-7-a-519910-34",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-35",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "dont_know",
       "comment": "Domnívám se, že 1,5% z HDP je dotačující na armádu pro země, které nemají mořskou flotilu. 2% z HDP pak pro země, které mají velké investice hlavně do vojenských lodí."
     },
     {
       "id": "senatni-2022-7-a-519910-36",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Příroda je dokonalá a ta má rozhodnout. Člověk si nemá hrát na boha, vrátí se mu."
     },
     {
       "id": "senatni-2022-7-a-519910-37",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-519910-38",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes",
       "comment": "Specializace by zlevnila celkové výdaje do zdravotnictví. "
     },
     {
       "id": "senatni-2022-7-a-519910-39",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes",
       "comment": "Na pole patří přírodní organická hmota. "
     },
     {
       "id": "senatni-2022-7-a-519910-40",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-41",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-42",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know",
       "comment": "Navrhul bych speciální přidružené členství k EU, to by dle mého názoru postačilo. "
     },
     {
       "id": "senatni-2022-7-a-519910-43",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know",
       "comment": "Navrhul bych partnerský statut k NATO."
     },
     {
       "id": "senatni-2022-7-a-519910-44",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-45",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-46",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-47",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-48",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-49",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-519910-50",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-51",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-52",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "dont_know",
       "comment": "Země střední a východní Evropy by se ale měly dohodnout na postupu. Německo si prosazuje pouze a jen svoje zájmy. Až skončí válka na Ukrajině, situace bude úplně jiná."
     },
     {
       "id": "senatni-2022-7-a-519910-53",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-54",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-519910-55",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-56",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-519910-57",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-519910-58",
       "candidate_id": "senatni-2022-7-c-519910",
-      "question_id": "senatni-2022-7-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Především se má vymáhání pohledávek přenést na ty, co peníze půjčují. Exekutory pak vůbec nebudeme potřebovat."
     },
     {
       "id": "senatni-2022-7-a-401024-1",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-2",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-3",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-401024-4",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-5",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-6",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know",
       "comment": "Dle potřeb. "
     },
     {
       "id": "senatni-2022-7-a-401024-7",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-8",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no",
       "comment": "Již nyní platí vyšší daně. "
     },
     {
       "id": "senatni-2022-7-a-401024-9",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Na doporučení lékaře, při bolestech. "
     },
     {
       "id": "senatni-2022-7-a-401024-10",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-401024-11",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-401024-12",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-13",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "dont_know",
       "comment": "Nesmí být trestáni za názor. "
     },
     {
       "id": "senatni-2022-7-a-401024-14",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-401024-15",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-401024-16",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Mají registrované partnerství. "
     },
     {
       "id": "senatni-2022-7-a-401024-17",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes",
       "comment": "Měli by patřit pod stát - soudy. "
     },
     {
       "id": "senatni-2022-7-a-401024-18",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-401024-19",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-20",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-21",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-22",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-23",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-24",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "I učební obory technické. "
     },
     {
       "id": "senatni-2022-7-a-401024-25",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no",
       "comment": "Dobře zde fungovali speciální školy - zvláštní. Inkluze je hrůza. "
     },
     {
       "id": "senatni-2022-7-a-401024-26",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-27",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "yes",
       "comment": "Dříve se rozpadne, než z ní vystoupíme. "
     },
     {
       "id": "senatni-2022-7-a-401024-28",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-29",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-401024-30",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-31",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "Sami máme problémy. Oni mají své vlády, které si občané daně země volí sami. "
     },
     {
       "id": "senatni-2022-7-a-401024-32",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-401024-33",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-34",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-401024-35",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "Využívat je efektivně, pro obranu státu a jejich občanů. "
     },
     {
       "id": "senatni-2022-7-a-401024-36",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-37",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-38",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no",
       "comment": "Péče a služby by měli být blíže k občanům. "
     },
     {
       "id": "senatni-2022-7-a-401024-39",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-401024-40",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-41",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-401024-42",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-43",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-44",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-45",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-401024-46",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "dont_know",
       "comment": "Měli by nést, ale do určité míry. "
     },
     {
       "id": "senatni-2022-7-a-401024-47",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-401024-48",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know",
       "comment": "Máme již dobré zákony. "
     },
     {
       "id": "senatni-2022-7-a-401024-49",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-50",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-51",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-401024-52",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-7-a-401024-53",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "dont_know",
       "comment": "Nemělo by se rozšiřovat NATO směrem k Rusku. "
     },
     {
       "id": "senatni-2022-7-a-401024-54",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "Pro ty, kteří produkují a dovedou nakrmit obyvatelstvo. "
     },
     {
       "id": "senatni-2022-7-a-401024-55",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-56",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-7-a-401024-57",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-7-a-401024-58",
       "candidate_id": "senatni-2022-7-c-401024",
-      "question_id": "senatni-2022-7-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     }
   ]

--- a/data/kalkulacka/senatni-2022/70.json
+++ b/data/kalkulacka/senatni-2022/70.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-70-c-523255",
       "name": "Radoslav Štědroň",
       "type": "person",
-      "description": "Radoslav Štědroň - DESCRIPTION",
+      "description": "Radoslav Štědroň",
       "contacts": {
         "web": []
       },
@@ -490,7 +490,7 @@
         {
           "id": "senatni-2022-70-c-523255-p",
           "name": "Radoslav Štědroň",
-          "description": "Radoslav Štědroň - DESCRIPTION",
+          "description": "Radoslav Štědroň",
           "contacts": {
             "web": []
           },
@@ -502,7 +502,7 @@
       "id": "senatni-2022-70-c-894640",
       "name": "Zdeněk Nytra",
       "type": "person",
-      "description": "Zdeněk Nytra - DESCRIPTION",
+      "description": "Zdeněk Nytra",
       "contacts": {
         "web": [
           {
@@ -521,7 +521,7 @@
         {
           "id": "senatni-2022-70-c-894640-p",
           "name": "Zdeněk Nytra",
-          "description": "Zdeněk Nytra - DESCRIPTION",
+          "description": "Zdeněk Nytra",
           "contacts": {
             "web": [
               {
@@ -544,7 +544,7 @@
       "id": "senatni-2022-70-c-397158",
       "name": "Liana Janáčková",
       "type": "person",
-      "description": "Liana Janáčková - DESCRIPTION",
+      "description": "Liana Janáčková",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/liana.janackova.1"
@@ -553,7 +553,7 @@
         {
           "id": "senatni-2022-70-c-397158-p",
           "name": "Liana Janáčková",
-          "description": "Liana Janáčková - DESCRIPTION",
+          "description": "Liana Janáčková",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/liana.janackova.1"
@@ -566,7 +566,7 @@
       "id": "senatni-2022-70-c-550066",
       "name": "Miroslav Antl",
       "type": "person",
-      "description": "Miroslav Antl - DESCRIPTION",
+      "description": "Miroslav Antl",
       "contacts": {
         "web": []
       },
@@ -574,7 +574,7 @@
         {
           "id": "senatni-2022-70-c-550066-p",
           "name": "Miroslav Antl",
-          "description": "Miroslav Antl - DESCRIPTION",
+          "description": "Miroslav Antl",
           "contacts": {
             "web": []
           },
@@ -586,7 +586,7 @@
       "id": "senatni-2022-70-c-254017",
       "name": "Peter Harvánek",
       "type": "person",
-      "description": "Peter Harvánek - DESCRIPTION",
+      "description": "Peter Harvánek",
       "contacts": {
         "web": [
           {
@@ -604,7 +604,7 @@
         {
           "id": "senatni-2022-70-c-254017-p",
           "name": "Peter Harvánek",
-          "description": "Peter Harvánek - DESCRIPTION",
+          "description": "Peter Harvánek",
           "contacts": {
             "web": [
               {
@@ -626,7 +626,7 @@
       "id": "senatni-2022-70-c-635788",
       "name": "Patrik Hujdus",
       "type": "person",
-      "description": "Patrik Hujdus - DESCRIPTION",
+      "description": "Patrik Hujdus",
       "contacts": {
         "web": []
       },
@@ -634,7 +634,7 @@
         {
           "id": "senatni-2022-70-c-635788-p",
           "name": "Patrik Hujdus",
-          "description": "Patrik Hujdus - DESCRIPTION",
+          "description": "Patrik Hujdus",
           "contacts": {
             "web": []
           },
@@ -646,7 +646,7 @@
       "id": "senatni-2022-70-c-938712",
       "name": "Hana Zelená",
       "type": "person",
-      "description": "Hana Zelená - DESCRIPTION",
+      "description": "Hana Zelená",
       "contacts": {
         "web": []
       },
@@ -654,7 +654,7 @@
         {
           "id": "senatni-2022-70-c-938712-p",
           "name": "Hana Zelená",
-          "description": "Hana Zelená - DESCRIPTION",
+          "description": "Hana Zelená",
           "contacts": {
             "web": []
           },
@@ -667,1090 +667,1090 @@
     {
       "id": "senatni-2022-70-a-523255-1",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-523255-2",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-523255-3",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "už podle ústavy, zločinci, kteří jsou dnes u moci se referenda bojí jako čert kříže"
     },
     {
       "id": "senatni-2022-70-a-523255-4",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-523255-5",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "to mohou hýkat jen ti co nikdy fysicky nepracovali"
     },
     {
       "id": "senatni-2022-70-a-523255-6",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes",
       "comment": "že jsme střechou Evropy znamená - pokud nám nenaprší, nenasněží jsme bez vody, proto si ji tu musíme schraňovat - na té střeše - kapito?"
     },
     {
       "id": "senatni-2022-70-a-523255-7",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "dont_know",
       "comment": "plechovky ano s petkama je to těžké"
     },
     {
       "id": "senatni-2022-70-a-523255-8",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-523255-9",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-523255-10",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-523255-11",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-523255-12",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-70-a-523255-13",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-70-a-523255-14",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-523255-15",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-523255-16",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "největším vynálezem Boha - je rodina"
     },
     {
       "id": "senatni-2022-70-a-523255-17",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-523255-18",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-523255-19",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-523255-20",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-523255-21",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-523255-22",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no",
       "comment": "třeba  i Jupiter, co?"
     },
     {
       "id": "senatni-2022-70-a-523255-23",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-523255-24",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-523255-25",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-523255-26",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-523255-27",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "yes",
       "comment": "závazným referendem (o jehož výsledku parlament ani nešpitne); víte vůbec, že referendum v roce 2003 rozhodlo pro vstup pouze 3,4 miliony hlasů z celkového počtu voličů, který byl 8 200 000? Víte to? Co? Víte to vůbec?"
     },
     {
       "id": "senatni-2022-70-a-523255-28",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no",
       "comment": "v roce 2003 jsme o podmínkách zavedední Eura, které dnes platí, nevěděli vůbec nic - takže to dnes neplatí, že jsme se k něčemu tehdáž zavázali - rozumíte tomu?"
     },
     {
       "id": "senatni-2022-70-a-523255-29",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes",
       "comment": "je to zločinecká organizace - ale rozhodnutí musí být pouze závazným referendem"
     },
     {
       "id": "senatni-2022-70-a-523255-30",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-523255-31",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "neumíte položit otázku - potřebných na této Zemi jsou 2 miliardy lidí - a nás je tu 10 miliónů, pomáhat se musí jen do míry než se sám neožebračím"
     },
     {
       "id": "senatni-2022-70-a-523255-32",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-523255-33",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-523255-34",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "no",
       "comment": "volně cestovat můžeme i bez něho"
     },
     {
       "id": "senatni-2022-70-a-523255-35",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no",
       "comment": "to vůbec není jenom otázka peněz, závaznýmn referendem se musí rozhodnout o povinné vojenské presenční službě, pro všechny občany ČR"
     },
     {
       "id": "senatni-2022-70-a-523255-36",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "vy jste banda debilů - co si to dovolujete mě na takové hovadiny se ptát? Co si to dovolujete?"
     },
     {
       "id": "senatni-2022-70-a-523255-37",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-523255-38",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-523255-39",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know",
       "comment": "co to je?"
     },
     {
       "id": "senatni-2022-70-a-523255-40",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "proč, někteří řidiči u nás jezdí jako hovada - nic jiné než toto na ně neplatí - kapito?"
     },
     {
       "id": "senatni-2022-70-a-523255-41",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-70-a-523255-42",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no",
       "comment": "jde o jeden z nejzločinějších režimů, rozkradených a zkorumpovaných režimů na světě - jak Vás taková otázka vůbec může napadnout?"
     },
     {
       "id": "senatni-2022-70-a-523255-43",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes",
       "comment": "určitě a Rusové pak budou mít povoleno mít své vojenské základny podél hranic v Kanadě a Mexiku, včetně Kuby"
     },
     {
       "id": "senatni-2022-70-a-523255-44",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "EU má rozhodovat o výši ceny komodit jiného státu?  Co to je za diktatura?"
     },
     {
       "id": "senatni-2022-70-a-523255-45",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-70-a-523255-46",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "no",
       "comment": "proč se mě neptáte na působení skupiny Azov pro politiku ukrajinského současného presidenta? Moudrý člověk se pídí po příčinách problému - vy se mě ptáte po následcích."
     },
     {
       "id": "senatni-2022-70-a-523255-47",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no",
       "comment": "čeští zákonodárřci nechť si přečtou moji analýzu vztahů Ruska a novodobé Ukrajiny, kterou jsem umístil na www.stranaprace.cz v září 201;  stejně si přečtěte komu patřil v dějinách Krym"
     },
     {
       "id": "senatni-2022-70-a-523255-48",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "no",
       "comment": "EU tu není od toho aby buzerovala české muže a ženy, aby zasahovala do soužití českého národa"
     },
     {
       "id": "senatni-2022-70-a-523255-49",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "těžba uhlí je dána konsekvencemi vyplývajícími z Krajíčkova zákona, protože ho neznáte opět se nekompetentně ptáte, vytěžíme všechno uhlí, které na našem území bude těžitelné "
     },
     {
       "id": "senatni-2022-70-a-523255-50",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "věřím, že tento zločinecký spolek už dávno nebude existovat"
     },
     {
       "id": "senatni-2022-70-a-523255-51",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "yes",
       "comment": "a nebo ho přiřkneme Turecku, i když tam dnes žijí z většiny jen Rusové?"
     },
     {
       "id": "senatni-2022-70-a-523255-52",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "a taky to tak bude "
     },
     {
       "id": "senatni-2022-70-a-523255-53",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "no",
       "comment": "já mám rozhodovat za Finy a Švédy - co to je opět za otázku? To je absolutně věc jen těchto dvou národů, jestli chtějí "
     },
     {
       "id": "senatni-2022-70-a-523255-54",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "žádné dotace a nikomu - a žádný dovoz jablek do Česka z Chile, rajčat z Francie, masa z Němec, brambor z Itálie , vinné révy z Jihoafrické republiky atd - a další zhůvěřilosti vymyšlené EU, viz náš cukrovar v Hrochově Týnci"
     },
     {
       "id": "senatni-2022-70-a-523255-55",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no",
       "comment": "zákonnou povinnost - to nevidíte, že Evropskou unií jde svět do háje a ještě bych vymyslel jak dlouho se mám denně sprchovat, mýt zuby a vyprazdňovat"
     },
     {
       "id": "senatni-2022-70-a-523255-56",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no",
       "comment": "víte vůbec, že v Česku je 830 000 neobydlených bytů?"
     },
     {
       "id": "senatni-2022-70-a-523255-57",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know",
       "comment": "to je věc těchto dvou států jak píšu ve své stati viz výše; a ne zločineckých band NATO a EU"
     },
     {
       "id": "senatni-2022-70-a-523255-58",
       "candidate_id": "senatni-2022-70-c-523255",
-      "question_id": "senatni-2022-70-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-1",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-2",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-3",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-4",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-5",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-6",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-70-a-635788-7",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-8",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-9",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-10",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-11",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-12",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-13",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-14",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-15",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-16",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-17",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-18",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-19",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-20",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-21",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-22",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-23",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Ano za předpokladu bezpečné volby. "
     },
     {
       "id": "senatni-2022-70-a-635788-24",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-25",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-26",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-27",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-28",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes",
       "comment": "Ano za předpokladu, že to nebude znamenat zdražení komodit pro české obyvatele a podniky."
     },
     {
       "id": "senatni-2022-70-a-635788-29",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-30",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-31",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-32",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-33",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-34",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-35",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-36",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-37",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-38",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-39",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-40",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-41",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-42",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-43",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-44",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-45",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-70-a-635788-46",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-47",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-48",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-49",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-50",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-51",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-52",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-53",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-54",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-55",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-56",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-635788-57",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-635788-58",
       "candidate_id": "senatni-2022-70-c-635788",
-      "question_id": "senatni-2022-70-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-1",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-2",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-3",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-4",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-5",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-6",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "dont_know",
       "comment": "Nejsem apriori proti stavbě nových přehrad, ale pouze tam, kde to dává smysl"
     },
     {
       "id": "senatni-2022-70-a-894640-7",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "dont_know",
       "comment": "Má to své kladné, ale i záporné stránky, např. zpětná doprava"
     },
     {
       "id": "senatni-2022-70-a-894640-8",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-9",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "no",
       "comment": "U takto položen=é otázky musím odpovědět ne. Co to je \"pro vlastní potřebu\"?"
     },
     {
       "id": "senatni-2022-70-a-894640-10",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-894640-11",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-894640-12",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Je to odpovědnost přispívatele"
     },
     {
       "id": "senatni-2022-70-a-894640-13",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-14",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-15",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no",
       "comment": "regulována ano, ale ne \"výrazně omezena\""
     },
     {
       "id": "senatni-2022-70-a-894640-16",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Práva by měla mít stejná, ale ne název \"manželství\""
     },
     {
       "id": "senatni-2022-70-a-894640-17",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-18",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-19",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "Budeme nutit soukromníka stavět sociální byty?"
     },
     {
       "id": "senatni-2022-70-a-894640-20",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-21",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-22",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-23",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-24",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-894640-25",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-26",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "dont_know",
       "comment": "V podstatě ano, ale nesmí dojít k omezení nadaných dětí"
     },
     {
       "id": "senatni-2022-70-a-894640-27",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-28",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-894640-29",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-30",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-894640-31",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-70-a-894640-32",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-70-a-894640-33",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-34",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-894640-35",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-894640-36",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-37",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-894640-38",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-894640-39",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-894640-40",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-70-a-894640-41",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-894640-42",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know",
       "comment": "ANo, ale musí splnit kritéria"
     },
     {
       "id": "senatni-2022-70-a-894640-43",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know",
       "comment": "Problém s územní celistvostí, nutno nejprve vyřešit"
     },
     {
       "id": "senatni-2022-70-a-894640-44",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-894640-45",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-70-a-894640-46",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-894640-47",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-48",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know",
       "comment": "Důležitý je obsah návrhu směrnice, pak případně ano"
     },
     {
       "id": "senatni-2022-70-a-894640-49",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "dont_know",
       "comment": "Bude záležet na celkové situaci v energetice, spíše ne"
     },
     {
       "id": "senatni-2022-70-a-894640-50",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "Je to nereálný cíl, navíc s ohledem na další části Světa nesmyslný a EU poškozující"
     },
     {
       "id": "senatni-2022-70-a-894640-51",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-52",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-53",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-894640-54",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-70-a-894640-55",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-56",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-57",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-70-a-894640-58",
       "candidate_id": "senatni-2022-70-c-894640",
-      "question_id": "senatni-2022-70-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     }
   ]

--- a/data/kalkulacka/senatni-2022/73.json
+++ b/data/kalkulacka/senatni-2022/73.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-73-c-805498",
       "name": "Daniel Pawlas",
       "type": "person",
-      "description": "Daniel Pawlas - DESCRIPTION",
+      "description": "Daniel Pawlas",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/daniel.pawlas.9, https://www.facebook.com/daniel.pawlas.585"
@@ -491,7 +491,7 @@
         {
           "id": "senatni-2022-73-c-805498-p",
           "name": "Daniel Pawlas",
-          "description": "Daniel Pawlas - DESCRIPTION",
+          "description": "Daniel Pawlas",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/daniel.pawlas.9, https://www.facebook.com/daniel.pawlas.585"
@@ -504,7 +504,7 @@
       "id": "senatni-2022-73-c-245847",
       "name": "Stanislav Folwarczny",
       "type": "person",
-      "description": "Stanislav Folwarczny - DESCRIPTION",
+      "description": "Stanislav Folwarczny",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/StachoFolwarczny",
@@ -514,7 +514,7 @@
         {
           "id": "senatni-2022-73-c-245847-p",
           "name": "Stanislav Folwarczny",
-          "description": "Stanislav Folwarczny - DESCRIPTION",
+          "description": "Stanislav Folwarczny",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/StachoFolwarczny",
@@ -528,7 +528,7 @@
       "id": "senatni-2022-73-c-817015",
       "name": "Zdeněk Matušek",
       "type": "person",
-      "description": "Zdeněk Matušek - DESCRIPTION",
+      "description": "Zdeněk Matušek",
       "contacts": {
         "web": []
       },
@@ -536,7 +536,7 @@
         {
           "id": "senatni-2022-73-c-817015-p",
           "name": "Zdeněk Matušek",
-          "description": "Zdeněk Matušek - DESCRIPTION",
+          "description": "Zdeněk Matušek",
           "contacts": {
             "web": []
           },
@@ -548,7 +548,7 @@
       "id": "senatni-2022-73-c-878616",
       "name": "Gina Horylová",
       "type": "person",
-      "description": "Gina Horylová - DESCRIPTION",
+      "description": "Gina Horylová",
       "contacts": {
         "web": []
       },
@@ -556,7 +556,7 @@
         {
           "id": "senatni-2022-73-c-878616-p",
           "name": "Gina Horylová",
-          "description": "Gina Horylová - DESCRIPTION",
+          "description": "Gina Horylová",
           "contacts": {
             "web": []
           },
@@ -568,7 +568,7 @@
       "id": "senatni-2022-73-c-866259",
       "name": "Petr Hamrozi",
       "type": "person",
-      "description": "Petr Hamrozi - DESCRIPTION",
+      "description": "Petr Hamrozi",
       "contacts": {
         "web": [
           {
@@ -588,7 +588,7 @@
         {
           "id": "senatni-2022-73-c-866259-p",
           "name": "Petr Hamrozi",
-          "description": "Petr Hamrozi - DESCRIPTION",
+          "description": "Petr Hamrozi",
           "contacts": {
             "web": [
               {
@@ -612,7 +612,7 @@
       "id": "senatni-2022-73-c-795375",
       "name": "Petr Gawlas",
       "type": "person",
-      "description": "Petr Gawlas - DESCRIPTION",
+      "description": "Petr Gawlas",
       "contacts": {
         "web": [
           {
@@ -627,7 +627,7 @@
         {
           "id": "senatni-2022-73-c-795375-p",
           "name": "Petr Gawlas",
-          "description": "Petr Gawlas - DESCRIPTION",
+          "description": "Petr Gawlas",
           "contacts": {
             "web": [
               {
@@ -647,758 +647,758 @@
     {
       "id": "senatni-2022-73-a-866259-1",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes",
       "comment": "Určitě je to jedna z cest, jak motivovat k tomu, aby byly byty více využívány. Potkávají se zde dvě roviny - zájem jednotlivce (svoboda vlastníka) a veřejný zájem (nedostatek bytů). Podle mne v tomto by měl veřejný zájem převážit nad zájmy jednotlivce."
     },
     {
       "id": "senatni-2022-73-a-866259-2",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Ne, myslím, že to, jaké podmínky si stanoví majitel, je zcela na něm - je to jeho majetek. Je to pak o dohodě nebo nedohodě s případným nájemcem (partnere). Zároveň bych šel ale druhou cestou, a to začít s novou masívní výstavbou nájemních bytů ve vlastnictví měst, obcí, krajů a státu. Tyto byty by měly být občanům k dispozici za příznivých podmínek. Lidé se pak budou moci rozhodnout pro nájem v bytech vlastněných \"veřejným sektorem\" nebo soukromým. Podmínkou výstavby je také ochrana před budoucí privatizací nebo prodejem - což považuji za hrubou chybu minulých vlád."
     },
     {
       "id": "senatni-2022-73-a-866259-3",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Ano, jsem pro zvýšení prvků přímé demokracie na všech úrovních - městské a obecní, krajské nebo celostátní. Bylo by potřeba ovšem dotáhnout několik s tímto souvisejících otázek."
     },
     {
       "id": "senatni-2022-73-a-866259-4",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "dont_know",
       "comment": "Určitě by měla být výstavba infrastruktury pro rychlovlaky jednou z priorit vlády. Měly by se okamžitě změnit příslušné zákony tak, aby vše šlo výrazně rychleji. Nicméně nesmí se zapomínat na výstavbu i další infrastruktury, která je důležitá pro občany, kteří žijí i v jiných regionech ČR (kde nebudou rychlovlaky). Můj závěr - vše by mělo být na stejné rovině. Měly by být provedeny audity připravenosti a také by měl být jasný přehled  (veřejně dostupný), jak je na tom která stavba (v jaké fázi a kdo to případně brzdí - například který úřad a to by mělo být ihned odstraněno)."
     },
     {
       "id": "senatni-2022-73-a-866259-5",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Ne, to nepovažuji nyní za nutné. Je totiž otázkou, proč by se měl tento věk zvyšovat. Pokud je to kvůli financím, je nutné hledat i jiné zdroje na financování důchodů. A těch možností je několik. Tématu se podrobněji věnuji na svém webu www.petrhamrozi.cz"
     },
     {
       "id": "senatni-2022-73-a-866259-6",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes",
       "comment": "Jednoznačně ano a to z několika důvodů. Jak ve vztahu k hospodaření s vodou, tak k možnému výraznému zvýšení výroby elektrické energie nebo například podpoře regionálního cestovního ruchu a možností relaxace a odpočinku.\nMnohy se ovšem nemusí jednat o přehrady velké, mohou to být i daleko menší, které jsou vhodně zasazeny do dané lokality."
     },
     {
       "id": "senatni-2022-73-a-866259-7",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes",
       "comment": "Ano, systém dobře funguje na Slovensku a v další zemích, proto by to mohlo pomoci i v České republice."
     },
     {
       "id": "senatni-2022-73-a-866259-8",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "dont_know",
       "comment": "Myslím si, že ne. Lidé s vyššími příjmy by neměli být trestáni za to, že se mnohdy snaží daleko více (například mají dvě práce). Téma není jednoduché a argumety pro a proti mnohdy dávají smysl. Nicméně jako společnost se prostě rozhodnout musíme (a žádné z řešení není ideální)."
     },
     {
       "id": "senatni-2022-73-a-866259-9",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes",
       "comment": "Pokud se vlastní potřeba týká zdravotního hlediska  (například léčba některé z nemoci), měli by mít lidé tuto možnost. Pokud je to jen pro zábavu, tak ne."
     },
     {
       "id": "senatni-2022-73-a-866259-10",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes",
       "comment": "Určitě ano."
     },
     {
       "id": "senatni-2022-73-a-866259-11",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes",
       "comment": "Speciální daň asi ne. Nicméně velké společnosti by měly obecně platit stejné daně, jako kterákoliv jiná firma. Tyto společnosti by neměly být danově zvýhodňovány oproti malým firmám.\nZároveň bych rád inicioval změnu příslušné legislativy na národní i celoovropské úrovni, aby i v Evropě mohly začít vznikat takovéto mezinárodní kolosy (a tím přinés evropě a potažmu ČR a jejím regionům daleko větší příjmy) - prostě je nutné zjednodušit podnikání a dát prostor pro vznik nových a zajímavých projektů."
     },
     {
       "id": "senatni-2022-73-a-866259-12",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes",
       "comment": "Částečně ano. Zejména pokud se to týká nenávistného obsahu. Na jedné straně stojí svoboda slova - což je v pořádku, na straně druhé jsou ovšem mnohdy zneužívány k vylévání zlosti a šíření nenávisti - což je špatně."
     },
     {
       "id": "senatni-2022-73-a-866259-13",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "dont_know",
       "comment": "Téma je velmi složité. Je zde totiž otázka, co je fake news a kdo to bude hodnotit (kdo bude hodnoti pravdivost). Je nutné si uvědomit, že i velká (například veřejnoprávní i soukromá média) často sdělují nepravdu nebo zkreslenou pravdu. Proto by se měla v tomto otevřít celospolečenská debata. Obecně byla ale fakt news na všech úrovních měla být omezována nebo dokonce u některých závažných forem trestána. Není možné jen tak svobodně a záměrně šířit lži a nenávist."
     },
     {
       "id": "senatni-2022-73-a-866259-14",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Myslím, že ne. ČT a ČRo dělají mnohdy velmi dobrou práci. Myslím ovšem, že by měly tyto instituce být více hlídány, aby si nedělaly, co chtějí. Je totiž otázka, co znamená svoboda projevu (může si redaktor a novinář napsat co chce? Nebo to má být omezováno - pokud si chce psát podle sebe, může si založit své vlastní médium). Bezpodmínečně by měly  být provedeny také audity hospodaření a veřejně zpřístupňovány některé investice a nákladov (například kolik bereou někteří moderátoři, herci, management a je-li ve veřejném zájmu platit mnohdy královské honoráře a odměny, apod.). Je také nutné provést audit potřebnosti profesí - nnapříklad, zda-li není zbytečá přezaměstnanost na některých pozicích, apod."
     },
     {
       "id": "senatni-2022-73-a-866259-15",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know",
       "comment": "Toto téma je velmi obecné. Nevím, za jakého úhlu pohledu je tato otázka myšlena. Proto se nemohu vyjádřit..."
     },
     {
       "id": "senatni-2022-73-a-866259-16",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Ne. Manželství považuji za obrovský dar. Proto by to měl být výlučně svazek jednoho muže a jedné ženy. Téma manželství pro všechny se objevuje v poslední době velmi často (až podezřele). Je ovšem otázka, co znamená „pro všechny“? Pokud tento termín vezmu\ndoslova, mohou si pak manželství nárokovat prakticky jakékoliv minority (pokud bychom měli být korektní, tak je nutné dát prostor všem minoritám a každému,  kdo si o to řekne). Může se tak například jednat o manželství s malými holčičkami, mnohoženství nebo jakékoliv formy „vztahu“ vyskytující se v různých částech světa. A touto cestou bych já osobně jít opravdu nechtěl."
     },
     {
       "id": "senatni-2022-73-a-866259-17",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes",
       "comment": "Zcela jednoznačně ano. Zároveň by měla být zavedena trestní odpovědnost exekutorů a nutnost náhrady škody u špatně prováděných exekutorů. Zároveň by myl být zaveden nezávislý institut dohlížející nad činnostmi exekutorů (není možné abych jejich práci hodnotili jejich kolegové - evidentní střet zájmů a proto se téměř nikdy nic nevyřeší). Měl by být také zeveden institut státní exekutorů. Stát (a jeho složky - například pojišťovny) by neměl podporovat zhýralost a tento nechutnný business několika soukromých soukromých osob."
     },
     {
       "id": "senatni-2022-73-a-866259-18",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-866259-19",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no",
       "comment": "Soukromí vlastníci by se měli svobodně rozhodnout, co si postaví a komu to nabídnout. Pokud chceme podpořit výstavbu sociálně dostupného bydlení, jsou jiné nástroje - především masivní podpora výstavby bytů ve vlastnictví veřejného sektoru (města, obce, kraje, stát). Tyto byty by pak měly být dustupné za rozumných podmínek."
     },
     {
       "id": "senatni-2022-73-a-866259-20",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no",
       "comment": "Téma není jednoduché. Jsou lidé, kteří pomoc opravdu potřebují a jsou lidé, kteří vše zneužívají. S tímto by se mělo pracovat a podporovat ty, kteří pomoc opravdu potřebují."
     },
     {
       "id": "senatni-2022-73-a-866259-21",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "Ano, toto by mohlo přispět k rozvoji jednotlivých regionů a také ke snížení tlaku na potřebu bytů v Praze. Dnešní doba umožňuje velmi dobré způsoby komunikace na dálku - sdílení dat, telekonference, apod. Proto je tato forma velmi potřebná..."
     },
     {
       "id": "senatni-2022-73-a-866259-22",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know",
       "comment": "V rozumné míře. Jsou ovšem nyní jiné priority pro tuto zemi a pro celou Evropu."
     },
     {
       "id": "senatni-2022-73-a-866259-23",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Mnoha lidem by to jistě pomohlo jít volit a to jak v ČR, tak v zahraničí. Technické možnosti dnes vše umožňují bez problémů."
     },
     {
       "id": "senatni-2022-73-a-866259-24",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "V tuto chvíli ano. Jelikož sami máme aktivity, které podporují tento typ vzdělávání (například projekt Studuj techniku a řemeslo), pokládám toto téma za velmi důležité. Podpora by měla být konkrétní, například finanční již pro žáky SŠ. Forem podpory je několik."
     },
     {
       "id": "senatni-2022-73-a-866259-25",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes",
       "comment": "Ano, nicméně měli by mít na ZŠ daleko více možností rozvíjet své talenty již v ranném věku - pod pojmem talent ovšem nemyslím jen sport, hudbu nebo umění. Ale jsou i jiné formy talentu - například technické dovednosti, apod."
     },
     {
       "id": "senatni-2022-73-a-866259-26",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes",
       "comment": "Ano, ale v rozumné míře. Jsou prostě jedinci, kteří potřebují jít dále mnohem rychleji. Jsou jedinci, u kterých je to složitější. Neměli bychom v rámci \"korektnosti\" výrazně brzdit jedince, kteří potřebují jít rychleji dále - to bychom se jako společnost nikam moc neposunuli. Nehledě na to, že to mnohdy vyčerpává vyučující daleko více a ve finále to škodí všem.\nProto by měly znovu vzniknout instituce, které budou dávat slabším jedincům zvláštní péči."
     },
     {
       "id": "senatni-2022-73-a-866259-27",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "dont_know",
       "comment": "V  tuto  chvíli ne, stále vnímám, že by se mělo udělat vše pro to, aby se EU reformovala a kladl se daleko větší důraz na potřeby menších zemí (ne jen Německa nebo Francie). Jednotlivé země mají být vzájemně partneři. Menší země nemají být vyživány a zneužívány těmi většími...."
     },
     {
       "id": "senatni-2022-73-a-866259-28",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "dont_know",
       "comment": "Zatím ne. Zavedení Eura má své výhody i nevýhoda. Není too jednoznačné. Výhoda je nyní například ve výši úrokové sazby pro firmy i občany. Nevýhoda je ztráta suverenity a další zdražení (tak jak to proběhlo na Slovensku). Proto toto téma není jednoduché a měli bychom si říci jako země, chceme Euro (a za jakých podmínek)  nebo nechceme."
     },
     {
       "id": "senatni-2022-73-a-866259-29",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no",
       "comment": "Nyní v žádném případě. NATO je pro nás zárukou bezpečnosti proti agresorům, nyní zejména Rusku."
     },
     {
       "id": "senatni-2022-73-a-866259-30",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes",
       "comment": "Ano, v tuto chvíli neexistuje dostatečná kapacita v jiných zdrojích."
     },
     {
       "id": "senatni-2022-73-a-866259-31",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes",
       "comment": "Ano, ale ne vše. Záleží na konkrétních projektech a způsobech pomoci. Obecně by to měly být projekty, které pomohou nastartovat další projekty v dané zemi. Nedávat rybářům ryby, ale naučit je tyto ryby chytat  :-)."
     },
     {
       "id": "senatni-2022-73-a-866259-32",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes",
       "comment": "Ano. Nové zákony by měl být přijímány s rozumem a ne fanatismem, jaký jsme doposud u některých z nich viděli (například Green Deal a jiné fanatické a nereálné představy některých organizací)."
     },
     {
       "id": "senatni-2022-73-a-866259-33",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "yes",
       "comment": "Ano, nicméně s příhlédnutím na zemi původu a jejich důvody. Opět ne všem a ne za jakýchkoliv okolností (například u zcela jasných ekonomických migrantů z mnoha zemí Afriky). Zde je totiž otázka, proč migrují - pokud z ekonomických důvodů, měla by Evropa daleko více řešit to (a snažit se pomoci), jak motivovat tyto občany zůstat v dané zemi. Například zvýšením počtu pracovních příležitostí (některé výrobky se nemusí vyrábět v Asii, ale mohou se začít vyrábět v některých částech Afriky, apod.)."
     },
     {
       "id": "senatni-2022-73-a-866259-34",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes",
       "comment": "Ano, je ovšem otázka, zda-li Schengen opravdu funguje po celé Evropě. Schengen má své výhody a žel i nevýhody (a ty je potřeba řešit). Země by měly mít právo zakázaz vstup nepřizpůsobivým jedincům do své země nebo i do jiných zemí Schengenu."
     },
     {
       "id": "senatni-2022-73-a-866259-35",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes",
       "comment": "Ano, bezpečnost země je důležitá. Více peněz ovšem musí jít ruku v ruce audity hospodaření armády a potřebnosti navýšení investic. Musí být prostě jasné, že jsou finance správně vynaloženy - to ale platí i o jiných resortech..."
     },
     {
       "id": "senatni-2022-73-a-866259-36",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Nedokážu si představit, jak by toto mohlo fungovat. Ale nepodporoval bych to. Pokud chtějí mít dítě, měli by respektovat to, že to může být jak chlapeček, tak holčička. I u klasické formy oplodnění si není možné vybrat, kdo se narodí :-)."
     },
     {
       "id": "senatni-2022-73-a-866259-37",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes",
       "comment": "Ano,  měly by být zavedeny i jiné formy, které pomohou šetřit finance ve zdravotnictví nebo mít možnost zvýšení komfortu (péče)."
     },
     {
       "id": "senatni-2022-73-a-866259-38",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know",
       "comment": "Nedokážu přesně posoudit, jak je tato otázka myšlena... Pokud tak, že různá pracoviště mají být i v jiných regionech, tak částečně ano. Vše ovšem záleží na konkrétní odbornosti a využitelnosti. Například některé technologie jsou extrémně drahé a prostě by se tyto technologie ve více městech neuživily (nezaplatily). Naštěstí ČR není tak velká.\nMožná bych v tomto daleko více začal spolupracovat i s okolními, nám, blízkými zeměmi - Slovensko a Polsko."
     },
     {
       "id": "senatni-2022-73-a-866259-39",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-866259-40",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "dont_know",
       "comment": "Ne, v drtivé většině případů pomáhají zvyšovat bezpečnost na některých úsecích. Samozřejmě jsou situace, kdy se jedná o zbytečnou a zcela záměrnou šikanu řidičů - v tom případně ano. Pak tyto systémy nemají být používány."
     },
     {
       "id": "senatni-2022-73-a-866259-41",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know",
       "comment": "Téma je velmi citlivé. Na jedné straně je zde ochrana osobních údajů a soukromí osob. Na druhé straně to může pomoci vyřešit některé trestné činy. Proto by se o tom mělo diskutovat na celospolečenské úrovni, čemu dá společnost jako celek priority..."
     },
     {
       "id": "senatni-2022-73-a-866259-42",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes",
       "comment": "Ano, co nejdříve. Zároveň by se jí mělo maximálně pomoci splnit nutná kritéria. A když by se chtělo, šlo by to rychle..."
     },
     {
       "id": "senatni-2022-73-a-866259-43",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes",
       "comment": "Může to dále pomcoi zvýšit bezpečnost Evropy."
     },
     {
       "id": "senatni-2022-73-a-866259-44",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": "Ne, protože se vše zvrhne a země EU budou distributorům doplácet nehorázné sumy. Nebudou mít snahu snížit cenu v případě omezení spotřeby.\nEvropa by ovšem měla urychleně řešit náhradu za ruský plyn - jak u plynu samotného, tak u innvestic do alternativních zdrojů (třeba solární, vodní nebo větrné technologie). A toto by mohlo pomoci zemím, kde je například více světla nebo větru - třeba Španělsko, Itálie, Chorvatsko, Řecko nebo právě severní Afrika. Zároveň by měly být odstraněny zcela nesmyslné kroky, které zvýšují cenu energií (například emisní povolenky)."
     },
     {
       "id": "senatni-2022-73-a-866259-45",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know",
       "comment": "Moc ne."
     },
     {
       "id": "senatni-2022-73-a-866259-46",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes",
       "comment": "Ano a to ne jen ve vztahu k Ukrajině, ale i celé Evropě. Postup Ruska poškodil nejen Ukrajinu samotnou, ale právě i firmy a občany v EU. A to by nemělo být necháno jen tak. Je ovšem nutné otevřít podporu této nesmyslné války také jiných zemí - Čína, Indie, apod. I tyto země, díky své podpoře Ruska, tuto agresi podporují a současně pomáhají způsobovat problémy Evropě a dalším regionům. I zde by se mělo začít jednat. Tyto země by se měly rozhodnout - zda-li chtějí být na straně Ruska nebo civilizovaného světa."
     },
     {
       "id": "senatni-2022-73-a-866259-47",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-866259-48",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes",
       "comment": "Nicméně nesmí být k této směrnici \"přilepeny\" jiné věci a snahy. Tak jak je to například u tzv. Istambulské dohody."
     },
     {
       "id": "senatni-2022-73-a-866259-49",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Ne, ani později. Uhlí je velmi důležitá komodita v mnoha oborech a ti, kteří toto podporují většinou průmyslu téměř nerozumí. Zároveň, i díky nynější zkušenosti s Ruskem, musíme být samostatní..."
     },
     {
       "id": "senatni-2022-73-a-866259-50",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know",
       "comment": "Co znamená \"klimaticky neutrální\" - není toto pouze o výrobě energie, ale i o výrobě těchto technologií, jejich provozu a následné recyklaci. Proto je nutné maximální úsilí v této oblasti, ale s rozumem a ne pod nátlakem některých ekologických fanatiků nebo tzv. ekoteroristů."
     },
     {
       "id": "senatni-2022-73-a-866259-51",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-866259-52",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-866259-53",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-866259-54",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "dont_know",
       "comment": "I některé velké farmy dělají dobrou práci. Nicméně dotace by měly být obecně spravedlivé pro všechny."
     },
     {
       "id": "senatni-2022-73-a-866259-55",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-866259-56",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-866259-57",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-866259-58",
       "candidate_id": "senatni-2022-73-c-866259",
-      "question_id": "senatni-2022-73-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes",
       "comment": "Samozřejmě je nutné definovat pojem \"bezvýsledné exekuce\". Pokud ti lidé mohou pracovat a svůj dluh splácet, má to být podporováno. Je ovšem otázka, zda-li díky chybě a liknavosti státu se z malých dluhů nestaly dluhy obrovské, kdy lidé už nemají šanci ani motivaci tento dluh splatit - ikdyby praovali dalších 100 let. A to je špatně."
     },
     {
       "id": "senatni-2022-73-a-795375-1",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-2",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes",
       "comment": "Nesmí se stát aby soukromý vlastník nezneužíval stavu s nedostatkem bytů. "
     },
     {
       "id": "senatni-2022-73-a-795375-3",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-4",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "no",
       "comment": "Mělo by se vše dělat současně a se stejnou pripritou"
     },
     {
       "id": "senatni-2022-73-a-795375-5",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-6",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes",
       "comment": "Ano ať jsme soběstační. Například se dají stavět vodní elektrárny."
     },
     {
       "id": "senatni-2022-73-a-795375-7",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-8",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-9",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-10",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-11",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-12",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-13",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-14",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "yes",
       "comment": "Jelikož mají vysílací prostor, kterým mohou získat více peněz od soukromých zadavatelů. "
     },
     {
       "id": "senatni-2022-73-a-795375-15",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-16",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-17",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-18",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-19",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-20",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes",
       "comment": "Měl by se více zajímat o svoje občany."
     },
     {
       "id": "senatni-2022-73-a-795375-21",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-22",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no",
       "comment": "Měla by se více věnovat našim občanům"
     },
     {
       "id": "senatni-2022-73-a-795375-23",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-24",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no",
       "comment": "Každý obor je důležitý."
     },
     {
       "id": "senatni-2022-73-a-795375-25",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-26",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-27",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-28",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-29",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-30",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-31",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "Měli bychom nejdříve pomáhat našim občanů a pak až jiným státům. "
     },
     {
       "id": "senatni-2022-73-a-795375-32",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-33",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-34",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes",
       "comment": "Ale měli bychom mít přehled o lidech kdo sem k nám jde."
     },
     {
       "id": "senatni-2022-73-a-795375-35",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-36",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no",
       "comment": "Každý život ke dar a o pohlaví by měl rozhodovat náhoda."
     },
     {
       "id": "senatni-2022-73-a-795375-37",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-38",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-39",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-40",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no",
       "comment": "Naplňuje to rozpočet obcí."
     },
     {
       "id": "senatni-2022-73-a-795375-41",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-42",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-43",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-44",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-45",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-46",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-47",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-48",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-49",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-50",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-51",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-52",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-53",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "no",
       "comment": "Jelikož chtějí vstoupit až mají strach dříve je to nezajímalo"
     },
     {
       "id": "senatni-2022-73-a-795375-54",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-55",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-56",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-73-a-795375-57",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-73-a-795375-58",
       "candidate_id": "senatni-2022-73-c-795375",
-      "question_id": "senatni-2022-73-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     }
   ]

--- a/data/kalkulacka/senatni-2022/76.json
+++ b/data/kalkulacka/senatni-2022/76.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-76-c-132112",
       "name": "Rudolf Seifert",
       "type": "person",
-      "description": "Rudolf Seifert - DESCRIPTION",
+      "description": "Rudolf Seifert",
       "contacts": {
         "web": [
           {
@@ -496,7 +496,7 @@
         {
           "id": "senatni-2022-76-c-132112-p",
           "name": "Rudolf Seifert",
-          "description": "Rudolf Seifert - DESCRIPTION",
+          "description": "Rudolf Seifert",
           "contacts": {
             "web": [
               {
@@ -514,7 +514,7 @@
       "id": "senatni-2022-76-c-592201",
       "name": "Stanislav Skála",
       "type": "person",
-      "description": "Stanislav Skála - DESCRIPTION",
+      "description": "Stanislav Skála",
       "contacts": {
         "web": []
       },
@@ -522,7 +522,7 @@
         {
           "id": "senatni-2022-76-c-592201-p",
           "name": "Stanislav Skála",
-          "description": "Stanislav Skála - DESCRIPTION",
+          "description": "Stanislav Skála",
           "contacts": {
             "web": []
           },
@@ -534,7 +534,7 @@
       "id": "senatni-2022-76-c-623635",
       "name": "Lucie Pluhařová",
       "type": "person",
-      "description": "Lucie Pluhařová - DESCRIPTION",
+      "description": "Lucie Pluhařová",
       "contacts": {
         "web": []
       },
@@ -542,7 +542,7 @@
         {
           "id": "senatni-2022-76-c-623635-p",
           "name": "Lucie Pluhařová",
-          "description": "Lucie Pluhařová - DESCRIPTION",
+          "description": "Lucie Pluhařová",
           "contacts": {
             "web": []
           },
@@ -554,7 +554,7 @@
       "id": "senatni-2022-76-c-179826",
       "name": "Olga Sehnalová",
       "type": "person",
-      "description": "Olga Sehnalová - DESCRIPTION",
+      "description": "Olga Sehnalová",
       "contacts": {
         "web": [
           {
@@ -573,7 +573,7 @@
         {
           "id": "senatni-2022-76-c-179826-p",
           "name": "Olga Sehnalová",
-          "description": "Olga Sehnalová - DESCRIPTION",
+          "description": "Olga Sehnalová",
           "contacts": {
             "web": [
               {
@@ -596,7 +596,7 @@
       "id": "senatni-2022-76-c-651961",
       "name": "Šárka Jelínková",
       "type": "person",
-      "description": "Šárka Jelínková - DESCRIPTION",
+      "description": "Šárka Jelínková",
       "contacts": {
         "web": [
           {
@@ -619,7 +619,7 @@
         {
           "id": "senatni-2022-76-c-651961-p",
           "name": "Šárka Jelínková",
-          "description": "Šárka Jelínková - DESCRIPTION",
+          "description": "Šárka Jelínková",
           "contacts": {
             "web": [
               {
@@ -646,7 +646,7 @@
       "id": "senatni-2022-76-c-161118",
       "name": "Jana Zwyrtek Hamplová",
       "type": "person",
-      "description": "Jana Zwyrtek Hamplová - DESCRIPTION",
+      "description": "Jana Zwyrtek Hamplová",
       "contacts": {
         "web": [
           {
@@ -659,7 +659,7 @@
         {
           "id": "senatni-2022-76-c-161118-p",
           "name": "Jana Zwyrtek Hamplová",
-          "description": "Jana Zwyrtek Hamplová - DESCRIPTION",
+          "description": "Jana Zwyrtek Hamplová",
           "contacts": {
             "web": [
               {
@@ -677,349 +677,702 @@
     {
       "id": "senatni-2022-76-a-651961-1",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-2",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-3",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-4",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-5",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-6",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-7",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-8",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-9",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-76-a-651961-10",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-11",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-12",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-13",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-14",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-15",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-76-a-651961-16",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-17",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-18",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-76-a-651961-19",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-20",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-21",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-76-a-651961-22",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-76-a-651961-23",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-76-a-651961-24",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-25",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-26",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-27",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-28",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-29",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-30",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-31",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-32",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-33",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-76-a-651961-34",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-35",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-36",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-37",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-38",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-76-a-651961-39",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-40",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-41",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-76-a-651961-42",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-43",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-44",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-45",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-46",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-47",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-48",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-76-a-651961-49",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-50",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-76-a-651961-51",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-52",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-53",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-54",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-55",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-76-a-651961-56",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-76-a-651961-57",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-76-a-651961-58",
       "candidate_id": "senatni-2022-76-c-651961",
-      "question_id": "senatni-2022-76-q-58",
+      "question_id": "senatni-2022-global-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-1",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-2",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-2",
+      "answer": "no",
+      "comment": "Obecní byty regulaci (na zvyšování nájemného) podléhají a to by se mělo zachovat."
+    },
+    {
+      "id": "senatni-2022-76-a-132112-3",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-4",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-5",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-6",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-7",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-8",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-9",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-9",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-10",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-11",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-11",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-12",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-13",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-14",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-15",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-16",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-16",
+      "answer": "no",
+      "comment": "Statut manželstí vychází ze základů naší kultury. Registrovaná partnersví jsou schopana pomoci těmto lidem zvládat případné problémy s úřady apod."
+    },
+    {
+      "id": "senatni-2022-76-a-132112-17",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-18",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-19",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-20",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-20",
+      "answer": "yes",
+      "comment": "Nyní to musejí dělat obce popř. neziskové organizace mnohdy bez podpory státu."
+    },
+    {
+      "id": "senatni-2022-76-a-132112-21",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-22",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-22",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-23",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-24",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-25",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-26",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-26",
+      "answer": "dont_know",
+      "comment": "Ano i ne, zachovat speciální školy pro méně nadané nebo hendikepované je nutnost, ale ne omezovat nadané žáky tím, že se např. výuka zpožďuje."
+    },
+    {
+      "id": "senatni-2022-76-a-132112-27",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-28",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-28",
+      "answer": "dont_know",
+      "comment": "Zatím asi ne, ale asi se tomu nevyhneme."
+    },
+    {
+      "id": "senatni-2022-76-a-132112-29",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-30",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-31",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-32",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-33",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-34",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-35",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-36",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-36",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-37",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-38",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-39",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-40",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-41",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-42",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-43",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-44",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-45",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-46",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-47",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-48",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-49",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-50",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-51",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-52",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-53",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-54",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-55",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-56",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-57",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-76-a-132112-58",
+      "candidate_id": "senatni-2022-76-c-132112",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     }
   ]

--- a/data/kalkulacka/senatni-2022/79.json
+++ b/data/kalkulacka/senatni-2022/79.json
@@ -482,7 +482,7 @@
       "id": "senatni-2022-79-c-228951",
       "name": "Antonín Kuchař",
       "type": "person",
-      "description": "Antonín Kuchař - DESCRIPTION",
+      "description": "Antonín Kuchař",
       "contacts": {
         "web": []
       },
@@ -490,7 +490,7 @@
         {
           "id": "senatni-2022-79-c-228951-p",
           "name": "Antonín Kuchař",
-          "description": "Antonín Kuchař - DESCRIPTION",
+          "description": "Antonín Kuchař",
           "contacts": {
             "web": []
           },
@@ -502,7 +502,7 @@
       "id": "senatni-2022-79-c-231466",
       "name": "Eva Rajchmanová",
       "type": "person",
-      "description": "Eva Rajchmanová - DESCRIPTION",
+      "description": "Eva Rajchmanová",
       "contacts": {
         "web": [
           {
@@ -524,7 +524,7 @@
         {
           "id": "senatni-2022-79-c-231466-p",
           "name": "Eva Rajchmanová",
-          "description": "Eva Rajchmanová - DESCRIPTION",
+          "description": "Eva Rajchmanová",
           "contacts": {
             "web": [
               {
@@ -550,7 +550,7 @@
       "id": "senatni-2022-79-c-623931",
       "name": "Ladislava Brančíková",
       "type": "person",
-      "description": "Ladislava Brančíková - DESCRIPTION",
+      "description": "Ladislava Brančíková",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/profile.php?id=100082698219514"
@@ -559,7 +559,7 @@
         {
           "id": "senatni-2022-79-c-623931-p",
           "name": "Ladislava Brančíková",
-          "description": "Ladislava Brančíková - DESCRIPTION",
+          "description": "Ladislava Brančíková",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/profile.php?id=100082698219514"
@@ -572,7 +572,7 @@
       "id": "senatni-2022-79-c-410558",
       "name": "Lenka Ingrová",
       "type": "person",
-      "description": "Lenka Ingrová - DESCRIPTION",
+      "description": "Lenka Ingrová",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/profile.php?id=100000634963687"
@@ -581,7 +581,7 @@
         {
           "id": "senatni-2022-79-c-410558-p",
           "name": "Lenka Ingrová",
-          "description": "Lenka Ingrová - DESCRIPTION",
+          "description": "Lenka Ingrová",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/profile.php?id=100000634963687"
@@ -594,7 +594,7 @@
       "id": "senatni-2022-79-c-771797",
       "name": "Ivo Vašíček",
       "type": "person",
-      "description": "Ivo Vašíček - DESCRIPTION",
+      "description": "Ivo Vašíček",
       "contacts": {
         "web": [
           {
@@ -612,7 +612,7 @@
         {
           "id": "senatni-2022-79-c-771797-p",
           "name": "Ivo Vašíček",
-          "description": "Ivo Vašíček - DESCRIPTION",
+          "description": "Ivo Vašíček",
           "contacts": {
             "web": [
               {
@@ -634,7 +634,7 @@
       "id": "senatni-2022-79-c-266442",
       "name": "Vítězslav Krabička",
       "type": "person",
-      "description": "Vítězslav Krabička - DESCRIPTION",
+      "description": "Vítězslav Krabička",
       "contacts": {
         "web": [],
         "facebook": "https://www.facebook.com/vitezslav.krabicka"
@@ -643,7 +643,7 @@
         {
           "id": "senatni-2022-79-c-266442-p",
           "name": "Vítězslav Krabička",
-          "description": "Vítězslav Krabička - DESCRIPTION",
+          "description": "Vítězslav Krabička",
           "contacts": {
             "web": [],
             "facebook": "https://www.facebook.com/vitezslav.krabicka"
@@ -656,7 +656,7 @@
       "id": "senatni-2022-79-c-811606",
       "name": "Zbyněk Pastyřík",
       "type": "person",
-      "description": "Zbyněk Pastyřík - DESCRIPTION",
+      "description": "Zbyněk Pastyřík",
       "contacts": {
         "web": [
           {
@@ -670,7 +670,7 @@
         {
           "id": "senatni-2022-79-c-811606-p",
           "name": "Zbyněk Pastyřík",
-          "description": "Zbyněk Pastyřík - DESCRIPTION",
+          "description": "Zbyněk Pastyřík",
           "contacts": {
             "web": [
               {
@@ -689,1456 +689,1456 @@
     {
       "id": "senatni-2022-79-a-771797-1",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-2",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-771797-3",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-4",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-5",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-6",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-7",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-8",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-9",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-10",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-11",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-12",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-13",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-14",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-771797-15",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-16",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-17",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-18",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-19",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-20",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-771797-21",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-22",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-23",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-24",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-25",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-26",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-27",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-28",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-29",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-30",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-31",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-32",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-33",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-34",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-35",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-36",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-37",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-38",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-39",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-40",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-41",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-42",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-43",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-44",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-45",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-46",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-47",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-771797-48",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-49",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-50",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-771797-51",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-771797-52",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-53",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-54",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-55",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-771797-56",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-771797-57",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-771797-58",
       "candidate_id": "senatni-2022-79-c-771797",
-      "question_id": "senatni-2022-79-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-410558-1",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "yes",
       "comment": "Je třeba ale definovat, co to je ,,dlouhodobě\" - měsíce, roky a jak to a kdo to zjistí a co se myslí pod pojmem - ,,prázdný byt\"."
     },
     {
       "id": "senatni-2022-79-a-410558-2",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-410558-3",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Rozhodování občanů přímo - referendem - je zakotveno v Ústavě České republiky."
     },
     {
       "id": "senatni-2022-79-a-410558-4",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "dont_know",
       "comment": "Mám za to, že by mělo být postupováno v souladu s celospolečenským zájmem a ne podle síly té, které betonové lobby."
     },
     {
       "id": "senatni-2022-79-a-410558-5",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no",
       "comment": "Naopak, měla by se přehodnotit současná věková hranice odchodu do důchodu a v první fázi stanovit nižší věkovou hranici odchodu do důchodu u profesí s vysokou fyzickou             \n i psychickou zátěží."
     },
     {
       "id": "senatni-2022-79-a-410558-6",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-410558-7",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "dont_know",
       "comment": "Názory i odborníků se různí a to vzhledem k náročnosti sběru zálohových PET lahví                \ni náročnosti dalšího použití."
     },
     {
       "id": "senatni-2022-79-a-410558-8",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes",
       "comment": "Je to nejen o solidaritě ,,bohatých\" s ,,chudými\", ale i o tom, že podíl ,,bohatých\" na využívání veřejných prostředků je zpravidla svojí mírou vyšší."
     },
     {
       "id": "senatni-2022-79-a-410558-9",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-410558-10",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-410558-11",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-410558-12",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-410558-13",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-410558-14",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-410558-15",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-410558-16",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-410558-17",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-410558-18",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-410558-19",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-410558-20",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-410558-21",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-410558-22",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "no",
       "comment": "Pokud je to otázka míněna vážně, tak u mne vyvolává - 🙂."
     },
     {
       "id": "senatni-2022-79-a-410558-23",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no",
       "comment": "Touto formou nelze zajistit dodržení základních atributů volby - zejména tajnost volebního aktu a zaručit, že takto volí skutečně zapsaný volič."
     },
     {
       "id": "senatni-2022-79-a-410558-24",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "Souhlasím, ale bez dovětku ,,než jiné obory\"."
     },
     {
       "id": "senatni-2022-79-a-410558-25",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "dont_know",
       "comment": "Vždy by měla zůstat možnost individuální volby ze stanovených podmínek."
     },
     {
       "id": "senatni-2022-79-a-410558-26",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no",
       "comment": "Inkluze ve školách je jeden velký omyl. "
     },
     {
       "id": "senatni-2022-79-a-410558-27",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "yes",
       "comment": "A to zavčas!"
     },
     {
       "id": "senatni-2022-79-a-410558-28",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-410558-29",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "yes",
       "comment": "ČR by neměla být členem žádného vojenského bloku."
     },
     {
       "id": "senatni-2022-79-a-410558-30",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-410558-31",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know",
       "comment": "Nejsem proti adresné a konkrétní humanitární pomoci, ale zásadně nesouhlasím s ,,humanitární pomocí\" dodávkami zbraní a vojenské výstroje do oblastí vojenských konfliktů."
     },
     {
       "id": "senatni-2022-79-a-410558-32",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-410558-33",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no",
       "comment": "Naopak, mělo by se zpřísnit."
     },
     {
       "id": "senatni-2022-79-a-410558-34",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-410558-35",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "no",
       "comment": "Pro mne jsou přednější a důležitější výdaje na sociální zabezpečení a na rozvoj společnosti."
     },
     {
       "id": "senatni-2022-79-a-410558-36",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-410558-37",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no",
       "comment": "Se zavedením soukromého připojištění se i výkony rozdělí na ,,standardní a nestandardní\"    \na tím nutně dojde k omezení rozsahu zdravotní péče z veřejných prostředků."
     },
     {
       "id": "senatni-2022-79-a-410558-38",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "dont_know",
       "comment": "To by mohlo vést, spolu s další úpravou, ke snížení dostupnosti péče pro standardně zdravotně pojištěné občany. "
     },
     {
       "id": "senatni-2022-79-a-410558-39",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-410558-40",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-410558-41",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know",
       "comment": "Nedá se zcela vyloučit zneužití."
     },
     {
       "id": "senatni-2022-79-a-410558-42",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "no",
       "comment": "Pokud by z EU Česká republika vystoupila, bylo by na orgánech a zemích EU, koho si do EU přijmou."
     },
     {
       "id": "senatni-2022-79-a-410558-43",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no",
       "comment": "NATO by mělo být rozpuštěno, obdobně jako Varšavská smlouva."
     },
     {
       "id": "senatni-2022-79-a-410558-44",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "no",
       "comment": ",,Zastropovat\" ceny všech energií by měla především Česká republika, bez ohledu na to, zda se v EU dohodnou a jak "
     },
     {
       "id": "senatni-2022-79-a-410558-45",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes",
       "comment": "Dle veřejných informací."
     },
     {
       "id": "senatni-2022-79-a-410558-46",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "dont_know",
       "comment": "Jde o sugestivní a zkratkovou otázku, není jeden viník tohoto stavu, včetně pokračování konfliktu."
     },
     {
       "id": "senatni-2022-79-a-410558-47",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-410558-48",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-410558-49",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "S ohledem na dopady Zelené dohody by mělo dojít co nejdříve k její revizi."
     },
     {
       "id": "senatni-2022-79-a-410558-50",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "no",
       "comment": "Nelze řešit ,,zelenou politiku\" Evropy bez souběžného řešení na ostatních kontinentech, zejména Asie a Ameriky."
     },
     {
       "id": "senatni-2022-79-a-410558-51",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-410558-52",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "yes",
       "comment": "Stejně jako Slovensko, Maďarsko i Německo a další země."
     },
     {
       "id": "senatni-2022-79-a-410558-53",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "no",
       "comment": "Jak jsem uvedla shora, požaduji rozpuštění NATO."
     },
     {
       "id": "senatni-2022-79-a-410558-54",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "Zemědělské dotace by s ohledem na mezinárodní konkurenci měly být poskytovány, tak aby zajistili soběstačnost v zemědělské výrobě České republiky v úrovni 80 %."
     },
     {
       "id": "senatni-2022-79-a-410558-55",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-410558-56",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-410558-57",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know",
       "comment": "To není otázka pro české občany a ani zákonodárce. Rozhodovat o tom budou jiní a jinde..."
     },
     {
       "id": "senatni-2022-79-a-410558-58",
       "candidate_id": "senatni-2022-79-c-410558",
-      "question_id": "senatni-2022-79-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-1",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-2",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-3",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "yes",
       "comment": "Ano, ale s přesně definovanými podmínkami referenda."
     },
     {
       "id": "senatni-2022-79-a-228951-4",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-5",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-6",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes",
       "comment": "Souhlasím, ovšem za podmínky předchozího pečlivě provedeného průzkumu nezbytnosti."
     },
     {
       "id": "senatni-2022-79-a-228951-7",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-8",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-9",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-10",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-11",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-12",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-13",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-14",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-15",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-16",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Nikomu neupírám jeho práva, ale pouze svazek muže a ženy je manželství."
     },
     {
       "id": "senatni-2022-79-a-228951-17",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-18",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-19",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-20",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-21",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "Pokud to pomůže dobré věci, zcela jednoznačně ano."
     },
     {
       "id": "senatni-2022-79-a-228951-22",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-228951-23",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "yes",
       "comment": "Ano, pokud bude zajištěna 100% nezneužitelnost."
     },
     {
       "id": "senatni-2022-79-a-228951-24",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes",
       "comment": "Z důvodu nedostatku řemesel."
     },
     {
       "id": "senatni-2022-79-a-228951-25",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-26",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-27",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-28",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-29",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-30",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-31",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-228951-32",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-33",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-34",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-35",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-36",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-228951-37",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-38",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-39",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "no",
       "comment": "Ne zákaz, ale omezení používání."
     },
     {
       "id": "senatni-2022-79-a-228951-40",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-41",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-42",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "yes",
       "comment": "Ano, za splnění vstupních podmínek."
     },
     {
       "id": "senatni-2022-79-a-228951-43",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-228951-44",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-45",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-46",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-47",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-48",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-49",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "Za současné energetické krize ne."
     },
     {
       "id": "senatni-2022-79-a-228951-50",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-51",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-52",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-53",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-54",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-228951-55",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-56",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no",
       "comment": "Tato provomoc by měla zůstat v kompetenci obcí a měst."
     },
     {
       "id": "senatni-2022-79-a-228951-57",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-228951-58",
       "candidate_id": "senatni-2022-79-c-228951",
-      "question_id": "senatni-2022-79-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-811606-1",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-1",
+      "question_id": "senatni-2022-global-q-1",
       "answer": "no",
       "comment": "Definujme pojem \"dlouhodobě prázdný byt\" a jak by se posuzoval, když nás státním systém neeviduje tzv. přechodné pobyty."
     },
     {
       "id": "senatni-2022-79-a-811606-2",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-2",
+      "question_id": "senatni-2022-global-q-2",
       "answer": "no",
       "comment": "Nikoliv, ale naopak by ČR přijmout nástroje rozšíření bytové nabídky a zlepšení dostupnosti bydlení, zejména výstavbou a pronájmem státních, obecních a družstevních bytů, tak jako tomu je například ve Vídni."
     },
     {
       "id": "senatni-2022-79-a-811606-3",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-3",
+      "question_id": "senatni-2022-global-q-3",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-811606-4",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-4",
+      "question_id": "senatni-2022-global-q-4",
       "answer": "dont_know",
       "comment": "Výstavba liniových staveb silniční a železniční povahy je stejně důležitá, nejdůležitější je však infrastruktura pro energetiku."
     },
     {
       "id": "senatni-2022-79-a-811606-5",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-5",
+      "question_id": "senatni-2022-global-q-5",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-811606-6",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-6",
+      "question_id": "senatni-2022-global-q-6",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-811606-7",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-7",
+      "question_id": "senatni-2022-global-q-7",
       "answer": "no",
       "comment": "Protože zálohování pouze upravuje problematiku třídění odpadů, avšak třídění odpadů je u nás velmi dobré, problémem je následná recyklace vytříděných odpadů, což zálohování stejně neřeší a odčerpává zdroje finančních prostředků z oblasti odpadového hospodářství."
     },
     {
       "id": "senatni-2022-79-a-811606-8",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-8",
+      "question_id": "senatni-2022-global-q-8",
       "answer": "yes",
       "comment": "Spíše ano, vzhledem k současné ekonomické situaci."
     },
     {
       "id": "senatni-2022-79-a-811606-9",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-9",
+      "question_id": "senatni-2022-global-q-9",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-811606-10",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-10",
+      "question_id": "senatni-2022-global-q-10",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-811606-11",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-11",
+      "question_id": "senatni-2022-global-q-11",
       "answer": "dont_know",
       "comment": "Spíše ano."
     },
     {
       "id": "senatni-2022-79-a-811606-12",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-12",
+      "question_id": "senatni-2022-global-q-12",
       "answer": "no",
       "comment": "Zodpovědní mají být především uživatelé a to jak \"publikující\" tak \"sledující.\" "
     },
     {
       "id": "senatni-2022-79-a-811606-13",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-13",
+      "question_id": "senatni-2022-global-q-13",
       "answer": "dont_know",
       "comment": "Kdo o tom bude rozhodovat, co je \"pravda.\" ? nějaký nejvyšší úřad pseudocenzora? "
     },
     {
       "id": "senatni-2022-79-a-811606-14",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-14",
+      "question_id": "senatni-2022-global-q-14",
       "answer": "no",
       "comment": "Avšak pozor, veřejnoprávní média by měla hospodařit zodpovědněji."
     },
     {
       "id": "senatni-2022-79-a-811606-15",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-15",
+      "question_id": "senatni-2022-global-q-15",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-811606-16",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-16",
+      "question_id": "senatni-2022-global-q-16",
       "answer": "no",
       "comment": "Otázka je nepřesná. Manželství je svazek muže a ženy. "
     },
     {
       "id": "senatni-2022-79-a-811606-17",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-17",
+      "question_id": "senatni-2022-global-q-17",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-811606-18",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-18",
+      "question_id": "senatni-2022-global-q-18",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-811606-19",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-19",
+      "question_id": "senatni-2022-global-q-19",
       "answer": "dont_know",
       "comment": "Definujme nejprve co je \"sociální byt\" když například z hlediska snížení sazby DPH je již dnes většina bytů sociálním bydlením."
     },
     {
       "id": "senatni-2022-79-a-811606-20",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-20",
+      "question_id": "senatni-2022-global-q-20",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-811606-21",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-21",
+      "question_id": "senatni-2022-global-q-21",
       "answer": "yes",
       "comment": "Ale to je zavádějící otázka. Hlavně potřebuje decentralizaci a reformu veřejné správy v čele s obnovením země Moravskoslezské."
     },
     {
       "id": "senatni-2022-79-a-811606-22",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-22",
+      "question_id": "senatni-2022-global-q-22",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-811606-23",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-23",
+      "question_id": "senatni-2022-global-q-23",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-811606-24",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-24",
+      "question_id": "senatni-2022-global-q-24",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-811606-25",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-25",
+      "question_id": "senatni-2022-global-q-25",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-811606-26",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-26",
+      "question_id": "senatni-2022-global-q-26",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-811606-27",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-27",
+      "question_id": "senatni-2022-global-q-27",
       "answer": "no",
       "comment": "Ovšem EU se musí reformovat. Zachovat suverenitu členských států a odstranit snahy o většinovém hlasování s odstraněním \"práva veta.\""
     },
     {
       "id": "senatni-2022-79-a-811606-28",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-28",
+      "question_id": "senatni-2022-global-q-28",
       "answer": "dont_know",
       "comment": "Ano, ovšem nyní ani v nadcházejících pár letech nikoliv. Naše ekonomika na to není ještě připravena."
     },
     {
       "id": "senatni-2022-79-a-811606-29",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-29",
+      "question_id": "senatni-2022-global-q-29",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-811606-30",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-30",
+      "question_id": "senatni-2022-global-q-30",
       "answer": "dont_know",
       "comment": "Místo ČR je především uprostřed Střední Evropy, v rámci V4."
     },
     {
       "id": "senatni-2022-79-a-811606-31",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-31",
+      "question_id": "senatni-2022-global-q-31",
       "answer": "no",
       "comment": "Tuto součanou pomoc našeho státu považuji za dostatečnou. Nezapomínejme na pomoc našim ohroženým či zranitelným občanům."
     },
     {
       "id": "senatni-2022-79-a-811606-32",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-32",
+      "question_id": "senatni-2022-global-q-32",
       "answer": "no",
       "comment": "Velmi divná otázka. "
     },
     {
       "id": "senatni-2022-79-a-811606-33",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-33",
+      "question_id": "senatni-2022-global-q-33",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-811606-34",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-34",
+      "question_id": "senatni-2022-global-q-34",
       "answer": "yes",
       "comment": "Ano, ale za podmínky důrazné a funkční ochrany vnější hranice Schengenu."
     },
     {
       "id": "senatni-2022-79-a-811606-35",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-35",
+      "question_id": "senatni-2022-global-q-35",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-811606-36",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-36",
+      "question_id": "senatni-2022-global-q-36",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-811606-37",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-37",
+      "question_id": "senatni-2022-global-q-37",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-811606-38",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-38",
+      "question_id": "senatni-2022-global-q-38",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-811606-39",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-39",
+      "question_id": "senatni-2022-global-q-39",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-811606-40",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-40",
+      "question_id": "senatni-2022-global-q-40",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-811606-41",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-41",
+      "question_id": "senatni-2022-global-q-41",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-811606-42",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-42",
+      "question_id": "senatni-2022-global-q-42",
       "answer": "dont_know",
       "comment": "Velmi ale velmi předčasná otázka. Ano, možná někdy v budoucnu po splnění všech podmínek přístupových rozhovorů."
     },
     {
       "id": "senatni-2022-79-a-811606-43",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-43",
+      "question_id": "senatni-2022-global-q-43",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-811606-44",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-44",
+      "question_id": "senatni-2022-global-q-44",
       "answer": "yes",
       "comment": "Ale vlastně proč, když EU nechce odebírat Ruský plyn."
     },
     {
       "id": "senatni-2022-79-a-811606-45",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-45",
+      "question_id": "senatni-2022-global-q-45",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-811606-46",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-46",
+      "question_id": "senatni-2022-global-q-46",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-811606-47",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-47",
+      "question_id": "senatni-2022-global-q-47",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-811606-48",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-48",
+      "question_id": "senatni-2022-global-q-48",
       "answer": "dont_know",
       "comment": "Přiznávám, že v této oblasti musím nejprve načerpat hlubší informace."
     },
     {
       "id": "senatni-2022-79-a-811606-49",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-49",
+      "question_id": "senatni-2022-global-q-49",
       "answer": "no",
       "comment": "A hlavně, staré technologie (spalování uhlí) mají být nahrazovány novými technologiemi na základě principu tržního hospodářství a efektivity novějších technologií při jejich provozním zlevnění apod."
     },
     {
       "id": "senatni-2022-79-a-811606-50",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-50",
+      "question_id": "senatni-2022-global-q-50",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-811606-51",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-51",
+      "question_id": "senatni-2022-global-q-51",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-811606-52",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-52",
+      "question_id": "senatni-2022-global-q-52",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-811606-53",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-53",
+      "question_id": "senatni-2022-global-q-53",
       "answer": "yes"
     },
     {
       "id": "senatni-2022-79-a-811606-54",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-54",
+      "question_id": "senatni-2022-global-q-54",
       "answer": "no",
       "comment": "Dnes je bohužel v EU nastavena zemědělská politika pro naše zemědělství tak špatně, že není možné dotovat jen některé malé farmy."
     },
     {
       "id": "senatni-2022-79-a-811606-55",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-55",
+      "question_id": "senatni-2022-global-q-55",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-811606-56",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-56",
+      "question_id": "senatni-2022-global-q-56",
       "answer": "no"
     },
     {
       "id": "senatni-2022-79-a-811606-57",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-57",
+      "question_id": "senatni-2022-global-q-57",
       "answer": "dont_know"
     },
     {
       "id": "senatni-2022-79-a-811606-58",
       "candidate_id": "senatni-2022-79-c-811606",
-      "question_id": "senatni-2022-79-q-58",
+      "question_id": "senatni-2022-global-q-58",
       "answer": "no"
     }
   ]


### PR DESCRIPTION
To be able to reuse answers between different senate districts their corresponding questions have to have the same id. To achieve that, there is special "global" district. So senate questions are referring to `global` districts. When JSONs were generated real districts were used => there was mismatch => it was not working. Now we generate ids during parsing and then they are just used.

Previous PR with fixes - #114 

# :school: Testing
* `backend` - generate data - `make run-converter`
* `backend` - add images - `make run-add-images`./validate`
* `schemas` - check that generated files are valid - `