### PR TITLE
VK-201: Add support for ordering questions

### DIFF
--- a/data/kalkulacka/komunalni-2022/554782.json
+++ b/data/kalkulacka/komunalni-2022/554782.json
@@ -13,156 +13,12 @@
   },
   "questions": [
     {
-      "id": "komunalni-2022-554782-q-1",
-      "name": "Gentrifikace",
-      "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
-      "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
-      "detail": "",
-      "tags": ["Bydlení"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-2",
-      "name": "Poplatek za popelnice",
-      "title": "Má město účtovat poplatek za svoz komunálního odpadu?",
-      "gist": "Odpůrci tento poplatek považují za zbytečný; jedná se podle nich jen o jakousi „skrytou“ daň. Zastánci poplatku odmítají takový zásah do rozpočtu města na úkor důležitějších položek, přenesením zátěže na město.",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-3",
-      "name": "Omezení vytápění",
-      "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
-      "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
-      "detail": "",
-      "tags": ["Úspora energií"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-4",
-      "name": "Zóny 30 km/h",
-      "title": "Měly by se ve městě rozšířit zóny, kde mají auta povoleno jet max 30 km/h.?",
-      "gist": "Obecně platí, že v obci smí vozidlo jet maximálně rychlostí 50 km/h. Zóny 30 (km/h) jsou podle zastánců levné opatření pro zklidňování dopravy v městské zástavbě a v některých evropských zemích se používají více než 20 let. Odpůrci to považují za brždění provozu a komplikaci dopravy.",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-5",
-      "name": "Milostivé léto",
-      "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
-      "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
-      "detail": "Milostivé léto je akce, která napomáhá splatit tzv. veřejnoprávní dluhy vymáhané exekučně. Zákonodárci neplánují, že by se měla v budoucnu zopakovat.",
-      "tags": ["Sociální podpora"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-6",
-      "name": "Více kamer",
-      "title": "Měly by být ve městě instalovány další kamery?",
-      "gist": "Zastánci uvádějí zvýšení bezpečnosti problémových lokalit, odpůrci zdůrazňují přílišný zásah do osobních práv a přesun kriminality do jiných míst.",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-7",
-      "name": "Hazard zakázán",
-      "title": "Jste pro úplný zákaz hazardu na území města?",
-      "gist": "Příznivci zákazu argumentují sociálními problémy plynoucími z hazardu. Odpůrci zmiňují svobodu podnikání a finance, které město získá na daních.",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-8",
-      "name": "MHD zdarma",
-      "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
-      "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
-      "detail": "",
-      "tags": ["Doprava"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-9",
-      "name": "Bezbariérové zastávky MHD",
-      "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
-      "gist": "",
-      "detail": "",
-      "tags": ["Doprava"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-10",
-      "name": "Jmenovité výsledky hlasování zastupitelstva",
-      "title": "Hlasování členů zastupitelstva města se má zveřejňovat jmenovitě.",
-      "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v zastupitelstvu města hlasuje. Kritici to považují za zbytečné.",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-11",
-      "name": "Jmenovité výsledky hlasování rady",
-      "title": "Hlasování členů rady města se má zveřejňovat jmenovitě.",
-      "gist": "Podle zastánců je pro veřejnou kontrolu důležité vidět, jak přesně kdo v radě města hlasuje. Kritici to považují za zbytečné.",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-12",
-      "name": "Regulace zábavní pyrotechniky",
-      "title": "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
-      "gist": "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-13",
-      "name": "Přístupné veřejné budovy v chladnu",
-      "title": "Město by v topné sezóně mělo zpřístupnit některé veřejné budovy lidem jen pro zahřátí.",
-      "gist": "Některá evropská města zvažují, že veřejnosti zpřístupní knihovny, komunitní centra či umělecké galerie, aby se zde mohli v nadcházející zimě zahřát ti, kdo si nemohou dovolit vytápět své domovy.",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-14",
-      "name": "Úspora energií – světelná výzdoba",
-      "title": "Kvůli úspoře energií by město mělo omezovat noční nasvícení kulturních památek.",
-      "gist": "",
-      "detail": "",
-      "tags": []
-    },
-    {
       "id": "komunalni-2022-554782-q-15",
       "name": "Úspora energií – veřejné osvětlení",
       "title": "Má město kvůli úspoře energií omezovat veřejné osvětlení?",
       "gist": "Kvůli energetické krizi řada měst v Rakousku, Německu, Francii a Itálii omezuje pouliční osvětlení, některé obce ho v noci vypnou úplně. Vypnutí světel na tři a půl hodiny každou noc má snížit spotřebu energie cca o čtvrtinu. Kritici namítají, že se zhorší bezpečnost ve městě.",
       "detail": "",
       "tags": ["Úspora energií"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-16",
-      "name": "Úspora energií – omezení vytápění",
-      "title": "V topné sezóně by se mělo omezit vytápění v městských budovách.",
-      "gist": "Např. v sousedním Německu nyní plánují, že veřejné budovy se až na výjimky (např. školy) budou z důvodu úspor energie vytápět max. na 19 C.",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-17",
-      "name": "Konec dětských exekucí",
-      "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
-      "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
-      "detail": "",
-      "tags": ["Sociální podpora"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-18",
-      "name": "Městské transparentní účty",
-      "title": "Má mít město transparentní účty, do kterých lze veřejně nahlížet?",
-      "gist": "Zastánci uvádějí nutnost kontroly toho, jak město s penězi nakládá. Odpůrci se domnívají, že je to komplikované a že hrozí únik osobních údajů.",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-19",
-      "name": "Participativní rozpočet",
-      "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
-      "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
-      "detail": "",
-      "tags": ["Občanská společnost"]
     },
     {
       "id": "komunalni-2022-554782-q-20",
@@ -173,36 +29,44 @@
       "tags": ["Bydlení"]
     },
     {
-      "id": "komunalni-2022-554782-q-21",
-      "name": "Omezení vánoční výzdoby",
-      "title": "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
-      "gist": "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-22",
-      "name": "Regulovaný nájem",
-      "title": "Nájem v městských bytech by se měl regulovat.",
-      "gist": "Kritici poukazují, že by snížené příjmy z nájmů vedly k zanedbávání těchto bytů i celých budov. Zastánci by tím chtěli mírnit růst cen nájemného.",
+      "id": "komunalni-2022-554782-q-30",
+      "name": "Zdanění prázdných bytů",
+      "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
+      "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
       "detail": "",
       "tags": ["Bydlení"]
     },
     {
-      "id": "komunalni-2022-554782-q-23",
-      "name": "Obědy zdarma",
-      "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
-      "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
+      "id": "komunalni-2022-554782-q-1",
+      "name": "Gentrifikace",
+      "title": "V žádaných městských částech mají bydlet jen ti, kdo si to mohou finančně dovolit.",
+      "gist": "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
       "detail": "",
-      "tags": ["Sociální podpora"]
+      "tags": ["Bydlení"]
     },
     {
-      "id": "komunalni-2022-554782-q-24",
-      "name": "Sdílení aut",
-      "title": "Je třeba, aby město podporovalo sdílení aut (tzv. carsharing).",
-      "gist": "Podle zastánců má sdílení vozů pomoci odlehčit dopravu ve městě. Kritici poukazují, že carsharingové společnosti pouze moderním druhem autopůjčovny, která je dostupnější a pohodlnější.",
+      "id": "komunalni-2022-554782-q-8",
+      "name": "MHD zdarma",
+      "title": "Měla by být městská hromadná doprava pro všechny rezidenty zdarma?",
+      "gist": "Zastánci zrušení jízdného argumentují zlepšením životního prostředí, zklidnění dopravy i úsporami za tisk lístků nebo vedení agendy s vymáháním dlužného jízdného. Odpůrci tvrdí, že se jedná o nehospodárné nakládání s veřejnými prostředky. Podle jiných by to příliš zatížilo městský rozpočet.",
       "detail": "",
-      "tags": []
+      "tags": ["Doprava"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-58",
+      "name": "Vzdělávání - gymnázia",
+      "title": "Praha by měla navýšit kapacitu čtyřletých gymnázií.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Vzdělávání"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-59",
+      "name": "Vzdělávání - střední školy",
+      "title": "Praha by měla podporovat vznik nových gymnaziálních tříd v rámci jiných středních škol.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Vzdělávání"]
     },
     {
       "id": "komunalni-2022-554782-q-25",
@@ -229,12 +93,20 @@
       "tags": ["Bydlení"]
     },
     {
-      "id": "komunalni-2022-554782-q-28",
-      "name": "Podíl developerů na veřejných výdajích",
-      "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
-      "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
-      "detail": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
-      "tags": ["Developeři"]
+      "id": "komunalni-2022-554782-q-22",
+      "name": "Regulovaný nájem",
+      "title": "Nájem v městských bytech by se měl regulovat.",
+      "gist": "Kritici poukazují, že by snížené příjmy z nájmů vedly k zanedbávání těchto bytů i celých budov. Zastánci by tím chtěli mírnit růst cen nájemného.",
+      "detail": "",
+      "tags": ["Bydlení"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-61",
+      "name": "Obavy z gentrifikace",
+      "title": "V okolí Vltavské filharmonie by měla Praha zachovat dostupné bydlení.",
+      "gist": "Zastánci poukazují, že s větší atraktivitou oblasti narostou ceny nemovitostí i nájmů a že dojde k odlivu původních obyvatel.",
+      "detail": "Součástí nové budovy Vltavské filharmonie má být hlavní koncertní sál pro 1800 diváků, malý sál pro 700 posluchačů, dále multifunkční sál a prostory pro menší akce a konference pro 200 návštěvníků. V nové budově bude sídlit Česká filharmonie, Symfonický orchestr hlavního města Prahy a hudební oddělení Městské knihovny. Plánuje se také vybudování zkušeben a studií a kavárny a restaurace.",
+      "tags": ["Bydlení"]
     },
     {
       "id": "komunalni-2022-554782-q-29",
@@ -245,38 +117,6 @@
       "tags": ["Doprava"]
     },
     {
-      "id": "komunalni-2022-554782-q-30",
-      "name": "Zdanění prázdných bytů",
-      "title": "Dlouhodobě prázdné byty by měly být více zdaněné.",
-      "gist": "Krok má odrazovat od nákupu investičních bytů. Ty podle zastánců zdanění vyčerpávají bytové zásoby a zhoršují situaci pro lidi s nízkými a středními příjmy, kteří si chtějí zajistit vlastní bydlení. Podle kritiků se zvýší ceny nemovitostí a nájemní bydlení podraží. V ČR je jednotný výpočet daně pro všechny byty bez ohledu na to, kolik bytů majitel vlastní a zda jsou dlouhodobě obydlené.",
-      "detail": "",
-      "tags": ["Bydlení"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-31",
-      "name": "Podíl developerů na veřejných výdajích",
-      "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
-      "gist": "",
-      "detail": "",
-      "tags": ["Developeři"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-32",
-      "name": "Dobíjecí místa pro elektromobily",
-      "title": "Město má podporovat budování dobíjecích míst pro elektromobily.",
-      "gist": "",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-33",
-      "name": "Podpora družstevního bydlení",
-      "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
-      "gist": "",
-      "detail": "",
-      "tags": ["Bydlení"]
-    },
-    {
       "id": "komunalni-2022-554782-q-34",
       "name": "MHD zdarma do 18 let",
       "title": "Děti do 18 let mají mít MHD zdarma.",
@@ -285,92 +125,12 @@
       "tags": ["Doprava"]
     },
     {
-      "id": "komunalni-2022-554782-q-35",
-      "name": "Fotovoltaika na soukromých střechách",
-      "title": "Město má pomoci vlastníkům bytových domů s instalací fotovoltaických panelů na střeše.",
-      "gist": "",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-36",
-      "name": "Vstupné na kulturu a sport",
-      "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
-      "gist": "",
-      "detail": "",
-      "tags": ["Volný čas"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-37",
-      "name": "Menstruační pomůcky v městských budovách",
-      "title": "Na všech městských veřejných toaletách (na úřadech, v knihovnách apod.) mají být volně dostupné menstruační pomůcky.",
-      "gist": "Podobně jako bývá dnes na všech toaletách mýdlo nebo toaletní papír.",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-38",
-      "name": "Menstruační pomůcky –vydávání zdarma",
-      "title": "Místní úřady mají mít zákonnou povinnost poskytovat vložky či tampony bezplatně každému, kdo je potřebuje.",
-      "gist": "Některé ženy, např. samoživitelky, navíc s dospívajícími dcerami, pro svůj nízký příjem nemají přístup k adekvátním menstruačním pomůckám. Zastánci argumentují rovností a důstojností ve společnosti a tím, že toaletní papír či mýdlo jsou ve veřejných budovách běžně dostupné. Odpůrci to považují za finančně nákladné či nespravedlivé vůči lidem, kteří menstruaci nemají.",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-39",
-      "name": "Fotovoltaika na městské budovy",
-      "title": "Město má investovat do fotovoltaických panelů na střechách městských budov.",
-      "gist": "",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-40",
-      "name": "Elektrické koloběžky",
-      "title": "Město má podporovat rozvoj dopravy na elektrických koloběžkách a podobných dopravních prostředcích.",
-      "gist": "",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-41",
-      "name": "Integrace cizinců",
-      "title": "Město by mělo aktivně prosazovat integraci cizinců žijících ve městě.",
-      "gist": "",
-      "detail": "",
-      "tags": []
-    },
-    {
-      "id": "komunalni-2022-554782-q-42",
-      "name": "Více strážníků",
-      "title": "Mělo by být více městských strážníků?",
-      "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
-      "detail": "",
-      "tags": ["Bezpečnost"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-43",
-      "name": "Zelené střechy",
-      "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
-      "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
-      "detail": "Klasické střechy mohou mít až 70 stupňů, teplota ozeleněné střechy se blíží například trávníku v okolí.",
-      "tags": ["Klimatické změny"]
-    },
-    {
       "id": "komunalni-2022-554782-q-44",
       "name": "Cyklodoprava",
       "title": "Město by mělo podporovat dopravu obyvatel do práce či do školy na kole.",
       "gist": "Výhody cyklodopravy jsou podle zastánců nízký zábor veřejného prostoru, snižování dopravních zácp, zlepšení ovzduší či kladný vliv na lidské fyzické i mentální zdraví cyklistů. Odpůrci to považují za komplikaci pro autodopravu, za zbytečnost nebo za nedostatečně chráněný způsob dopravy. Cyklisté by měli jezdit po cyklostezkách, kde je neohrožují auta.",
       "detail": "",
       "tags": ["Doprava"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-45",
-      "name": "Podpora profesionálního sportu",
-      "title": "Souhlasím, aby město finančně podporovalo profesionální sport ve městě.",
-      "gist": "",
-      "detail": "",
-      "tags": []
     },
     {
       "id": "komunalni-2022-554782-q-46",
@@ -397,28 +157,84 @@
       "tags": ["Bydlení"]
     },
     {
+      "id": "komunalni-2022-554782-q-3",
+      "name": "Omezení vytápění",
+      "title": "Mělo by město v případě nouze začít omezovat vytápění v domovech pro seniory?",
+      "gist": "Zastánci omezování tvrdí, že nejen domácnosti, ale i samosprávy mohou mít potíže hradit výdaje za teplo kvůli velkému růstu cen energií. Odpůrci namítají, že senioři jsou zranitelná skupina obyvatel a nesmí být vystaveni ohrožení zdraví ani ve stavu nouze.",
+      "detail": "",
+      "tags": ["Úspora energií"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-5",
+      "name": "Milostivé léto",
+      "title": "Právě probíhá akce Milostivé léto: Má město individuálně obeslat všechny své dlužníky s potřebnými informacemi?",
+      "gist": "Odpůrci obesílání dlužníků říkají, že se o své dluhy mají starat hlavně sami. Zastánci tvrdí, že by město mělo aktivně usilovat, aby se dlužné peníze vrátily do rozpočtu, a že osobní obeslání je účinné.",
+      "detail": "Milostivé léto je akce, která napomáhá splatit tzv. veřejnoprávní dluhy vymáhané exekučně. Zákonodárci neplánují, že by se měla v budoucnu zopakovat.",
+      "tags": ["Sociální podpora"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-17",
+      "name": "Konec dětských exekucí",
+      "title": "Souhlasím, aby město plošně odpouštělo dluhy dětským dlužníkům a nechalo zastavit jejich exekuce.",
+      "gist": "Jedná se zpravidla o historické dluhy. Dnes již dětem u města obvykle dluhy nevznikají, zodpovídají za ně např. rodiče.",
+      "detail": "",
+      "tags": ["Sociální podpora"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-19",
+      "name": "Participativní rozpočet",
+      "title": "O části rozpočtu města mají mít možnost rozhodovat občané přímo.",
+      "gist": "Jde např. o participativní rozpočet: radnice vymezí část peněz z ročního rozpočtu, občané pak podávají návrhy, co by se za tyto peníze mělo ve městě v následujícím roce vylepšit a vítězné projekty se poté realizují.",
+      "detail": "",
+      "tags": ["Občanská společnost"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-23",
+      "name": "Obědy zdarma",
+      "title": "Ve všech veřejných základních školách na území města by měly mít děti možnost obědvat zdarma.",
+      "gist": "Podle průzkumů žije 20 procent českých dětí v ohrožení příjmovou chudobou. Některé děti již dostávají obědy zdarma díky několika různým projektům, závisí to ale na vůli školy a města, zda se do takových projektů zapojí.",
+      "detail": "",
+      "tags": ["Sociální podpora"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-28",
+      "name": "Podíl developerů na veřejných výdajích",
+      "title": "Soukromí developeři se musí podílet na úhradě veřejných nákladů spojených s výstavbou jejich projektů.",
+      "gist": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
+      "detail": "Podíl se týká komunikací, sítí, MHD apod. Může být finanční, nebo jako konkrétní plnění v rámci výstavby, např. výstavbou veřejné vybavenosti nebo poskytnutím podílu bytů do obecního vlastnictví.",
+      "tags": ["Developeři"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-9",
+      "name": "Bezbariérové zastávky MHD",
+      "title": "Město by mělo více investovat do zastávek hromadné dopravy, aby byly až na výjimky bezbariérové.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Doprava"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-31",
+      "name": "Podíl developerů na veřejných výdajích",
+      "title": "Příspěvky developerů na veřejnou vybavenost by se měly zvýšit.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Developeři"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-33",
+      "name": "Podpora družstevního bydlení",
+      "title": "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Bydlení"]
+    },
+    {
       "id": "komunalni-2022-554782-q-49",
       "name": "Společné vzdělávání",
       "title": "Město by mělo zamezovat shromažďování sociálně znevýhodněných dětí v jedné nebo několika málo školách.",
       "gist": "Zastánci chtějí zajistit všem dětem bez ohledu na jejich původ odpovídající podporu na každé škole. Odpůrci argumentují svobodným výběrem školy.",
       "detail": "",
       "tags": ["Vzdělávání"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-50",
-      "name": "Zklidnění dopravy v centru Prahy",
-      "title": "Podporuji rozšířené chodníky a zklidnění automobilové dopravy na Smetanově nábřeží.",
-      "gist": "Zastánci říkají, že Smetanovo nábřeží je historicky hodnotný prostor, který nikdy neměl sloužit výhradně dopravě. Má jít o atraktivní veřejný prostor s pěší promenádou s vyhlídkou na Pražský hrad, kde lidé chtějí trávit volný čas. Kritici namítají, že se automobilová doprava z dříve rušných komunikací přelije do okolních, rezidenčních ulic.",
-      "detail": "",
-      "tags": ["Doprava"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-51",
-      "name": "Zklidnění dopravy v centru Prahy",
-      "title": "Masarykovo a Rašínovo nábřeží má sloužit v první řadě chodcům, cyklistům a tramvajím.",
-      "gist": "Kritici namítají, že se automobilová doprava z dříve rušných komunikací přelije do okolních, rezidenčních ulic. Zastánci poukazují, že se omezení průjezdu aut už dříve osvědčilo a zlepšilo plynulost tramvají.",
-      "detail": "",
-      "tags": ["Doprava"]
     },
     {
       "id": "komunalni-2022-554782-q-52",
@@ -453,34 +269,10 @@
       "tags": ["Bydlení"]
     },
     {
-      "id": "komunalni-2022-554782-q-56",
-      "name": "Sociální pomoc",
-      "title": "Souhlasím, aby Pražané s postižením měli komplexní pobytovou péči v Praze.",
-      "gist": "Praha provozovala svá ústavní zařízení daleko za svými hranicemi. Klienti by podle svého přání měli mít možnost zůstat v Praze nebo v okolí. Síť komunitních služeb má pro Pražany zůstat přímo na území města.",
-      "detail": "",
-      "tags": ["Sociální podpora"]
-    },
-    {
       "id": "komunalni-2022-554782-q-57",
       "name": "Sociální pomoc",
       "title": "Praha má podporovat předškolní zařízení pro děti od 2 let věku.",
       "gist": "Pomocí sítě dětských skupin nebo mateřských klubů má město podle zastánců pomoci rodičům skloubit pracovní povinnosti s péčí o děti. Odpůrci namítají, že děti do tří let mají být v domácí péči a že časnější péči mimo domov nemá město podporovat.",
-      "detail": "",
-      "tags": ["Vzdělávání"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-58",
-      "name": "Vzdělávání - gymnázia",
-      "title": "Praha by měla navýšit kapacitu čtyřletých gymnázií.",
-      "gist": "",
-      "detail": "",
-      "tags": ["Vzdělávání"]
-    },
-    {
-      "id": "komunalni-2022-554782-q-59",
-      "name": "Vzdělávání - střední školy",
-      "title": "Praha by měla podporovat vznik nových gymnaziálních tříd v rámci jiných středních škol.",
-      "gist": "",
       "detail": "",
       "tags": ["Vzdělávání"]
     },
@@ -493,12 +285,28 @@
       "tags": ["Finance"]
     },
     {
-      "id": "komunalni-2022-554782-q-61",
-      "name": "Obavy z gentrifikace",
-      "title": "V okolí Vltavské filharmonie by měla Praha zachovat dostupné bydlení.",
-      "gist": "Zastánci poukazují, že s větší atraktivitou oblasti narostou ceny nemovitostí i nájmů a že dojde k odlivu původních obyvatel.",
-      "detail": "Součástí nové budovy Vltavské filharmonie má být hlavní koncertní sál pro 1800 diváků, malý sál pro 700 posluchačů, dále multifunkční sál a prostory pro menší akce a konference pro 200 návštěvníků. V nové budově bude sídlit Česká filharmonie, Symfonický orchestr hlavního města Prahy a hudební oddělení Městské knihovny. Plánuje se také vybudování zkušeben a studií a kavárny a restaurace.",
-      "tags": ["Bydlení"]
+      "id": "komunalni-2022-554782-q-56",
+      "name": "Sociální pomoc",
+      "title": "Souhlasím, aby Pražané s postižením měli komplexní pobytovou péči v Praze.",
+      "gist": "Praha provozovala svá ústavní zařízení daleko za svými hranicemi. Klienti by podle svého přání měli mít možnost zůstat v Praze nebo v okolí. Síť komunitních služeb má pro Pražany zůstat přímo na území města.",
+      "detail": "",
+      "tags": ["Sociální podpora"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-42",
+      "name": "Více strážníků",
+      "title": "Mělo by být více městských strážníků?",
+      "gist": "Zastánci uvádějí zvýšení pocitu bezpečí. Odpůrci namítají, že to jsou nyní pro město zbytečné výdaje navíc.",
+      "detail": "",
+      "tags": ["Bezpečnost"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-36",
+      "name": "Vstupné na kulturu a sport",
+      "title": "V městských muzeích, galeriích a na sportovištích má být pro mládež bezplatné nebo symbolické vstupné.",
+      "gist": "",
+      "detail": "",
+      "tags": ["Volný čas"]
     },
     {
       "id": "komunalni-2022-554782-q-62",
@@ -507,6 +315,30 @@
       "gist": "",
       "detail": "",
       "tags": ["Doprava"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-50",
+      "name": "Zklidnění dopravy v centru Prahy",
+      "title": "Podporuji rozšířené chodníky a zklidnění automobilové dopravy na Smetanově nábřeží.",
+      "gist": "Zastánci říkají, že Smetanovo nábřeží je historicky hodnotný prostor, který nikdy neměl sloužit výhradně dopravě. Má jít o atraktivní veřejný prostor s pěší promenádou s vyhlídkou na Pražský hrad, kde lidé chtějí trávit volný čas. Kritici namítají, že se automobilová doprava z dříve rušných komunikací přelije do okolních, rezidenčních ulic.",
+      "detail": "",
+      "tags": ["Doprava"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-51",
+      "name": "Zklidnění dopravy v centru Prahy",
+      "title": "Masarykovo a Rašínovo nábřeží má sloužit v první řadě chodcům, cyklistům a tramvajím.",
+      "gist": "Kritici namítají, že se automobilová doprava z dříve rušných komunikací přelije do okolních, rezidenčních ulic. Zastánci poukazují, že se omezení průjezdu aut už dříve osvědčilo a zlepšilo plynulost tramvají.",
+      "detail": "",
+      "tags": ["Doprava"]
+    },
+    {
+      "id": "komunalni-2022-554782-q-43",
+      "name": "Zelené střechy",
+      "title": "Město má prosazovat na nových či rekonstruovaných městských budovách zelené střechy.",
+      "gist": "Oproti klasické střeše je založení zelené střechy nákladnější a složitější a je třeba ji následně udržovat. Kvůli vyššímu zatížení je třeba silnější střešní konstrukce. Zastánci poukazují na to, že zelené střechy izolují a snižují náklady na vytápění či chlazení vnitřních prostor v létě.",
+      "detail": "Klasické střechy mohou mít až 70 stupňů, teplota ozeleněné střechy se blíží například trávníku v okolí.",
+      "tags": ["Klimatické změny"]
     }
   ],
   "candidates": [
@@ -1203,118 +1035,10 @@
   ],
   "answers": [
     {
-      "id": "komunalni-2022-554782-a-476009-1",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-1",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-2",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-2",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-3",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-3",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-4",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-4",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-5",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-6",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-6",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-7",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-7",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-8",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-8",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-9",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-9",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-10",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-11",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-12",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-12",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-13",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-14",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-14",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-476009-15",
       "candidate_id": "komunalni-2022-554782-c-476009",
       "question_id": "komunalni-2022-554782-q-15",
       "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-16",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-17",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-18",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-19",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-19",
-      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-476009-20",
@@ -1323,28 +1047,34 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-476009-21",
+      "id": "komunalni-2022-554782-a-476009-30",
       "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-21",
+      "question_id": "komunalni-2022-554782-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-476009-1",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-1",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-476009-22",
+      "id": "komunalni-2022-554782-a-476009-8",
       "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-22",
+      "question_id": "komunalni-2022-554782-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-476009-23",
+      "id": "komunalni-2022-554782-a-476009-58",
       "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-23",
-      "answer": "no"
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "dont_know"
     },
     {
-      "id": "komunalni-2022-554782-a-476009-24",
+      "id": "komunalni-2022-554782-a-476009-59",
       "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-24",
-      "answer": "no"
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "dont_know"
     },
     {
       "id": "komunalni-2022-554782-a-476009-25",
@@ -1365,9 +1095,15 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-476009-28",
+      "id": "komunalni-2022-554782-a-476009-22",
       "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-28",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-476009-61",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-61",
       "answer": "no"
     },
     {
@@ -1377,99 +1113,15 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-476009-30",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-31",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-32",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-33",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-33",
-      "answer": "no"
-    },
-    {
       "id": "komunalni-2022-554782-a-476009-34",
       "candidate_id": "komunalni-2022-554782-c-476009",
       "question_id": "komunalni-2022-554782-q-34",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-476009-35",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-36",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-37",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-38",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-39",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-40",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-41",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-42",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-43",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-43",
-      "answer": "no"
-    },
-    {
       "id": "komunalni-2022-554782-a-476009-44",
       "candidate_id": "komunalni-2022-554782-c-476009",
       "question_id": "komunalni-2022-554782-q-44",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-45",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-45",
       "answer": "no"
     },
     {
@@ -1491,21 +1143,63 @@
       "answer": "no"
     },
     {
+      "id": "komunalni-2022-554782-a-476009-3",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-476009-5",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-476009-17",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-476009-19",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-476009-23",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-476009-28",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-476009-9",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-476009-31",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-476009-33",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "no"
+    },
+    {
       "id": "komunalni-2022-554782-a-476009-49",
       "candidate_id": "komunalni-2022-554782-c-476009",
       "question_id": "komunalni-2022-554782-q-49",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-50",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-51",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-51",
       "answer": "no"
     },
     {
@@ -1533,28 +1227,10 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-476009-56",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "dont_know"
-    },
-    {
       "id": "komunalni-2022-554782-a-476009-57",
       "candidate_id": "komunalni-2022-554782-c-476009",
       "question_id": "komunalni-2022-554782-q-57",
       "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-58",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-476009-59",
-      "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-59",
-      "answer": "dont_know"
     },
     {
       "id": "komunalni-2022-554782-a-476009-60",
@@ -1563,9 +1239,21 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-476009-61",
+      "id": "komunalni-2022-554782-a-476009-56",
       "candidate_id": "komunalni-2022-554782-c-476009",
-      "question_id": "komunalni-2022-554782-q-61",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-476009-42",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-476009-36",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-36",
       "answer": "no"
     },
     {
@@ -1575,99 +1263,22 @@
       "answer": "dont_know"
     },
     {
-      "id": "komunalni-2022-554782-a-532713-1",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-1",
-      "answer": "no",
-      "comment": "Každý má právo na důstojné bydlení."
+      "id": "komunalni-2022-554782-a-476009-50",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-50",
+      "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-532713-2",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-2",
-      "answer": "yes",
-      "comment": "Poplatek musí jen takový, aby pokryl náklady na svoz odpadů. Důsledně rozšiřovat počet bezplatných kontejnerů na tříděný odpad."
+      "id": "komunalni-2022-554782-a-476009-51",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-532713-3",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-3",
-      "answer": "no",
-      "comment": "Rozhodně ne, neboť nesmíme podléhat zeleným šíleným plánům EU, aby to odnášeli naši občané."
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-4",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-4",
-      "answer": "no",
-      "comment": "Nepodléhejte cyklistickým Zeleným Khmerům, kteří svázali Prahu nesmyslnými omezeními."
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-5",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-6",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-6",
-      "answer": "yes",
-      "comment": "Ale dejme pozor na to, aby kamery nebyly zneužívány ke sledování občanů."
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-7",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-7",
-      "answer": "yes",
-      "comment": "Bez výjimek a radikálně!"
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-8",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-8",
-      "answer": "no",
-      "comment": "Nezdražovat stávající jízdenky předplatné i jednotlivé. MHD musí být dostupná pro všechny. A hlavně! Udělat pořádek a vyházet všechny parazity a korupčníky z DP hl.m. Prahy.\n\n\n\n\n"
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-9",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-9",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-10",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "yes",
-      "comment": "Nikdo se přece nestydí za svůj postoj, názor."
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-11",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "yes",
-      "comment": "A tam určitě, neboť tam jde o důležité otázky, které mají mnohdy vliv na chod města na roky dopředu."
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-12",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-12",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-13",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "yes",
-      "comment": "A bude to ostuda současné vlády ukrajinského místodržícího Fialy ."
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-14",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-14",
-      "answer": "no",
-      "comment": "Máme se v Praze čím chlubit, tak to svítí. Ať zhasnou v Senátu a ve Skrakovce."
+      "id": "komunalni-2022-554782-a-476009-43",
+      "candidate_id": "komunalni-2022-554782-c-476009",
+      "question_id": "komunalni-2022-554782-q-43",
+      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-532713-15",
@@ -1677,33 +1288,6 @@
       "comment": "Ať přestanou posílat miliardy na Ukrajinu, vystoupíme z energetické burzy, zestátníme ČEZ a bude El. proudu."
     },
     {
-      "id": "komunalni-2022-554782-a-532713-16",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "no",
-      "comment": "Ať přestanou posílat miliardy na Ukrajinu, vystoupíme z energetické burzy, zestátníme ČEZ a bude El. proudu."
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-17",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-18",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "yes",
-      "comment": "Přece se nemusí ničeho bát..."
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-19",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-19",
-      "answer": "yes",
-      "comment": "Důsledným tlakem na své zastupitele."
-    },
-    {
       "id": "komunalni-2022-554782-a-532713-20",
       "candidate_id": "komunalni-2022-554782-c-532713",
       "question_id": "komunalni-2022-554782-q-20",
@@ -1711,32 +1295,39 @@
       "comment": "Napravit to, co pokazilo začátkem devadesátých let."
     },
     {
-      "id": "komunalni-2022-554782-a-532713-21",
+      "id": "komunalni-2022-554782-a-532713-30",
       "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-21",
+      "question_id": "komunalni-2022-554782-q-30",
       "answer": "no",
-      "comment": "Ať přestanou posílat miliardy na Ukrajinu, vystoupíme z energetické burzy, zestátníme ČEZ a bude El. proudu."
+      "comment": "Bylo by to bolševické, zkrátka bruselské, přesně podle zadání EU ."
     },
     {
-      "id": "komunalni-2022-554782-a-532713-22",
+      "id": "komunalni-2022-554782-a-532713-1",
       "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-22",
+      "question_id": "komunalni-2022-554782-q-1",
       "answer": "no",
-      "comment": "A když, tak opatrně a citlivě "
+      "comment": "Každý má právo na důstojné bydlení."
     },
     {
-      "id": "komunalni-2022-554782-a-532713-23",
+      "id": "komunalni-2022-554782-a-532713-8",
       "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-23",
-      "answer": "yes",
-      "comment": "Děti nesmí hladovět, ať si obědy odpustí páni senátoři a páni poslanci."
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "no",
+      "comment": "Nezdražovat stávající jízdenky předplatné i jednotlivé. MHD musí být dostupná pro všechny. A hlavně! Udělat pořádek a vyházet všechny parazity a korupčníky z DP hl.m. Prahy.\n\n\n\n\n"
     },
     {
-      "id": "komunalni-2022-554782-a-532713-24",
+      "id": "komunalni-2022-554782-a-532713-58",
       "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-24",
+      "question_id": "komunalni-2022-554782-q-58",
       "answer": "no",
-      "comment": "Stop bolševizaci společnosti, sdílením aut to začíná a znárodněním a gulagy to končí."
+      "comment": "Ať rozhodne trh na uplatnění gymnazistů "
+    },
+    {
+      "id": "komunalni-2022-554782-a-532713-59",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "no",
+      "comment": "Ať rozhodne trh na uplatnění gymnazistů."
     },
     {
       "id": "komunalni-2022-554782-a-532713-25",
@@ -1758,11 +1349,18 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-532713-28",
+      "id": "komunalni-2022-554782-a-532713-22",
       "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-28",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "no",
+      "comment": "A když, tak opatrně a citlivě "
+    },
+    {
+      "id": "komunalni-2022-554782-a-532713-61",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-61",
       "answer": "yes",
-      "comment": "Kroťme developery!"
+      "comment": "Ale potřebujeme budovu Vltavské filharmonie, když nejsou peníze pro potřebné?"
     },
     {
       "id": "komunalni-2022-554782-a-532713-29",
@@ -1772,32 +1370,6 @@
       "comment": "Protože by to byla voda na bolševický mlýn Zeleným Khmerům."
     },
     {
-      "id": "komunalni-2022-554782-a-532713-30",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "no",
-      "comment": "Bylo by to bolševické, zkrátka bruselské, přesně podle zadání EU ."
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-31",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-32",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "no",
-      "comment": "Škoda peněz, dejme je dětem na obědy zdarma."
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-33",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-33",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-532713-34",
       "candidate_id": "komunalni-2022-554782-c-532713",
       "question_id": "komunalni-2022-554782-q-34",
@@ -1805,74 +1377,11 @@
       "comment": "Stačí do 15 let zadarmo a potom do 18 let za 1000 ročně "
     },
     {
-      "id": "komunalni-2022-554782-a-532713-35",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-36",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-37",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "no",
-      "comment": "Genderové šílenství."
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-38",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-39",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-40",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "no",
-      "comment": "Koloběžky jedině ohrožují chodce. Zrušit a basta!"
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-41",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-42",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "yes",
-      "comment": "Ale musí odvádět více práce, než jen nasazovat botičky..."
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-43",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-43",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-532713-44",
       "candidate_id": "komunalni-2022-554782-c-532713",
       "question_id": "komunalni-2022-554782-q-44",
       "answer": "no",
       "comment": "Myslím, že je dost cyklostezek, které zpolykaly zbytečně miliardy."
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-45",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-45",
-      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-532713-46",
@@ -1895,24 +1404,69 @@
       "answer": "yes"
     },
     {
+      "id": "komunalni-2022-554782-a-532713-3",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no",
+      "comment": "Rozhodně ne, neboť nesmíme podléhat zeleným šíleným plánům EU, aby to odnášeli naši občané."
+    },
+    {
+      "id": "komunalni-2022-554782-a-532713-5",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-532713-17",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-532713-19",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes",
+      "comment": "Důsledným tlakem na své zastupitele."
+    },
+    {
+      "id": "komunalni-2022-554782-a-532713-23",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "yes",
+      "comment": "Děti nesmí hladovět, ať si obědy odpustí páni senátoři a páni poslanci."
+    },
+    {
+      "id": "komunalni-2022-554782-a-532713-28",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes",
+      "comment": "Kroťme developery!"
+    },
+    {
+      "id": "komunalni-2022-554782-a-532713-9",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-532713-31",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-532713-33",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
       "id": "komunalni-2022-554782-a-532713-49",
       "candidate_id": "komunalni-2022-554782-c-532713",
       "question_id": "komunalni-2022-554782-q-49",
       "answer": "no",
       "comment": "Ale hlavně zastavme levicovou inkluzi."
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-50",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "no",
-      "comment": "Odmítněme Zelené Khmery."
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-51",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-51",
-      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-532713-52",
@@ -1941,30 +1495,10 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-532713-56",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-532713-57",
       "candidate_id": "komunalni-2022-554782-c-532713",
       "question_id": "komunalni-2022-554782-q-57",
       "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-58",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "no",
-      "comment": "Ať rozhodne trh na uplatnění gymnazistů "
-    },
-    {
-      "id": "komunalni-2022-554782-a-532713-59",
-      "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-59",
-      "answer": "no",
-      "comment": "Ať rozhodne trh na uplatnění gymnazistů."
     },
     {
       "id": "komunalni-2022-554782-a-532713-60",
@@ -1974,11 +1508,23 @@
       "comment": "Když se nebude krást, lobovat a podplácet, bude peněz dost."
     },
     {
-      "id": "komunalni-2022-554782-a-532713-61",
+      "id": "komunalni-2022-554782-a-532713-56",
       "candidate_id": "komunalni-2022-554782-c-532713",
-      "question_id": "komunalni-2022-554782-q-61",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-532713-42",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-42",
       "answer": "yes",
-      "comment": "Ale potřebujeme budovu Vltavské filharmonie, když nejsou peníze pro potřebné?"
+      "comment": "Ale musí odvádět více práce, než jen nasazovat botičky..."
+    },
+    {
+      "id": "komunalni-2022-554782-a-532713-36",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-532713-62",
@@ -1988,95 +1534,23 @@
       "comment": "Václavské náměstí bez tramvají a hlavně s nulovou kriminalitou. Ať se na Václavské náměstí vrátí pořádek a bezpečnost a ne tramvaje."
     },
     {
-      "id": "komunalni-2022-554782-a-254716-1",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-1",
+      "id": "komunalni-2022-554782-a-532713-50",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-50",
       "answer": "no",
-      "comment": "Protože senioři, kteří zde bydlí celý život, by stěhování nepřežili."
+      "comment": "Odmítněme Zelené Khmery."
     },
     {
-      "id": "komunalni-2022-554782-a-254716-2",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-2",
+      "id": "komunalni-2022-554782-a-532713-51",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-51",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-254716-3",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-3",
-      "answer": "no",
-      "comment": "Znamená to pro seniory smrt"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-4",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-4",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-5",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "yes",
-      "comment": "město musí lidi vyrozumět nezpochybnitelným způsobem"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-6",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-6",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-7",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-7",
-      "answer": "no",
-      "comment": "casina nám nevadí"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-8",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-8",
+      "id": "komunalni-2022-554782-a-532713-43",
+      "candidate_id": "komunalni-2022-554782-c-532713",
+      "question_id": "komunalni-2022-554782-q-43",
       "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-9",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-9",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-10",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-11",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-12",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-12",
-      "answer": "no",
-      "comment": "s povinností ohlášení na MÚ."
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-13",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "yes",
-      "comment": "nesmí tím ale město řešit nedostatek tepla pro domácnosti"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-14",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-14",
-      "answer": "no",
-      "comment": "Jsme proti sankcím, které toto způsobily"
     },
     {
       "id": "komunalni-2022-554782-a-254716-15",
@@ -2086,60 +1560,40 @@
       "comment": "Zvýšila by se tím kriminalita v Praze"
     },
     {
-      "id": "komunalni-2022-554782-a-254716-16",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-17",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-18",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-19",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-19",
-      "answer": "yes",
-      "comment": "Ale formou referenda"
-    },
-    {
       "id": "komunalni-2022-554782-a-254716-20",
       "candidate_id": "komunalni-2022-554782-c-254716",
       "question_id": "komunalni-2022-554782-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-254716-21",
+      "id": "komunalni-2022-554782-a-254716-30",
       "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-21",
-      "answer": "no",
-      "comment": "Jsme proti důsledku sankcí"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-22",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-22",
+      "question_id": "komunalni-2022-554782-q-30",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-254716-23",
+      "id": "komunalni-2022-554782-a-254716-1",
       "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-23",
+      "question_id": "komunalni-2022-554782-q-1",
       "answer": "no",
-      "comment": "Nutno řešit individuálně dle sociálního postavení rodiny"
+      "comment": "Protože senioři, kteří zde bydlí celý život, by stěhování nepřežili."
     },
     {
-      "id": "komunalni-2022-554782-a-254716-24",
+      "id": "komunalni-2022-554782-a-254716-8",
       "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-24",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-58",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-59",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-59",
       "answer": "no"
     },
     {
@@ -2163,40 +1617,22 @@
       "comment": "ale pouze stávajícím nájemcům, a z těchto peněz stavět sociální byty."
     },
     {
-      "id": "komunalni-2022-554782-a-254716-28",
+      "id": "komunalni-2022-554782-a-254716-22",
       "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-28",
-      "answer": "yes"
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-61",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-254716-29",
       "candidate_id": "komunalni-2022-554782-c-254716",
       "question_id": "komunalni-2022-554782-q-29",
       "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-30",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-31",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-32",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-33",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-33",
-      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-254716-34",
@@ -2206,72 +1642,10 @@
       "comment": "všichni"
     },
     {
-      "id": "komunalni-2022-554782-a-254716-35",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-36",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-37",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-38",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-39",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-40",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-41",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-42",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "yes",
-      "comment": "ale v ulicích a pěšky."
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-43",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-43",
-      "answer": "dont_know"
-    },
-    {
       "id": "komunalni-2022-554782-a-254716-44",
       "candidate_id": "komunalni-2022-554782-c-254716",
       "question_id": "komunalni-2022-554782-q-44",
       "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-45",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-45",
-      "answer": "no",
-      "comment": " pouze mládežnický a neprofesionální"
     },
     {
       "id": "komunalni-2022-554782-a-254716-46",
@@ -2293,21 +1667,67 @@
       "answer": "yes"
     },
     {
+      "id": "komunalni-2022-554782-a-254716-3",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no",
+      "comment": "Znamená to pro seniory smrt"
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-5",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes",
+      "comment": "město musí lidi vyrozumět nezpochybnitelným způsobem"
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-17",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-19",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes",
+      "comment": "Ale formou referenda"
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-23",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "no",
+      "comment": "Nutno řešit individuálně dle sociálního postavení rodiny"
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-28",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-9",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-31",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-33",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
       "id": "komunalni-2022-554782-a-254716-49",
       "candidate_id": "komunalni-2022-554782-c-254716",
       "question_id": "komunalni-2022-554782-q-49",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-50",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-51",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-51",
       "answer": "no"
     },
     {
@@ -2337,28 +1757,10 @@
       "comment": "ale zkontrolovat důvěryhodnost pronajímatele i  nájemce"
     },
     {
-      "id": "komunalni-2022-554782-a-254716-56",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-254716-57",
       "candidate_id": "komunalni-2022-554782-c-254716",
       "question_id": "komunalni-2022-554782-q-57",
       "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-58",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-254716-59",
-      "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-59",
-      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-254716-60",
@@ -2367,15 +1769,64 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-254716-61",
+      "id": "komunalni-2022-554782-a-254716-56",
       "candidate_id": "komunalni-2022-554782-c-254716",
-      "question_id": "komunalni-2022-554782-q-61",
-      "answer": "no"
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-42",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes",
+      "comment": "ale v ulicích a pěšky."
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-36",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-254716-62",
       "candidate_id": "komunalni-2022-554782-c-254716",
       "question_id": "komunalni-2022-554782-q-62",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-50",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-51",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-254716-43",
+      "candidate_id": "komunalni-2022-554782-c-254716",
+      "question_id": "komunalni-2022-554782-q-43",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-662662-15",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-662662-20",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-662662-30",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-30",
       "answer": "no"
     },
     {
@@ -2385,42 +1836,6 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-662662-2",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-2",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-3",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-3",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-4",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-4",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-5",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-6",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-6",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-7",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-7",
-      "answer": "dont_know"
-    },
-    {
       "id": "komunalni-2022-554782-a-662662-8",
       "candidate_id": "komunalni-2022-554782-c-662662",
       "question_id": "komunalni-2022-554782-q-8",
@@ -2428,100 +1843,15 @@
       "comment": "Navrhujeme zavést MHD zdarma pouze dočasně, pro krizový rok 2023."
     },
     {
-      "id": "komunalni-2022-554782-a-662662-9",
+      "id": "komunalni-2022-554782-a-662662-58",
       "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-9",
+      "question_id": "komunalni-2022-554782-q-58",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-662662-10",
+      "id": "komunalni-2022-554782-a-662662-59",
       "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-11",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-12",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-12",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-13",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-14",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-14",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-15",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-15",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-16",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-17",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-18",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-19",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-19",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-20",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-20",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-21",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-21",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-22",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-22",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-23",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-23",
-      "answer": "no",
-      "comment": "Dočasně ano."
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-24",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-24",
+      "question_id": "komunalni-2022-554782-q-59",
       "answer": "yes"
     },
     {
@@ -2543,10 +1873,16 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-662662-28",
+      "id": "komunalni-2022-554782-a-662662-22",
       "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-28",
+      "question_id": "komunalni-2022-554782-q-22",
       "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-662662-61",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "dont_know"
     },
     {
       "id": "komunalni-2022-554782-a-662662-29",
@@ -2555,87 +1891,9 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-662662-30",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-31",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-32",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-33",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-33",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-662662-34",
       "candidate_id": "komunalni-2022-554782-c-662662",
       "question_id": "komunalni-2022-554782-q-34",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-35",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-36",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-37",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-38",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-39",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-40",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-41",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-42",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-43",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-43",
       "answer": "yes"
     },
     {
@@ -2643,12 +1901,6 @@
       "candidate_id": "komunalni-2022-554782-c-662662",
       "question_id": "komunalni-2022-554782-q-44",
       "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-45",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-45",
-      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-662662-46",
@@ -2669,22 +1921,65 @@
       "answer": "yes"
     },
     {
+      "id": "komunalni-2022-554782-a-662662-3",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-662662-5",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-662662-17",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-662662-19",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-662662-23",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "no",
+      "comment": "Dočasně ano."
+    },
+    {
+      "id": "komunalni-2022-554782-a-662662-28",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-662662-9",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-662662-31",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-662662-33",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
       "id": "komunalni-2022-554782-a-662662-49",
       "candidate_id": "komunalni-2022-554782-c-662662",
       "question_id": "komunalni-2022-554782-q-49",
       "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-50",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-51",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-51",
-      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-662662-52",
@@ -2711,27 +2006,9 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-662662-56",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-662662-57",
       "candidate_id": "komunalni-2022-554782-c-662662",
       "question_id": "komunalni-2022-554782-q-57",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-58",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-662662-59",
-      "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-59",
       "answer": "yes"
     },
     {
@@ -2741,10 +2018,22 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-662662-61",
+      "id": "komunalni-2022-554782-a-662662-56",
       "candidate_id": "komunalni-2022-554782-c-662662",
-      "question_id": "komunalni-2022-554782-q-61",
-      "answer": "dont_know"
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-662662-42",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-662662-36",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-662662-62",
@@ -2753,88 +2042,21 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-318069-1",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-1",
+      "id": "komunalni-2022-554782-a-662662-50",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-50",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-318069-2",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-2",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-3",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-3",
+      "id": "komunalni-2022-554782-a-662662-51",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-51",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-318069-4",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-4",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-5",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-6",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-6",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-7",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-7",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-8",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-8",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-9",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-9",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-10",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-11",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-12",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-12",
-      "answer": "no",
-      "comment": "Umožnit elektronickou oznamovací povinnost"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-13",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-14",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-14",
+      "id": "komunalni-2022-554782-a-662662-43",
+      "candidate_id": "komunalni-2022-554782-c-662662",
+      "question_id": "komunalni-2022-554782-q-43",
       "answer": "yes"
     },
     {
@@ -2844,58 +2066,40 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-318069-16",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-17",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-18",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-19",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-19",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-318069-20",
       "candidate_id": "komunalni-2022-554782-c-318069",
       "question_id": "komunalni-2022-554782-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-318069-21",
+      "id": "komunalni-2022-554782-a-318069-30",
       "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-21",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-22",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-22",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-23",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-23",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-24",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-24",
+      "question_id": "komunalni-2022-554782-q-30",
       "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-318069-1",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-318069-8",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-318069-58",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-318069-59",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-318069-25",
@@ -2916,9 +2120,15 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-318069-28",
+      "id": "komunalni-2022-554782-a-318069-22",
       "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-28",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-318069-61",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-61",
       "answer": "yes"
     },
     {
@@ -2928,99 +2138,15 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-318069-30",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-31",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-32",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-33",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-33",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-318069-34",
       "candidate_id": "komunalni-2022-554782-c-318069",
       "question_id": "komunalni-2022-554782-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-318069-35",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-36",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-37",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-38",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-39",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-40",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-41",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-42",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-43",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-43",
-      "answer": "no"
-    },
-    {
       "id": "komunalni-2022-554782-a-318069-44",
       "candidate_id": "komunalni-2022-554782-c-318069",
       "question_id": "komunalni-2022-554782-q-44",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-45",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-45",
       "answer": "no"
     },
     {
@@ -3043,21 +2169,63 @@
       "answer": "yes"
     },
     {
+      "id": "komunalni-2022-554782-a-318069-3",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-318069-5",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-318069-17",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-318069-19",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-318069-23",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-318069-28",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-318069-9",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-318069-31",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-318069-33",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
       "id": "komunalni-2022-554782-a-318069-49",
       "candidate_id": "komunalni-2022-554782-c-318069",
       "question_id": "komunalni-2022-554782-q-49",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-50",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-51",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-51",
       "answer": "no"
     },
     {
@@ -3085,27 +2253,9 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-318069-56",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-318069-57",
       "candidate_id": "komunalni-2022-554782-c-318069",
       "question_id": "komunalni-2022-554782-q-57",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-58",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-318069-59",
-      "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-59",
       "answer": "yes"
     },
     {
@@ -3115,9 +2265,21 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-318069-61",
+      "id": "komunalni-2022-554782-a-318069-56",
       "candidate_id": "komunalni-2022-554782-c-318069",
-      "question_id": "komunalni-2022-554782-q-61",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-318069-42",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-318069-36",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-36",
       "answer": "yes"
     },
     {
@@ -3128,93 +2290,22 @@
       "comment": "Tento počin ničemu nepospěje"
     },
     {
-      "id": "komunalni-2022-554782-a-174835-1",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-1",
+      "id": "komunalni-2022-554782-a-318069-50",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-50",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-174835-2",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-2",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-3",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-3",
+      "id": "komunalni-2022-554782-a-318069-51",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-51",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-174835-4",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-4",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-5",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-6",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-6",
+      "id": "komunalni-2022-554782-a-318069-43",
+      "candidate_id": "komunalni-2022-554782-c-318069",
+      "question_id": "komunalni-2022-554782-q-43",
       "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-7",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-7",
-      "answer": "no",
-      "comment": "Nejsme pro úplný zákaz, ale jsme pro silnou regulaci. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-8",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-8",
-      "answer": "no",
-      "comment": "Podporujeme levnou, dostupnou a kvalitní MHD. MHD zdarma by vedla ke zhoršení kvality a dostupnosti."
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-9",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-9",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-10",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "yes",
-      "comment": "Stejně jako v Poslanecké sněmovně."
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-11",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "no",
-      "comment": "Rada je kolektivní orgán, kde podobně jako při hlasování vlády, záleží na rozhodnutí celku. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-12",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-12",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-13",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-14",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-14",
-      "answer": "yes",
-      "comment": "Jedná se o projev solidarity s domácnostmi, které v této době musí šetřit. "
     },
     {
       "id": "komunalni-2022-554782-a-174835-15",
@@ -3224,61 +2315,41 @@
       "comment": "Vedlo by to ke snížení bezpečnosti v nočních hodinách."
     },
     {
-      "id": "komunalni-2022-554782-a-174835-16",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "yes",
-      "comment": "Jedná se o omezení obdobné v jiných evropských metropolích. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-17",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-18",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-19",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-19",
-      "answer": "yes",
-      "comment": "Posiluje to participaci občanů na rozvoji města. "
-    },
-    {
       "id": "komunalni-2022-554782-a-174835-20",
       "candidate_id": "komunalni-2022-554782-c-174835",
       "question_id": "komunalni-2022-554782-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-174835-21",
+      "id": "komunalni-2022-554782-a-174835-30",
       "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-21",
-      "answer": "yes",
-      "comment": "Jedná se opět o projev solidarity. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-22",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-22",
+      "question_id": "komunalni-2022-554782-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-174835-23",
+      "id": "komunalni-2022-554782-a-174835-1",
       "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-23",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-174835-8",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "no",
+      "comment": "Podporujeme levnou, dostupnou a kvalitní MHD. MHD zdarma by vedla ke zhoršení kvality a dostupnosti."
+    },
+    {
+      "id": "komunalni-2022-554782-a-174835-58",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-58",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-174835-24",
+      "id": "komunalni-2022-554782-a-174835-59",
       "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-24",
-      "answer": "yes"
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "dont_know"
     },
     {
       "id": "komunalni-2022-554782-a-174835-25",
@@ -3299,9 +2370,15 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-174835-28",
+      "id": "komunalni-2022-554782-a-174835-22",
       "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-28",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-174835-61",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-61",
       "answer": "yes"
     },
     {
@@ -3311,89 +2388,9 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-174835-30",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-31",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-32",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-33",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-33",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-174835-34",
       "candidate_id": "komunalni-2022-554782-c-174835",
       "question_id": "komunalni-2022-554782-q-34",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-35",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-36",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-37",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-38",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-39",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-40",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "no",
-      "comment": "Obecně podporujeme mikromobilitu včetně elektrokol. Elektrické koloběžky mohou mít v dopravním mixu své místo, nicméně, jejich parkovaní a umístění ve veřejném prostoru je třeba striktně regulovat.  "
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-41",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "yes",
-      "comment": "Prosazujeme vytvoření Rady cizinců (Expat Council), která by byla poradním orgánem Rady hlavního města Prahy."
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-42",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-43",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-43",
       "answer": "yes"
     },
     {
@@ -3402,12 +2399,6 @@
       "question_id": "komunalni-2022-554782-q-44",
       "answer": "yes",
       "comment": "Chceme vybudovat bezpečnou infrastrukturu pro cyklodopravu, včetně páteřních tras tak, aby se rodiče nebáli posílat své děti na kole."
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-45",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-45",
-      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-174835-46",
@@ -3428,21 +2419,64 @@
       "answer": "yes"
     },
     {
+      "id": "komunalni-2022-554782-a-174835-3",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-174835-5",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-174835-17",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-174835-19",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes",
+      "comment": "Posiluje to participaci občanů na rozvoji města. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-174835-23",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-174835-28",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-174835-9",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-174835-31",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-174835-33",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
       "id": "komunalni-2022-554782-a-174835-49",
       "candidate_id": "komunalni-2022-554782-c-174835",
       "question_id": "komunalni-2022-554782-q-49",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-50",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-51",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-51",
       "answer": "yes"
     },
     {
@@ -3470,28 +2504,10 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-174835-56",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-174835-57",
       "candidate_id": "komunalni-2022-554782-c-174835",
       "question_id": "komunalni-2022-554782-q-57",
       "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-58",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-174835-59",
-      "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-59",
-      "answer": "dont_know"
     },
     {
       "id": "komunalni-2022-554782-a-174835-60",
@@ -3501,9 +2517,21 @@
       "comment": "Motivace obyvatel ke změně trvalého bydliště, aby odpovídalo tomu, kde skutečně bydlí, je součástí programu Voltu. Přineslo by navýšení příjmu do městské pokladny. "
     },
     {
-      "id": "komunalni-2022-554782-a-174835-61",
+      "id": "komunalni-2022-554782-a-174835-56",
       "candidate_id": "komunalni-2022-554782-c-174835",
-      "question_id": "komunalni-2022-554782-q-61",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-174835-42",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-174835-36",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-36",
       "answer": "yes"
     },
     {
@@ -3513,117 +2541,27 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-540309-1",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-1",
+      "id": "komunalni-2022-554782-a-174835-50",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-50",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-540309-2",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-2",
+      "id": "komunalni-2022-554782-a-174835-51",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-51",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-540309-3",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-3",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-4",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-4",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-5",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-6",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-6",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-7",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-7",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-8",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-8",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-9",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-9",
+      "id": "komunalni-2022-554782-a-174835-43",
+      "candidate_id": "komunalni-2022-554782-c-174835",
+      "question_id": "komunalni-2022-554782-q-43",
       "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-10",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-11",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-12",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-12",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-13",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-14",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-14",
-      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-540309-15",
       "candidate_id": "komunalni-2022-554782-c-540309",
       "question_id": "komunalni-2022-554782-q-15",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-16",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-17",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-18",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-19",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-19",
       "answer": "no"
     },
     {
@@ -3633,27 +2571,33 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-540309-21",
+      "id": "komunalni-2022-554782-a-540309-30",
       "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-21",
+      "question_id": "komunalni-2022-554782-q-30",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-540309-22",
+      "id": "komunalni-2022-554782-a-540309-1",
       "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-22",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-540309-8",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-8",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-540309-23",
+      "id": "komunalni-2022-554782-a-540309-58",
       "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-23",
+      "question_id": "komunalni-2022-554782-q-58",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-540309-24",
+      "id": "komunalni-2022-554782-a-540309-59",
       "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-24",
+      "question_id": "komunalni-2022-554782-q-59",
       "answer": "no"
     },
     {
@@ -3675,9 +2619,15 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-540309-28",
+      "id": "komunalni-2022-554782-a-540309-22",
       "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-28",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-540309-61",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-61",
       "answer": "no"
     },
     {
@@ -3687,99 +2637,15 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-540309-30",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-31",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-32",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-33",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-33",
-      "answer": "no"
-    },
-    {
       "id": "komunalni-2022-554782-a-540309-34",
       "candidate_id": "komunalni-2022-554782-c-540309",
       "question_id": "komunalni-2022-554782-q-34",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-540309-35",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-36",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-37",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-38",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-39",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-40",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-41",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-42",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-43",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-43",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-540309-44",
       "candidate_id": "komunalni-2022-554782-c-540309",
       "question_id": "komunalni-2022-554782-q-44",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-45",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-45",
       "answer": "no"
     },
     {
@@ -3801,21 +2667,63 @@
       "answer": "no"
     },
     {
+      "id": "komunalni-2022-554782-a-540309-3",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-540309-5",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-540309-17",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-540309-19",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-540309-23",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-540309-28",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-540309-9",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-540309-31",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-540309-33",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "no"
+    },
+    {
       "id": "komunalni-2022-554782-a-540309-49",
       "candidate_id": "komunalni-2022-554782-c-540309",
       "question_id": "komunalni-2022-554782-q-49",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-50",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-51",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-51",
       "answer": "no"
     },
     {
@@ -3843,27 +2751,9 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-540309-56",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "no"
-    },
-    {
       "id": "komunalni-2022-554782-a-540309-57",
       "candidate_id": "komunalni-2022-554782-c-540309",
       "question_id": "komunalni-2022-554782-q-57",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-58",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-540309-59",
-      "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-59",
       "answer": "no"
     },
     {
@@ -3873,9 +2763,21 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-540309-61",
+      "id": "komunalni-2022-554782-a-540309-56",
       "candidate_id": "komunalni-2022-554782-c-540309",
-      "question_id": "komunalni-2022-554782-q-61",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-540309-42",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-540309-36",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-36",
       "answer": "no"
     },
     {
@@ -3885,91 +2787,21 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-595054-1",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-1",
-      "answer": "no",
-      "comment": "Bydlení je pro všechny, nejen pro bohaté."
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-2",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-2",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-3",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-3",
+      "id": "komunalni-2022-554782-a-540309-50",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-50",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-595054-4",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-4",
-      "answer": "yes",
-      "comment": "V obytných lokalitách."
+      "id": "komunalni-2022-554782-a-540309-51",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-595054-5",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "yes",
-      "comment": "V součinnosti s městskými firmami, jako je dopravní podnik apod."
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-6",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-6",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-7",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-7",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-8",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-8",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-9",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-9",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-10",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-11",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-12",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-12",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-13",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "yes",
-      "comment": "Jde o nouzové řešení. Prioritou je, aby lidé bydleli ve vytopeném bytě."
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-14",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-14",
+      "id": "komunalni-2022-554782-a-540309-43",
+      "candidate_id": "komunalni-2022-554782-c-540309",
+      "question_id": "komunalni-2022-554782-q-43",
       "answer": "yes"
     },
     {
@@ -3980,59 +2812,41 @@
       "comment": "V místech s nízkou frekvencí obyvatel zajistit chytré osvětlení reagující na pohyb."
     },
     {
-      "id": "komunalni-2022-554782-a-595054-16",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "yes",
-      "comment": "V administrativních budovách ano, ale ne ve školách a zdravotnických a sociálních zařízeních."
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-17",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-18",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-19",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-19",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-595054-20",
       "candidate_id": "komunalni-2022-554782-c-595054",
       "question_id": "komunalni-2022-554782-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-595054-21",
+      "id": "komunalni-2022-554782-a-595054-30",
       "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-21",
+      "question_id": "komunalni-2022-554782-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-595054-22",
+      "id": "komunalni-2022-554782-a-595054-1",
       "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-22",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "no",
+      "comment": "Bydlení je pro všechny, nejen pro bohaté."
+    },
+    {
+      "id": "komunalni-2022-554782-a-595054-8",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-8",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-595054-23",
+      "id": "komunalni-2022-554782-a-595054-58",
       "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-23",
-      "answer": "yes"
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-595054-24",
+      "id": "komunalni-2022-554782-a-595054-59",
       "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-24",
-      "answer": "yes"
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-595054-25",
@@ -4054,39 +2868,21 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-595054-28",
+      "id": "komunalni-2022-554782-a-595054-22",
       "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-28",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-595054-61",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-61",
       "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-595054-29",
       "candidate_id": "komunalni-2022-554782-c-595054",
       "question_id": "komunalni-2022-554782-q-29",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-30",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-31",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-32",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-33",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-33",
       "answer": "yes"
     },
     {
@@ -4097,71 +2893,11 @@
       "comment": "Jsme pro bezplatnou MHD. "
     },
     {
-      "id": "komunalni-2022-554782-a-595054-35",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-36",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-37",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-38",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-39",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-40",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-41",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-42",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-43",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-43",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-595054-44",
       "candidate_id": "komunalni-2022-554782-c-595054",
       "question_id": "komunalni-2022-554782-q-44",
       "answer": "yes",
       "comment": "Cyklostezky by měly být oddělené od silniční dopravy."
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-45",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-45",
-      "answer": "dont_know"
     },
     {
       "id": "komunalni-2022-554782-a-595054-46",
@@ -4182,25 +2918,66 @@
       "answer": "yes"
     },
     {
+      "id": "komunalni-2022-554782-a-595054-3",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-595054-5",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes",
+      "comment": "V součinnosti s městskými firmami, jako je dopravní podnik apod."
+    },
+    {
+      "id": "komunalni-2022-554782-a-595054-17",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-595054-19",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-595054-23",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-595054-28",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-595054-9",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-595054-31",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-595054-33",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
       "id": "komunalni-2022-554782-a-595054-49",
       "candidate_id": "komunalni-2022-554782-c-595054",
       "question_id": "komunalni-2022-554782-q-49",
       "answer": "dont_know",
       "comment": " Ne inkluzi za každou cenu, ale podle potřeb dítěte a možností dané školy. Podporuji speciální školství."
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-50",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "dont_know",
-      "comment": "Obecně jsem pro zklidnění dopravy v centru, ale pokud nejsou dobudovány vnější a městský okruh, je to těžko řešitelné."
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-51",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-51",
-      "answer": "dont_know",
-      "comment": "Obecně jsem pro zklidnění dopravy v centru, ale pokud nejsou dobudovány vnější a městský okruh, je to těžko řešitelné."
     },
     {
       "id": "komunalni-2022-554782-a-595054-52",
@@ -4227,28 +3004,10 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-595054-56",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-595054-57",
       "candidate_id": "komunalni-2022-554782-c-595054",
       "question_id": "komunalni-2022-554782-q-57",
       "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-58",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-595054-59",
-      "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-59",
-      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-595054-60",
@@ -4258,9 +3017,21 @@
       "comment": "Především na dopravní stavby (metro a městský okruh)."
     },
     {
-      "id": "komunalni-2022-554782-a-595054-61",
+      "id": "komunalni-2022-554782-a-595054-56",
       "candidate_id": "komunalni-2022-554782-c-595054",
-      "question_id": "komunalni-2022-554782-q-61",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-595054-42",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-595054-36",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-36",
       "answer": "yes"
     },
     {
@@ -4270,87 +3041,23 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-834158-1",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-1",
-      "answer": "no"
+      "id": "komunalni-2022-554782-a-595054-50",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-50",
+      "answer": "dont_know",
+      "comment": "Obecně jsem pro zklidnění dopravy v centru, ale pokud nejsou dobudovány vnější a městský okruh, je to těžko řešitelné."
     },
     {
-      "id": "komunalni-2022-554782-a-834158-2",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-2",
-      "answer": "yes"
+      "id": "komunalni-2022-554782-a-595054-51",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "dont_know",
+      "comment": "Obecně jsem pro zklidnění dopravy v centru, ale pokud nejsou dobudovány vnější a městský okruh, je to těžko řešitelné."
     },
     {
-      "id": "komunalni-2022-554782-a-834158-3",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-3",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-4",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-4",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-5",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-6",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-6",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-7",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-7",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-8",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-8",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-9",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-9",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-10",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-11",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-12",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-12",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-13",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-14",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-14",
+      "id": "komunalni-2022-554782-a-595054-43",
+      "candidate_id": "komunalni-2022-554782-c-595054",
+      "question_id": "komunalni-2022-554782-q-43",
       "answer": "yes"
     },
     {
@@ -4360,57 +3067,39 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-834158-16",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-17",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-18",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-19",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-19",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-834158-20",
       "candidate_id": "komunalni-2022-554782-c-834158",
       "question_id": "komunalni-2022-554782-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-834158-21",
+      "id": "komunalni-2022-554782-a-834158-30",
       "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-21",
+      "question_id": "komunalni-2022-554782-q-30",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-834158-22",
+      "id": "komunalni-2022-554782-a-834158-1",
       "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-22",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-834158-8",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-8",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-834158-23",
+      "id": "komunalni-2022-554782-a-834158-58",
       "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-23",
+      "question_id": "komunalni-2022-554782-q-58",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-834158-24",
+      "id": "komunalni-2022-554782-a-834158-59",
       "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-24",
+      "question_id": "komunalni-2022-554782-q-59",
       "answer": "dont_know"
     },
     {
@@ -4432,9 +3121,15 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-834158-28",
+      "id": "komunalni-2022-554782-a-834158-22",
       "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-28",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-834158-61",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-61",
       "answer": "yes"
     },
     {
@@ -4444,100 +3139,15 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-834158-30",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-31",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-32",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-33",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-33",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-834158-34",
       "candidate_id": "komunalni-2022-554782-c-834158",
       "question_id": "komunalni-2022-554782-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-834158-35",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-36",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-37",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-38",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-39",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-40",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "yes",
-      "comment": "Vybudujeme celoměstský hustý systém parkování prostředků mikromobility (kola, e-koloběžky a d.), který budou muset respektovat i sdílené služby.    "
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-41",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-42",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-43",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-43",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-834158-44",
       "candidate_id": "komunalni-2022-554782-c-834158",
       "question_id": "komunalni-2022-554782-q-44",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-45",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-45",
       "answer": "yes"
     },
     {
@@ -4559,21 +3169,63 @@
       "answer": "yes"
     },
     {
+      "id": "komunalni-2022-554782-a-834158-3",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-834158-5",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-834158-17",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-834158-19",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-834158-23",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-834158-28",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-834158-9",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-834158-31",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-834158-33",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
       "id": "komunalni-2022-554782-a-834158-49",
       "candidate_id": "komunalni-2022-554782-c-834158",
       "question_id": "komunalni-2022-554782-q-49",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-50",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-51",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-51",
       "answer": "yes"
     },
     {
@@ -4601,28 +3253,10 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-834158-56",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-834158-57",
       "candidate_id": "komunalni-2022-554782-c-834158",
       "question_id": "komunalni-2022-554782-q-57",
       "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-58",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-834158-59",
-      "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-59",
-      "answer": "dont_know"
     },
     {
       "id": "komunalni-2022-554782-a-834158-60",
@@ -4631,9 +3265,21 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-834158-61",
+      "id": "komunalni-2022-554782-a-834158-56",
       "candidate_id": "komunalni-2022-554782-c-834158",
-      "question_id": "komunalni-2022-554782-q-61",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-834158-42",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-834158-36",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-36",
       "answer": "yes"
     },
     {
@@ -4643,90 +3289,21 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-401009-1",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-1",
+      "id": "komunalni-2022-554782-a-834158-50",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-50",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-401009-2",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-2",
+      "id": "komunalni-2022-554782-a-834158-51",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-51",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-401009-3",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-3",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-4",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-4",
-      "answer": "no",
-      "comment": "Počet těchto zón by se naopak měl zredukovat."
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-5",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-6",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-6",
-      "answer": "no",
-      "comment": "Místo kamer by mělo být ve městě více strážníků."
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-7",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-7",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-8",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-8",
-      "answer": "no",
-      "comment": "Metro zdarma, zbytek MHD za 1000,-/ ročně, ale úplně zadarmo ne. Rozlišovat podmínky pro rezidenty a nerezidenty (turisty) není možné kvůli antidiskrimninační legislativě."
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-9",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-9",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-10",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-11",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-12",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-12",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-13",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-14",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-14",
+      "id": "komunalni-2022-554782-a-834158-43",
+      "candidate_id": "komunalni-2022-554782-c-834158",
+      "question_id": "komunalni-2022-554782-q-43",
       "answer": "yes"
     },
     {
@@ -4736,58 +3313,41 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-401009-16",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-17",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-18",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-19",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-19",
-      "answer": "no"
-    },
-    {
       "id": "komunalni-2022-554782-a-401009-20",
       "candidate_id": "komunalni-2022-554782-c-401009",
       "question_id": "komunalni-2022-554782-q-20",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-401009-21",
+      "id": "komunalni-2022-554782-a-401009-30",
       "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-21",
+      "question_id": "komunalni-2022-554782-q-30",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-401009-22",
+      "id": "komunalni-2022-554782-a-401009-1",
       "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-22",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-23",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-23",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-24",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-24",
+      "question_id": "komunalni-2022-554782-q-1",
       "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-401009-8",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "no",
+      "comment": "Metro zdarma, zbytek MHD za 1000,-/ ročně, ale úplně zadarmo ne. Rozlišovat podmínky pro rezidenty a nerezidenty (turisty) není možné kvůli antidiskrimninační legislativě."
+    },
+    {
+      "id": "komunalni-2022-554782-a-401009-58",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-401009-59",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-401009-25",
@@ -4810,10 +3370,16 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-401009-28",
+      "id": "komunalni-2022-554782-a-401009-22",
       "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-28",
-      "answer": "yes"
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-401009-61",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-401009-29",
@@ -4822,103 +3388,16 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-401009-30",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-31",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-32",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-33",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-33",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-401009-34",
       "candidate_id": "komunalni-2022-554782-c-401009",
       "question_id": "komunalni-2022-554782-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-401009-35",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "no",
-      "comment": "Soukromý sektor to zvládne lépe než úředníci města."
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-36",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "no",
-      "comment": "Stávající režim studentských slev je postačující."
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-37",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-38",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-39",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-40",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "no",
-      "comment": "Nebudou-li společnosti poskytující sdílené koloběžky schopny vynutit u svých klientů dodržování elementárních pravidel bezpečnosti a silničního provozu, jejich podnikání by mělo být silně regulováno. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-41",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-42",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-43",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-43",
-      "answer": "no"
-    },
-    {
       "id": "komunalni-2022-554782-a-401009-44",
       "candidate_id": "komunalni-2022-554782-c-401009",
       "question_id": "komunalni-2022-554782-q-44",
       "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-45",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-45",
-      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-401009-46",
@@ -4940,22 +3419,63 @@
       "comment": "Byly by to pouze byty pro úředníky a městské elity, ale určitě ne pro běžné občany. Město nemá suplovat soukromý sektor."
     },
     {
-      "id": "komunalni-2022-554782-a-401009-49",
+      "id": "komunalni-2022-554782-a-401009-3",
       "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-49",
+      "question_id": "komunalni-2022-554782-q-3",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-401009-50",
+      "id": "komunalni-2022-554782-a-401009-5",
       "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "no",
-      "comment": "Dokud nebude dobudován městský okruh, tedy jasná alternativní trasa, není možné dopravu v Praze násilím \"zklidňovat\" - ani na Smetanově nábřeží ani nikde jinde."
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-401009-51",
+      "id": "komunalni-2022-554782-a-401009-17",
       "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-51",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-401009-19",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-401009-23",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-401009-28",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-401009-9",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-401009-31",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-401009-33",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-401009-49",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-49",
       "answer": "no"
     },
     {
@@ -4984,28 +3504,10 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-401009-56",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-401009-57",
       "candidate_id": "komunalni-2022-554782-c-401009",
       "question_id": "komunalni-2022-554782-q-57",
       "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-58",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-401009-59",
-      "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-59",
-      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-401009-60",
@@ -5015,10 +3517,23 @@
       "comment": "Některé klíčové infrastrukturní projekty na území Prahy budou sloužit celé České republice a bez přispění státu není možné je realizovat."
     },
     {
-      "id": "komunalni-2022-554782-a-401009-61",
+      "id": "komunalni-2022-554782-a-401009-56",
       "candidate_id": "komunalni-2022-554782-c-401009",
-      "question_id": "komunalni-2022-554782-q-61",
-      "answer": "no"
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-401009-42",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-401009-36",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "no",
+      "comment": "Stávající režim studentských slev je postačující."
     },
     {
       "id": "komunalni-2022-554782-a-401009-62",
@@ -5027,92 +3542,23 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-528817-1",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-1",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-2",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-2",
-      "answer": "yes",
-      "comment": "Poplatky za svoz nerecyklovatelného odpadu mohou být efektivním způsobem motivace k větší recyklaci a podpoře cirkulární ekonomiky."
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-3",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-3",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-4",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-4",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-5",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-6",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-6",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-7",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-7",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-8",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-8",
+      "id": "komunalni-2022-554782-a-401009-50",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-50",
       "answer": "no",
-      "comment": "Přestože má MHD naši plnou podporu, se znalostí finančních možností města se domníváme, že není možné k tomuto opatření přistoupit, pokud by neměly být ohroženy investice do zlepšování dopravních služeb."
+      "comment": "Dokud nebude dobudován městský okruh, tedy jasná alternativní trasa, není možné dopravu v Praze násilím \"zklidňovat\" - ani na Smetanově nábřeží ani nikde jinde."
     },
     {
-      "id": "komunalni-2022-554782-a-528817-9",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-9",
-      "answer": "yes"
+      "id": "komunalni-2022-554782-a-401009-51",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-528817-10",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-11",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-12",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-12",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-13",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "no",
-      "comment": "Město by se mělo spíše ubírat směrem konkrétní pomoci lidem bez domova a prevenci bezdomovectví."
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-14",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-14",
-      "answer": "yes",
-      "comment": "Obecně je třeba zlepšovat způsoby nasvícení památek, nasvěcovat lokálně detaily a upoštět od plnoplošného nasvícení. K tomu je potřeba užívat úspornějších zářičů. I ve vztahu ke světelnému smogu."
+      "id": "komunalni-2022-554782-a-401009-43",
+      "candidate_id": "komunalni-2022-554782-c-401009",
+      "question_id": "komunalni-2022-554782-q-43",
+      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-528817-15",
@@ -5122,30 +3568,6 @@
       "comment": "Je třeba jednat o zmírnění normy, která nařizuje velmi intenzivní osvětlení. Zároveň je však třeba osvětlení zachovat kvůli bezpečnosti, v nočních hodinách nesmí být narušena."
     },
     {
-      "id": "komunalni-2022-554782-a-528817-16",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-17",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-18",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-19",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-19",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-528817-20",
       "candidate_id": "komunalni-2022-554782-c-528817",
       "question_id": "komunalni-2022-554782-q-20",
@@ -5153,29 +3575,35 @@
       "comment": "V minulém volebním období naše koalice zastavila privatizaci bytů a začala připravovat městskou výstavbu díky založení Pražské developerské společnosti."
     },
     {
-      "id": "komunalni-2022-554782-a-528817-21",
+      "id": "komunalni-2022-554782-a-528817-30",
       "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-21",
+      "question_id": "komunalni-2022-554782-q-30",
+      "answer": "yes",
+      "comment": "Mělo by to být součástí komplexní reformy daně z nemovitosti, která by měla obsahovat celou řadu motivačních nástrojů."
+    },
+    {
+      "id": "komunalni-2022-554782-a-528817-1",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-528817-8",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "no",
+      "comment": "Přestože má MHD naši plnou podporu, se znalostí finančních možností města se domníváme, že není možné k tomuto opatření přistoupit, pokud by neměly být ohroženy investice do zlepšování dopravních služeb."
+    },
+    {
+      "id": "komunalni-2022-554782-a-528817-58",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-58",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-528817-22",
+      "id": "komunalni-2022-554782-a-528817-59",
       "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-22",
-      "answer": "yes",
-      "comment": "Nájem v městských bytech by měl být co nejnižší, nemusí být tržní, ovšem nemí být podnákladový. Výstavba městských bytů musí být ekonomicky udržitelná. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-23",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-23",
-      "answer": "no",
-      "comment": "Měla by být možnost pro děti z ohrožených skupin využívat fondy na obědy zřízené městem nebo neziskovými organizacemi. Preferujeme ale cílenou pomoc před plošnou."
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-24",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-24",
+      "question_id": "komunalni-2022-554782-q-59",
       "answer": "yes"
     },
     {
@@ -5198,10 +3626,18 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-528817-28",
+      "id": "komunalni-2022-554782-a-528817-22",
       "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-28",
-      "answer": "yes"
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "yes",
+      "comment": "Nájem v městských bytech by měl být co nejnižší, nemusí být tržní, ovšem nemí být podnákladový. Výstavba městských bytů musí být ekonomicky udržitelná. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-528817-61",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "yes",
+      "comment": "Podporujeme, aby se v okolí filharmonie na městských a drážních pozemcích budovalo městské bydlení."
     },
     {
       "id": "komunalni-2022-554782-a-528817-29",
@@ -5211,102 +3647,15 @@
       "comment": "Musí se ale hledat vyvážený mix."
     },
     {
-      "id": "komunalni-2022-554782-a-528817-30",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "yes",
-      "comment": "Mělo by to být součástí komplexní reformy daně z nemovitosti, která by měla obsahovat celou řadu motivačních nástrojů."
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-31",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "yes",
-      "comment": "Ano, ale musí vycházet z reálné ekonomické situaci. Nesmí se nich stát nástroj blokování výstavby."
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-32",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-33",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-33",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-528817-34",
       "candidate_id": "komunalni-2022-554782-c-528817",
       "question_id": "komunalni-2022-554782-q-34",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-528817-35",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-36",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-37",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-38",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-39",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-40",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "dont_know",
-      "comment": "Ano, ale za jasných pravidel provozu i umístění."
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-41",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-42",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-43",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-43",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-528817-44",
       "candidate_id": "komunalni-2022-554782-c-528817",
       "question_id": "komunalni-2022-554782-q-44",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-45",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-45",
       "answer": "yes"
     },
     {
@@ -5328,21 +3677,65 @@
       "answer": "yes"
     },
     {
+      "id": "komunalni-2022-554782-a-528817-3",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-528817-5",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-528817-17",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-528817-19",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-528817-23",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "no",
+      "comment": "Měla by být možnost pro děti z ohrožených skupin využívat fondy na obědy zřízené městem nebo neziskovými organizacemi. Preferujeme ale cílenou pomoc před plošnou."
+    },
+    {
+      "id": "komunalni-2022-554782-a-528817-28",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-528817-9",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-528817-31",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes",
+      "comment": "Ano, ale musí vycházet z reálné ekonomické situaci. Nesmí se nich stát nástroj blokování výstavby."
+    },
+    {
+      "id": "komunalni-2022-554782-a-528817-33",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
       "id": "komunalni-2022-554782-a-528817-49",
       "candidate_id": "komunalni-2022-554782-c-528817",
       "question_id": "komunalni-2022-554782-q-49",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-50",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-51",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-51",
       "answer": "yes"
     },
     {
@@ -5372,29 +3765,11 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-528817-56",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-528817-57",
       "candidate_id": "komunalni-2022-554782-c-528817",
       "question_id": "komunalni-2022-554782-q-57",
       "answer": "yes",
       "comment": "Je třeba vyřešit i legislatviní souvislosti."
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-58",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-528817-59",
-      "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-59",
-      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-528817-60",
@@ -5403,11 +3778,22 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-528817-61",
+      "id": "komunalni-2022-554782-a-528817-56",
       "candidate_id": "komunalni-2022-554782-c-528817",
-      "question_id": "komunalni-2022-554782-q-61",
-      "answer": "yes",
-      "comment": "Podporujeme, aby se v okolí filharmonie na městských a drážních pozemcích budovalo městské bydlení."
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-528817-42",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-528817-36",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-528817-62",
@@ -5416,102 +3802,22 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-738486-1",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-1",
-      "answer": "no",
-      "comment": "Je v zájmu města, aby jednotlivé čtvrti byly sociálně heterogenní a pestré. Každá městská část potřebuje pro svůj chod i další skupiny lidí, kteří na vysoké příjmy nedosáhnou (učitelé, zdravotní sestry, policisté,...). Rovněž lidé, kteří v dané lokalitě žijí celý život, by měli mít možnost zde trávit i své stáří. Proto by v každé čtvrti měla být část bytů dostupná za zvýhodněných podmínek formou dostupného a sociálního bydlení. Odmítáme vznik uzavřených neprůchodných částí města (tzv. gated communities)."
+      "id": "komunalni-2022-554782-a-528817-50",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-50",
+      "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-738486-2",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-2",
-      "answer": "yes",
-      "comment": "Nakládání s odpadem stojí veřejné prostředky a odpad zatěžuje životní prostředí. Skrze poplatky za svoz odpadu město motivuje Pražany ke snižování produkce odpadu a také ke třídění tak, aby bylo možné s odpadem dále nakládat a nekončil na skládkách. Podporujeme také principy reuse, repair a upcycle, které rovněž pomáhají redukovat množství komunálního odpadu."
+      "id": "komunalni-2022-554782-a-528817-51",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-738486-3",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-3",
-      "answer": "no",
-      "comment": "Samosprávy mají jiné rezervy. Můžeme začít spíše tím, že nebudeme přetápět školy, úřady a další veřejné budovy. Už omezení takových základních nehospodárností významně pomůže. Domovy seniorů potom musí zachovat takovou úroveň vytápění, aby nebylo ohroženo zdraví jejich klientů. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-4",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-4",
-      "answer": "yes",
-      "comment": "Zóny 30 už fungují na velké části města a měly by se dále rozšiřovat, protože výrazně zvyšují bezpečnost dopravy a umožňují příjemnější soužití aut s chodci a cyklisty. Podporujeme, aby městské části rozšiřovaly zóny 30 v rezidenčních oblastech mimo hlavní tahy."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-5",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "yes",
-      "comment": "Je potřeba napomáhat tomu, aby se snižovalo zadlužení Pražanů. Dřívější praxe, kdy dlužníkům naskakovaly obrovské úroky z prodlení a pokuty, které několikanásobně převyšují původní dluh, je nemorální. Proto jsme zaúkolovali Magistrát, aby obeslal své dlužníky a informoval je o možnosti využít Milostivého léta. To stejné dělá například Dopravní podnik."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-6",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-6",
-      "answer": "no",
-      "comment": "V Praze je v současnosti integrovaného do metropolitního kamerového systému přes 4 500 kamer, z toho více než 1 000 pod správou města a městských částí. Město by se nyní mělo soustředit na výměnu stávajících kamer za moderní digitální s vysokým rozlišením, které bude možné efektivně využít pro zvýšení bezpečnosti. Důležité je i zabezpečení kamerového systému jako takového a důsledná kontrola přístupu k datům z kamer, aby nemohla být zneužita. Piráti současně odmítají jakékoli snahy o využívání umělé inteligence a dalších technologií pro rozpoznávání obličejů."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-7",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-7",
-      "answer": "no",
-      "comment": "U hazardu stejně jako u návykových látek je potřeba snižovat rizika s nimi spojená, protože ničí mnohé lidské životy jak uživatelů, tak jejich okolí. Prohibice ale není nejlepším řešením. S jednotlivými hazardními hrami jsou spojena různá rizika, nelze všechny házet do jednoho pytle. Navíc v případě nulové tolerance se hráči ve velké míře přesouvají do těžko regulovatelného online prostoru, kde nelze účinně snižovat rizika. Proto místo prohibice prosazujeme prevenci, regulaci tvrdých hazardních her (například „výherních“ automatů) a rozšiřování adiktologických služeb. Nevidíme ale důvod omezovat lidi například v tom, aby si šli zahrát poker do kasina."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-8",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-8",
-      "answer": "no",
-      "comment": "Praha má oproti ostatním městům jak v Česku, tak v zahraničí cenově velmi dostupné MHD a tak by to mělo zůstat, protože mobilita je pro město klíčová a cestování MHD je ekologické a prostorově efektivní. Rozšiřování, zvyšování kvality a provoz MHD ale stojí hodně peněz, v současnosti na něj město vydává cca čtvrtinu svého rozpočtu. Kdyby bylo MHD bezplatné, Praha by neměla dostatek prostředků na investice například do dalšího rozvoje MHD, který je potřebný pro zvyšování počtu cestujících a kvality poskytovaných služeb."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-9",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-9",
-      "answer": "yes",
-      "comment": "Bezbariérové zastávky a stanice slouží všem, ne pouze lidem na vozíku či osobám se zdravotním omezením. Pomáhají i rodičům s malými dětmi nebo cyklistům. Nástupiště bez vysokých schodů v kombinaci s nízkopodlažními dopravními prostředky také urychlují výměnu cestujících a zrychlují veřejnou dopravu. Naším cílem je bezbariérové město jako celek, ne pouze bezbariérová veřejná doprava."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-10",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "yes",
-      "comment": "Jmenovité hlasování je důležité proto, aby voliči mohli kontrolovat, co prosazují jimi zvolení zástupci. V pražském zastupitelstvu je jmenovité hlasování již dlouhodobě a chceme ho zachovat. V tomto volebním období jsme začali zveřejňovat záznamy hlasování jednotlivých zastupitelů v portálu otevřených dat a u jednotlivých usnesení si kdokoliv může jednoduše zobrazit, jak kdo hlasoval. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-11",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "yes",
-      "comment": "Jmenovité hlasování v Radě prosazujeme dlouhodobě, podařilo se nám dosáhnout toho, že od roku 2023 již bude zavedené."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-12",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-12",
-      "answer": "yes",
-      "comment": "Pyrotechnika vytváří velký hluk a vede ke zraněním jak lidí, tak zvířat."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-13",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "yes",
-      "comment": "Za dodržení obecných pravidel, tj. dodržování pořádku, hygieny apod. by to mohlo být řešení pro případ nouze."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-14",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-14",
-      "answer": "yes",
-      "comment": "Praha už nyní zkrátila noční nasvícení památek a dalších objektů. Bylo by vhodné zamyslet se nad omezením osvětlení v pozdních nočních hodinách a co nejdříve dokončit výměnu zdrojů nascvícení za energeticky úspornější."
+      "id": "komunalni-2022-554782-a-528817-43",
+      "candidate_id": "komunalni-2022-554782-c-528817",
+      "question_id": "komunalni-2022-554782-q-43",
+      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-738486-15",
@@ -5521,34 +3827,6 @@
       "comment": "Veřejné osvětlení je důležité pro zajištění bezpečnosti ve městě i pro subjektivní pocit bezpečí občanů. Podporujeme proto modernizaci veřejného osvětlení a výměnu světelných zdrojů za energeticky úspornější, ne jeho omezování. V některých lokalitách (např. v parcích mimo rezidenční oblasti) bychom zvážili zavedení chytrého osvětlení, které by bylo v nočních hodinách ztlumené a více se rozsvítilo při zaznamenání pohybu osob."
     },
     {
-      "id": "komunalni-2022-554782-a-738486-16",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "yes",
-      "comment": "Rada hl. m. Prahy již schválila, že v objektech v majetku města má být regulováno vytápění tak, aby byla snížena průměrná vnitřní teplota na maximálně 22 °C a omezilo se vytápění v časech, kdy v budovách není nikdo přítomen. Budeme zvažovat zpřísnění tohoto usnesení."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-17",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "yes",
-      "comment": "Již jsme v tomto volebním období zrealizovali."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-18",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "yes",
-      "comment": "Je nicméně potřeba podotknout, že mnohem lepší obrázek o hospodaření města občanům poskytne aplikace Cityvizor, kterou jsme v tomto volebním období spustili a která umožňuje proklikat se skrze hospodaření města podle jednotlivých oblastí až na úroveň faktur. Informace z transparentních účtů je potřeba uvádět do kontextu. Město hromadí prostředky na účtech například kvůli budoucí splátce dluhopisů či plánovaným významným investicím."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-19",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-19",
-      "answer": "yes",
-      "comment": "Chceme nadále z pražského rozpočtu spolufinancovat participativní rozpočty na úrovni městských částí, které mají k občanům blíž."
-    },
-    {
       "id": "komunalni-2022-554782-a-738486-20",
       "candidate_id": "komunalni-2022-554782-c-738486",
       "question_id": "komunalni-2022-554782-q-20",
@@ -5556,32 +3834,39 @@
       "comment": "Chceme postavit tisíce nových městských bytů, jejichž výstavbu připravuje Pražská developerská společnost, kterou jsme v tomto volebním období vytvořili. Bytový fond města je hlavním nástrojem bytové politiky a město skrze něj může řešit bytové potřeby nízkopříjmových domácností, ať už jde o seniory, lidi v nouzi či zaměstnance potřebné k chodu města, jako jsou učitelé, hasiči či zdravotníci. Bydlení je také jednou z mála investic, z nichž může mít město průběžný příjem, navíc cena bytů a tím pádem hodnota městského majetku se neustále zvyšuje."
     },
     {
-      "id": "komunalni-2022-554782-a-738486-21",
+      "id": "komunalni-2022-554782-a-738486-30",
       "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-21",
+      "question_id": "komunalni-2022-554782-q-30",
       "answer": "dont_know",
-      "comment": "Praha už nyní zkrátila noční nasvícení památek a dalších objektů. Obdobně i vánoční světelná výzdoba by mohla být omezena v pozdních nočních hodinách."
+      "comment": "Daňová legislativa je věcí státu. Možností jak omezit spekulativní nákupy bytů je více. Identifikace prázdných bytů je obtížná. Je vhodnější to dělat pomocí jiný změn v daňovém systému, např. stavením odečitatelných položek v dani z nemovitosti. "
     },
     {
-      "id": "komunalni-2022-554782-a-738486-22",
+      "id": "komunalni-2022-554782-a-738486-1",
       "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-22",
-      "answer": "yes",
-      "comment": "Chceme udržet nájemné v městských bytech na dostupné úrovni, protože městské byty jsou určeny pro nízkopříjmové domácnosti. V současnosti je stanoveno zhruba na polovině tržních cen, což městu přináší dostatečné prostředky na průběžnou údržbu bytového fondu."
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "no",
+      "comment": "Je v zájmu města, aby jednotlivé čtvrti byly sociálně heterogenní a pestré. Každá městská část potřebuje pro svůj chod i další skupiny lidí, kteří na vysoké příjmy nedosáhnou (učitelé, zdravotní sestry, policisté,...). Rovněž lidé, kteří v dané lokalitě žijí celý život, by měli mít možnost zde trávit i své stáří. Proto by v každé čtvrti měla být část bytů dostupná za zvýhodněných podmínek formou dostupného a sociálního bydlení. Odmítáme vznik uzavřených neprůchodných částí města (tzv. gated communities)."
     },
     {
-      "id": "komunalni-2022-554782-a-738486-23",
+      "id": "komunalni-2022-554782-a-738486-8",
       "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-23",
-      "answer": "yes",
-      "comment": "Nechceme, aby děti z chudších rodin zůstávály ve školách bez obědů. Proto budeme dále rozvíjet programy financování obědů zdarma pro děti, jejichž rodiče si je nemohou dovolit platit. Většina rodičů ale na hrazení obědů peníze má a nebylo by hospodárné platit obědy za všechny."
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "no",
+      "comment": "Praha má oproti ostatním městům jak v Česku, tak v zahraničí cenově velmi dostupné MHD a tak by to mělo zůstat, protože mobilita je pro město klíčová a cestování MHD je ekologické a prostorově efektivní. Rozšiřování, zvyšování kvality a provoz MHD ale stojí hodně peněz, v současnosti na něj město vydává cca čtvrtinu svého rozpočtu. Kdyby bylo MHD bezplatné, Praha by neměla dostatek prostředků na investice například do dalšího rozvoje MHD, který je potřebný pro zvyšování počtu cestujících a kvality poskytovaných služeb."
     },
     {
-      "id": "komunalni-2022-554782-a-738486-24",
+      "id": "komunalni-2022-554782-a-738486-58",
       "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-24",
+      "question_id": "komunalni-2022-554782-q-58",
       "answer": "yes",
-      "comment": "Carsharingové služby (na rozdíl od služeb typu Uber) pomáhají odlehčit dopravě a sdílená auta bývají využívána efektivněji než soukromé vozy, které až 95 % času tráví zaparkované na jednom místě. Podporujeme však nastavení takových pravidel, které bude poskytovatele carsharingových služeb motivovat k pořízení lokálně bezemisních vozidel."
+      "comment": "Dle vytvořené Koncepce rozvoje čtyřletých gymnázií v Praze by se měly paralelně rozšiřovat kapacity stávajících gymnázií, počty gymnaziálních tříd i zakládat gymnázia nová (např. Běchovice, Barrandov, Lužiny)."
+    },
+    {
+      "id": "komunalni-2022-554782-a-738486-59",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "yes",
+      "comment": "Tento koncept se už osvědčil jak svojí rolí v prolínání sociálních bublin, tak prakticky z důvodu lepšího sdílení personálních a materiálních nákladů."
     },
     {
       "id": "komunalni-2022-554782-a-738486-25",
@@ -5605,11 +3890,18 @@
       "comment": "V tomto volebním obdobdí jsme privatizaci bytů města ukončili. Bohužel některé městské části dále privatizují, což chceme omezit. Město už dnes nemá dostatek bytů pro naplňování bytové politiky. Chceme proto stavět nové byty a pronajímat je seniorům, rodinám v nouzi či podporovaným profesím jako jsou učitelé, hasiči či zdravotníci, jejichž činnost je klíčová pro chod města a přitom nejsou dostatečně platově ohodnoceni."
     },
     {
-      "id": "komunalni-2022-554782-a-738486-28",
+      "id": "komunalni-2022-554782-a-738486-22",
       "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-28",
+      "question_id": "komunalni-2022-554782-q-22",
       "answer": "yes",
-      "comment": "V tomto období jsme schválili metodiku spoluúčasti investorů na rozvoji Prahy. Podpoříme navýšení tarifů tak, aby se developeři skutečně adekvátně podíleli na nákladech, které nová výstavba přináší v souvislosti s budováním veřejné vybavenosti a infrastruktury, např. škol, školek či parků nebo poskytnutím části bytů pro dostupné či sociální bydlení."
+      "comment": "Chceme udržet nájemné v městských bytech na dostupné úrovni, protože městské byty jsou určeny pro nízkopříjmové domácnosti. V současnosti je stanoveno zhruba na polovině tržních cen, což městu přináší dostatečné prostředky na průběžnou údržbu bytového fondu."
+    },
+    {
+      "id": "komunalni-2022-554782-a-738486-61",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "yes",
+      "comment": "Je v zájmu města, aby jednotlivé čtvrti byly sociálně heterogenní a pestré. Každá městská část potřebuje pro svůj chod i další skupiny lidí, kteří na vysoké příjmy nedosáhnou (učitelé, zdravotní sestry, policisté,...). Rovněž lidé, kteří v dané lokalitě žijí celý život, by měli mít možnost zde trávit i své stáří. Proto by v každé čtvrti měla být část bytů dostupná za zvýhodněných podmínek formou dostupného a sociálního bydlení."
     },
     {
       "id": "komunalni-2022-554782-a-738486-29",
@@ -5619,34 +3911,6 @@
       "comment": "Dlouhodobým cílem Prahy podle jejího strategického a klimatického plánu i plánu udržitelné mobility je zvýšení podílu veřejné, pěší a cyklistické dopravy, tedy těch módů dopravy, které jsou ekologicky, ekonomicky a prostorově šetrné. Automobilová doprava však má v pražském dopravním mixu své pevné místo pro všechny druhy případů, kdy je nenahraditelná."
     },
     {
-      "id": "komunalni-2022-554782-a-738486-30",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "dont_know",
-      "comment": "Daňová legislativa je věcí státu. Možností jak omezit spekulativní nákupy bytů je více. Identifikace prázdných bytů je obtížná. Je vhodnější to dělat pomocí jiný změn v daňovém systému, např. stavením odečitatelných položek v dani z nemovitosti. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-31",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "yes",
-      "comment": "Navážeme na metodiku spoluúčasti investorů na rozvoji Prahy, kterou jsme schválili v tomto období. Podpoříme navýšení tarifů tak, aby se developeři adekvátně podíleli na nákladech, které nová výstavba přináší v souvislosti s budováním veřejné vybavenosti a infrastruktury, např. škol, školek či parků."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-32",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "yes",
-      "comment": "Město v roce 2020 vypracovalo Generel rozvoje dobíjecí infrastruktury, který počítá s výstavnou tzv. pomalého parkovacího dobíjení v rezidenčních lokalitách na modernizovaných lampách veřejného osvětlení či na samostatných sloupcích. Počet bateriových a plug-in hybridních vozidel, která se nabíjejí ze zásuvky, v Praze roste rychleji než v dalších regionech a je třeba na situaci reagovat, aby bylo dobíjení dostupné i pro občany, kteří si nemohou elektromobil dobíjet z domácí zásuvky nebo v zaměstnání. Město současně podporuje výstavbu vysoce výkonných rychlodobíječek ve spolupráci se soukromými partnery."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-33",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-33",
-      "answer": "yes",
-      "comment": "Plánujeme realizovat pilotní projekty spolkového a družstevního bydlení na městských pozemcích, které jsme v tomto volebním období připravili. Může se jednat o vhodný doplněk k tržnímu a městskému bydlení."
-    },
-    {
       "id": "komunalni-2022-554782-a-738486-34",
       "candidate_id": "komunalni-2022-554782-c-738486",
       "question_id": "komunalni-2022-554782-q-34",
@@ -5654,81 +3918,11 @@
       "comment": "Podporujeme zachování současného systému, kdy děti do 15 let mají jízdné bezplatné a studenti do 26 mají slevu. Usilujeme o prosazení zastropování měsíčního jízdného v MHD. V případě nákupu měsíčního kuponu, pak výrazně nepřeplatí náklady na pořízení ročního kuponu."
     },
     {
-      "id": "komunalni-2022-554782-a-738486-35",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "yes",
-      "comment": "Město by mělo prostřednictvím Pražského společenství obnovitelné energie metodicky i prakticky pomáhat vlastníkům soukromých objektů k rychlejší a snazší instalaci fotovoltaiky i k získávání dotací. Důležité je, aby se podařilo prosadit změny legislativy, které umožní vznik tzv. lokálních distribučních soustav (LDS), aby vlastníci objektů nemuseli za vlastní vyrobenou elektřinu platit distribuční poplatky."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-36",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "yes",
-      "comment": "Ano, pro studenty je dobré otevřít městské kulturní instituce zdarma. Všem, resp. společnosti jako celku, tedy i obyvatelům Prahy, se to vyplatí. Studenti potřebují navštěvovat reálnou kulturu, výstavy apod., na kterou ovšem často nemají peníze. Přispívá to k jejich všestranému rozvoji a tzv. kulturní kompetence, tedy schopnost vnímat umění a kulturu, která posiluje komplexní kreativní myšlení, tak potřebné v moderní ekonomice, se stává jasným a zřetelným fenoménem i v celém světě."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-37",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "yes",
-      "comment": "Řadě žen s nízkými příjmy zasahuje nutnost nákupu menstruačních hygienických pomůcek každý měsíc do výdajů. Jde o fenomén tzv. „menstruační chudoby“, proti níž chceme bojovat."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-38",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "dont_know",
-      "comment": "Řadě žen s nízkými příjmy zasahuje nutnost nákupu menstruačních hygienických pomůcek každý měsíc do výdajů. Jde o fenomén tzv. „menstruační chudoby“, proti níž chceme bojovat. Zavedení zákonné povinnosti pro místní úřady poskytovat tyto pomůcky zdarma však nepovažujeme za dobrý způsob. Podporujeme dostupnost menstruačních pomůcek ve školách a na úřadech."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-39",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "yes",
-      "comment": "Chceme instalovat fotovoltaické panely na střechách městských budov tam, kde to umožňuje stav objektů a podmínky památkové ochrany. Takto vyrobená elektřina pomůže snížit energetickou náročnost budov, ušetřit za dodávky elektřiny a v kombinaci s technologiemi pro ukládání energie třeba i dodávat elektřinu pro dobíjecí stanice pro elektromobily parkující u objektů. Navíc tím přispějeme ke snížení emisí."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-40",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "yes",
-      "comment": "Vidíme velký potenciál v individuální i sdílené mikromobilitě, a to hlavně ve sdílených kolech a elektrokolech, které Pražanům pomáhají překonávat kopcovitý terén. Vhodným dopravním prostředkem mohou být i sdílené elektrokoloběžky, které ale v současnosti působí mnoho problémů, protože jejich uživatelé s nimi často jezdí a parkují na chodnících. Budeme proto vytvářet parkovací místa pro kola a koloběžky mimo chodníky a vymáhat po poskytovatelích sdílených služeb, aby jejich uživatelé jezdili po vozovce tak, jak mají, a neodkládali koloběžky na chodník. Provozovatelé, kteří nebudou s městem spolupracovat, by měli být za přestupky svých zákazníků pokutováni."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-41",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "yes",
-      "comment": "Cizinci v Praze jsou a budou. Jejich integrace je důležitá nejen pro ně samotné, ale i pro Pražany."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-42",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "yes",
-      "comment": "Strážníků je v ulicích málo a státní policie řeší často jiné věci. Uhazečů o místo strážníka je ale málo a těch, kteří splní vysoké nároky na fyzickou i psychickou zdatnost je ještě méně - proto je třeba jednak motivovat uchazeče finančně i nefinančními benefity, jednak redukovat byrokracii a množství úkolů, které by mohl místo strážníka plnit úředník. Za podstatné tedy považujeme uvolnit strážníkům ruce od papírovaní, aby tak měli čas být skutečně více v terénu."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-43",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-43",
-      "answer": "yes",
-      "comment": "Zelené střechy jsou důležité pro adaptaci na klimatickou změnu. Instalace zelených střech je již navržena za určitých podmínek v novele pražských stavebních předpisu, které jsou právě projednávány."
-    },
-    {
       "id": "komunalni-2022-554782-a-738486-44",
       "candidate_id": "komunalni-2022-554782-c-738486",
       "question_id": "komunalni-2022-554782-q-44",
       "answer": "yes",
       "comment": "Cyklodoprava je jedním z šetrných druhů městské dopravy, a proto podpoříme její uživatele rozšiřováním míst pro uložení jízdních kol v podobě stojanů a koláren, dostupností šaten a sprch ve školách a úřadech, zlepšováním infrastruktury pro jízdu na kole či komunikačními kampaněmi."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-45",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-45",
-      "answer": "no",
-      "comment": "V současné době město podporuje profesionální sport jen cca 5 % financí určených celkem ročně podporu sportu, kdy jsou podporovány z důvodu cestovního ruchu a propagace města významné profesionální sportovní akce. Na tomto systému by se nemělo nic měnit."
     },
     {
       "id": "komunalni-2022-554782-a-738486-46",
@@ -5752,25 +3946,74 @@
       "comment": "Dostatečně velký obecní bytový fond je jednou z podmínek pro vytváření účinné bytové politiky města."
     },
     {
+      "id": "komunalni-2022-554782-a-738486-3",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no",
+      "comment": "Samosprávy mají jiné rezervy. Můžeme začít spíše tím, že nebudeme přetápět školy, úřady a další veřejné budovy. Už omezení takových základních nehospodárností významně pomůže. Domovy seniorů potom musí zachovat takovou úroveň vytápění, aby nebylo ohroženo zdraví jejich klientů. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-738486-5",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes",
+      "comment": "Je potřeba napomáhat tomu, aby se snižovalo zadlužení Pražanů. Dřívější praxe, kdy dlužníkům naskakovaly obrovské úroky z prodlení a pokuty, které několikanásobně převyšují původní dluh, je nemorální. Proto jsme zaúkolovali Magistrát, aby obeslal své dlužníky a informoval je o možnosti využít Milostivého léta. To stejné dělá například Dopravní podnik."
+    },
+    {
+      "id": "komunalni-2022-554782-a-738486-17",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes",
+      "comment": "Již jsme v tomto volebním období zrealizovali."
+    },
+    {
+      "id": "komunalni-2022-554782-a-738486-19",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes",
+      "comment": "Chceme nadále z pražského rozpočtu spolufinancovat participativní rozpočty na úrovni městských částí, které mají k občanům blíž."
+    },
+    {
+      "id": "komunalni-2022-554782-a-738486-23",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "yes",
+      "comment": "Nechceme, aby děti z chudších rodin zůstávály ve školách bez obědů. Proto budeme dále rozvíjet programy financování obědů zdarma pro děti, jejichž rodiče si je nemohou dovolit platit. Většina rodičů ale na hrazení obědů peníze má a nebylo by hospodárné platit obědy za všechny."
+    },
+    {
+      "id": "komunalni-2022-554782-a-738486-28",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes",
+      "comment": "V tomto období jsme schválili metodiku spoluúčasti investorů na rozvoji Prahy. Podpoříme navýšení tarifů tak, aby se developeři skutečně adekvátně podíleli na nákladech, které nová výstavba přináší v souvislosti s budováním veřejné vybavenosti a infrastruktury, např. škol, školek či parků nebo poskytnutím části bytů pro dostupné či sociální bydlení."
+    },
+    {
+      "id": "komunalni-2022-554782-a-738486-9",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes",
+      "comment": "Bezbariérové zastávky a stanice slouží všem, ne pouze lidem na vozíku či osobám se zdravotním omezením. Pomáhají i rodičům s malými dětmi nebo cyklistům. Nástupiště bez vysokých schodů v kombinaci s nízkopodlažními dopravními prostředky také urychlují výměnu cestujících a zrychlují veřejnou dopravu. Naším cílem je bezbariérové město jako celek, ne pouze bezbariérová veřejná doprava."
+    },
+    {
+      "id": "komunalni-2022-554782-a-738486-31",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes",
+      "comment": "Navážeme na metodiku spoluúčasti investorů na rozvoji Prahy, kterou jsme schválili v tomto období. Podpoříme navýšení tarifů tak, aby se developeři adekvátně podíleli na nákladech, které nová výstavba přináší v souvislosti s budováním veřejné vybavenosti a infrastruktury, např. škol, školek či parků."
+    },
+    {
+      "id": "komunalni-2022-554782-a-738486-33",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes",
+      "comment": "Plánujeme realizovat pilotní projekty spolkového a družstevního bydlení na městských pozemcích, které jsme v tomto volebním období připravili. Může se jednat o vhodný doplněk k tržnímu a městskému bydlení."
+    },
+    {
       "id": "komunalni-2022-554782-a-738486-49",
       "candidate_id": "komunalni-2022-554782-c-738486",
       "question_id": "komunalni-2022-554782-q-49",
       "answer": "yes",
       "comment": "Koncentrace sociálně znevýhodněných dětí v několika málo školách nepomáhá nikomu, naopak to vede k dědění chudoby, zvyšování počtu předčasných odchodů ze vzdělávání a prohlubování sociálního vyloučení, což stát stojí nemalé peníze."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-50",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "yes",
-      "comment": "Smetanovo nábřeží je cenný prostor přímo v srdci pražské památkové rezervace, a jako takový by neměl sloužit tranzitní dopravě. Auta na nábřežích navíc způsobují zpoždění tramvají, které přepravují řádově více Pražanů. Od otevření tunelu Blanka existují dostatečně kapacitní trasy, kterými lze toto území objet, proto se není třeba bát přelití do rezidenčních ulic. Smetanovo nábřeží spolu s protější Malou Stranou může sloužit návstěvníkům města, tramvajové a bezmotorové dopravě a rezidentům."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-51",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-51",
-      "answer": "dont_know",
-      "comment": "V případě Masarykova nábřeží je třeba dokončit druhou etapu, jak ji připravil IPR ve své koncepční studii, kde se počítá s zlepšením prostupnosti pro pěší a cyklisty. V případě Rašínova nábřeží žádná koncepční studie zpracována není. Peší a cyklodoprava je vedena po náplavkách, což bylo donedávna dostačujícím řešením, ale v buducnu ho bude třeba také řešit koncepčněji. Obě nábřeží je třeba upravit tak, aby umožňovaly bezpečný, klidný a plynulý průjezd všech druhů dopravy. Zejména Rašínovo nábřeží je důležitou dopravní spojnicí, jeho průjezdnost autem je klíčová pro Prahu 1, 2, 4 a 5 a musí být zachována."
     },
     {
       "id": "komunalni-2022-554782-a-738486-52",
@@ -5801,32 +4044,11 @@
       "comment": "Poskytovat domácnostem v nouzi finanční pomoc na úhradu kauce je úkolem Úřadu práce. Mnoho domácností totiž má dostatečné příjmy na placení nájemného, ale nemají peníze na kauci a bez pomoci pak končí například v azylových domech, které jsou velmi nákladné na provoz a navíc neřeší bytovou nouzi svých klientů. Efektivnější je pomoci lidem se zaplacením kauce, aby mohli bydlet ve standardních bytech. Tam, kde úřad práce nefunguje, by mělo pomoci město, proto jsme založili Sociální nadační fond."
     },
     {
-      "id": "komunalni-2022-554782-a-738486-56",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "yes",
-      "comment": "V tomto volebním období Praha začala s procesem tranformace pobytových zařízení, které byly umístěné po celé republice, v čemž chceme pokračovat. Cílem je zajistit péči o Pražany v přirozeném prostředí, kdy mnozí z klientů pobytových zařízení mohou žít v normálních bytech blízko svých rodinných příslušníků a známých, pokud mají zajištěnou podporu od sociálních pracovníků. Umisťování lidí s postižením do velkých ústavů daleko za hranicemi Prahy považujeme za nemorální socialistický přežitek."
-    },
-    {
       "id": "komunalni-2022-554782-a-738486-57",
       "candidate_id": "komunalni-2022-554782-c-738486",
       "question_id": "komunalni-2022-554782-q-57",
       "answer": "yes",
       "comment": "Ano, vznik a financování dětských skupin jsme podporovali i na celostátní úrovni. Aktuálně se zasazujeme o možnost fungování menších sousedských dětských skupin. Umožní to pracovat těm rodičům, teří buď nesehnali volné kapacity v jiných zařízeních předškolní péče, nebo jejich děti mají kspecifické potřeba - nezvládají velký kolektiv, potřebují více času na adaptaci na kolektiv apod. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-58",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "yes",
-      "comment": "Dle vytvořené Koncepce rozvoje čtyřletých gymnázií v Praze by se měly paralelně rozšiřovat kapacity stávajících gymnázií, počty gymnaziálních tříd i zakládat gymnázia nová (např. Běchovice, Barrandov, Lužiny)."
-    },
-    {
-      "id": "komunalni-2022-554782-a-738486-59",
-      "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-59",
-      "answer": "yes",
-      "comment": "Tento koncept se už osvědčil jak svojí rolí v prolínání sociálních bublin, tak prakticky z důvodu lepšího sdílení personálních a materiálních nákladů."
     },
     {
       "id": "komunalni-2022-554782-a-738486-60",
@@ -5836,11 +4058,25 @@
       "comment": "Praha v současnosti velmi doplácí na nastavení pravidel pro přerozdělování prostředků z rozpočtového určení daní, které reflektuje místo trvalého a ne skutečného bydliště. Podle odhadů v Praze žije cca 1,55 milionu občanů, tedy o 250 tisíc více, než kolik jich je zde registrováno k trvalému pobytu. Dalších cca 300 tisíc lidí do metropole pravidelně dojíždí za studiem či prací. Bylo by spravedlivé, aby Praha dostávala peníze na pokrytí nákladů spojených se zajištěním služeb a infrastruktury pro tyto občany."
     },
     {
-      "id": "komunalni-2022-554782-a-738486-61",
+      "id": "komunalni-2022-554782-a-738486-56",
       "candidate_id": "komunalni-2022-554782-c-738486",
-      "question_id": "komunalni-2022-554782-q-61",
+      "question_id": "komunalni-2022-554782-q-56",
       "answer": "yes",
-      "comment": "Je v zájmu města, aby jednotlivé čtvrti byly sociálně heterogenní a pestré. Každá městská část potřebuje pro svůj chod i další skupiny lidí, kteří na vysoké příjmy nedosáhnou (učitelé, zdravotní sestry, policisté,...). Rovněž lidé, kteří v dané lokalitě žijí celý život, by měli mít možnost zde trávit i své stáří. Proto by v každé čtvrti měla být část bytů dostupná za zvýhodněných podmínek formou dostupného a sociálního bydlení."
+      "comment": "V tomto volebním období Praha začala s procesem tranformace pobytových zařízení, které byly umístěné po celé republice, v čemž chceme pokračovat. Cílem je zajistit péči o Pražany v přirozeném prostředí, kdy mnozí z klientů pobytových zařízení mohou žít v normálních bytech blízko svých rodinných příslušníků a známých, pokud mají zajištěnou podporu od sociálních pracovníků. Umisťování lidí s postižením do velkých ústavů daleko za hranicemi Prahy považujeme za nemorální socialistický přežitek."
+    },
+    {
+      "id": "komunalni-2022-554782-a-738486-42",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes",
+      "comment": "Strážníků je v ulicích málo a státní policie řeší často jiné věci. Uhazečů o místo strážníka je ale málo a těch, kteří splní vysoké nároky na fyzickou i psychickou zdatnost je ještě méně - proto je třeba jednak motivovat uchazeče finančně i nefinančními benefity, jednak redukovat byrokracii a množství úkolů, které by mohl místo strážníka plnit úředník. Za podstatné tedy považujeme uvolnit strážníkům ruce od papírovaní, aby tak měli čas být skutečně více v terénu."
+    },
+    {
+      "id": "komunalni-2022-554782-a-738486-36",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "yes",
+      "comment": "Ano, pro studenty je dobré otevřít městské kulturní instituce zdarma. Všem, resp. společnosti jako celku, tedy i obyvatelům Prahy, se to vyplatí. Studenti potřebují navštěvovat reálnou kulturu, výstavy apod., na kterou ovšem často nemají peníze. Přispívá to k jejich všestranému rozvoji a tzv. kulturní kompetence, tedy schopnost vnímat umění a kulturu, která posiluje komplexní kreativní myšlení, tak potřebné v moderní ekonomice, se stává jasným a zřetelným fenoménem i v celém světě."
     },
     {
       "id": "komunalni-2022-554782-a-738486-62",
@@ -5850,96 +4086,25 @@
       "comment": "Tramvajová trať přes Václavské náměstí je klíčová pro zvýšení kapacity dnes přetížené tramvajové dopravy v centru Prahy, zrychlení propojení mezi Vinohrady a Prahou 1 i kvůli tomu, aby při nehodách v Ječné nezkolabovala doprava. Nové napojení od Muzea přes Vrchlického sady do Bolzanovy ulice zajistí také kratší přestup na Hlavním nádraží."
     },
     {
-      "id": "komunalni-2022-554782-a-550372-1",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-1",
-      "answer": "no",
-      "comment": "To je samozřejmě nesmysl. Proto třeba v Holešovické tržnici i během její rekonstrukce zachováváme služby pro obyvatele z okolí, jako je trh s ovocem či zeleninou nebo různé opravny. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-2",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-2",
+      "id": "komunalni-2022-554782-a-738486-50",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-50",
       "answer": "yes",
-      "comment": "Svoz odpadu stojí obrovské peníze a nějak se zaplatit musí. Kromě toho je to cesta jak spravedlivě zajistit, aby ti, kdo odpadu produkují méně, také platili méně. Nehledě na to, že produkce odpadu zatěžuje naše životní prostředí a pokud by byl svoz zdarma, nebyla by žádná motivace k jejímu snižování."
+      "comment": "Smetanovo nábřeží je cenný prostor přímo v srdci pražské památkové rezervace, a jako takový by neměl sloužit tranzitní dopravě. Auta na nábřežích navíc způsobují zpoždění tramvají, které přepravují řádově více Pražanů. Od otevření tunelu Blanka existují dostatečně kapacitní trasy, kterými lze toto území objet, proto se není třeba bát přelití do rezidenčních ulic. Smetanovo nábřeží spolu s protější Malou Stranou může sloužit návstěvníkům města, tramvajové a bezmotorové dopravě a rezidentům."
     },
     {
-      "id": "komunalni-2022-554782-a-550372-3",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-3",
-      "answer": "no",
-      "comment": "Křehcí senioři jsou náchylnější k nemocem a prochladnutí, je potřeba je chránit."
+      "id": "komunalni-2022-554782-a-738486-51",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "dont_know",
+      "comment": "V případě Masarykova nábřeží je třeba dokončit druhou etapu, jak ji připravil IPR ve své koncepční studii, kde se počítá s zlepšením prostupnosti pro pěší a cyklisty. V případě Rašínova nábřeží žádná koncepční studie zpracována není. Peší a cyklodoprava je vedena po náplavkách, což bylo donedávna dostačujícím řešením, ale v buducnu ho bude třeba také řešit koncepčněji. Obě nábřeží je třeba upravit tak, aby umožňovaly bezpečný, klidný a plynulý průjezd všech druhů dopravy. Zejména Rašínovo nábřeží je důležitou dopravní spojnicí, jeho průjezdnost autem je klíčová pro Prahu 1, 2, 4 a 5 a musí být zachována."
     },
     {
-      "id": "komunalni-2022-554782-a-550372-4",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-4",
+      "id": "komunalni-2022-554782-a-738486-43",
+      "candidate_id": "komunalni-2022-554782-c-738486",
+      "question_id": "komunalni-2022-554782-q-43",
       "answer": "yes",
-      "comment": "Zejména v blízkosti škol a pobytových zónách dává zóna 30 km/h smysl, a to z hlediska bezpečnosti ale i plynulosti dopravy."
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-5",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-6",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-6",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-7",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-7",
-      "answer": "yes",
-      "comment": "Hazard je jeden z nejodpornějších způsobů jak vydělávat peníze - na neštěstí a ničení životů jiných lidí. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-8",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-8",
-      "answer": "no",
-      "comment": "Již nyní město dotuje MHD zhruba třetinou svého rozpočtu. Potřebujeme peníze i jinde, třeba na výstavbu školek a škol. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-9",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-9",
-      "answer": "yes",
-      "comment": "Na tom již 4 roky pracujeme, otevřeli jsme výtah do stanice metra Karlovo náměstí, připravujeme výtah na náměstí Jiřího z Poděbrad, udělali jsme nájezdové rampy na nástupištích v metru, rozšiřujeme tramvajové ostrůvky a odstraňujeme bariéry ve veřejném prostoru. Máme schválenou strategii, že do roku 2025 budou všechny stanice metra plně bezbariérové."
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-10",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "yes",
-      "comment": "Hlasování ZHMP je jmenovité."
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-11",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-12",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-12",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-13",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-14",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-14",
-      "answer": "yes"
+      "comment": "Zelené střechy jsou důležité pro adaptaci na klimatickou změnu. Instalace zelených střech je již navržena za určitých podmínek v novele pražských stavebních předpisu, které jsou právě projednávány."
     },
     {
       "id": "komunalni-2022-554782-a-550372-15",
@@ -5949,33 +4114,6 @@
       "comment": "Lze využít chytré technologie, které regulují intenzitu svitu veřejného osvětlení na příklad podle toho, zda se v blízkosti pohybuje člověk."
     },
     {
-      "id": "komunalni-2022-554782-a-550372-16",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-17",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "yes",
-      "comment": "Kromě toho je ale třeba řešit příčiny: zneužívání a cílenou tvorbu dluhů na účet dětí."
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-18",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "yes",
-      "comment": "Město má při zachování soukromí osob mít transparentně vedené účetnictví. To neznamená přímo transparentní účet, ale přístup do přehledu výdajů města. V Praze 7 jsme transparentní účetnictví v roce 2018."
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-19",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-19",
-      "answer": "yes",
-      "comment": "Participativní rozpočet dlouhodobě prosazujeme."
-    },
-    {
       "id": "komunalni-2022-554782-a-550372-20",
       "candidate_id": "komunalni-2022-554782-c-550372",
       "question_id": "komunalni-2022-554782-q-20",
@@ -5983,31 +4121,37 @@
       "comment": "Chtěli bychom se dostat na dvojnásobek současného stavu, tedy asi na 10 % městských bytů z celkového počtu v Praze. Pak budeme mít šanci pozitivně ovlivňovat trh a budeme mít byty pro ty, kdo je potřebují. "
     },
     {
-      "id": "komunalni-2022-554782-a-550372-21",
+      "id": "komunalni-2022-554782-a-550372-30",
       "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-21",
+      "question_id": "komunalni-2022-554782-q-30",
+      "answer": "dont_know",
+      "comment": "Lépe by spíš fungovaly pobídky. Je fakt, že prázdné byty městu způsobují dodatečné náklady. K nové výstavbě musí město vytvořit infrastrukturu, a to stojí spoustu peněz. Když byty zůstanou prázdné, jsou to zbytečně vyhozené veřejné prostředky. Navíc nefungují městotvorně a musí se tedy stavět dál, o to víc, a opět to stojí další peníze. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-550372-1",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "no",
+      "comment": "To je samozřejmě nesmysl. Proto třeba v Holešovické tržnici i během její rekonstrukce zachováváme služby pro obyvatele z okolí, jako je trh s ovocem či zeleninou nebo různé opravny. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-550372-8",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "no",
+      "comment": "Již nyní město dotuje MHD zhruba třetinou svého rozpočtu. Potřebujeme peníze i jinde, třeba na výstavbu školek a škol. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-550372-58",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-58",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-550372-22",
+      "id": "komunalni-2022-554782-a-550372-59",
       "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-22",
-      "answer": "yes",
-      "comment": "Město již dnes nájem svým způsobem reguluje - často stanovuje nižší než tržní nájemné."
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-23",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-23",
-      "answer": "yes",
-      "comment": "Nesmí ale jít o plošné opatření. V Praze jsme zavedli na tento školní rok obědy zdarma pro rodiny v nouzi, abychom pomohli ohroženým rodinám zvládnout tvrdý náraz energetické krize. Jinak pomoc znevýhodněným pražským rodinám nabízíme přes obědová konta nebo fondy solidarity. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-24",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-24",
-      "answer": "yes",
-      "comment": "Sdílení aut znamená menší zácpy, více volných parkovacích parkovacích míst a lepší ovzduší ve městě. Těžit z toho budou skutečně všichni."
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-550372-25",
@@ -6031,11 +4175,17 @@
       "comment": "Město musí naopak svůj bytový fond rozšiřovat."
     },
     {
-      "id": "komunalni-2022-554782-a-550372-28",
+      "id": "komunalni-2022-554782-a-550372-22",
       "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-28",
+      "question_id": "komunalni-2022-554782-q-22",
       "answer": "yes",
-      "comment": "Proto jsme také zavedli participaci developerů, a již se tak děje. "
+      "comment": "Město již dnes nájem svým způsobem reguluje - často stanovuje nižší než tržní nájemné."
+    },
+    {
+      "id": "komunalni-2022-554782-a-550372-61",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-550372-29",
@@ -6045,32 +4195,6 @@
       "comment": "Fungovat by vedle sebe měly všechny druhy dopravy. Nicméně pěšky a v MHD se po městě pohybuje 70% lidí a je to mnohem efektivnější, než když v autě sedí jeden člověk. "
     },
     {
-      "id": "komunalni-2022-554782-a-550372-30",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "dont_know",
-      "comment": "Lépe by spíš fungovaly pobídky. Je fakt, že prázdné byty městu způsobují dodatečné náklady. K nové výstavbě musí město vytvořit infrastrukturu, a to stojí spoustu peněz. Když byty zůstanou prázdné, jsou to zbytečně vyhozené veřejné prostředky. Navíc nefungují městotvorně a musí se tedy stavět dál, o to víc, a opět to stojí další peníze. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-31",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "dont_know",
-      "comment": "V tuto chvíli již developeři nově městu dávají takzvané kontribuce. Systém funguje krátce, je třeba jej po nějaké době vyhodnotit. Nyní je na to příliš brzy. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-32",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-33",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-33",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-550372-34",
       "candidate_id": "komunalni-2022-554782-c-550372",
       "question_id": "komunalni-2022-554782-q-34",
@@ -6078,74 +4202,10 @@
       "comment": "Již nyní město dotuje MHD zhruba třetinou svého rozpočtu. Potřebujeme peníze i jinde, třeba na výstavbu školek a škol. Děti v Praze jezdí do 15 let zdarma, děti do 18 let mají významnou studentskou slevu. Roční lítačka vyjde v přepočtu na 3,50 koruny denně. "
     },
     {
-      "id": "komunalni-2022-554782-a-550372-35",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-36",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-37",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-38",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "no",
-      "comment": "Ve veřejných budovách by měly být veškeré hygienické potřeby dostupné stejně jako mýdlo a toaletní papír. Ženy a dívky ohrožené chudobou mají mít nárok na podporu na pořízení menstruačních pomůcek - bez nich jsou tyto ženy ohroženy na zdraví, popř. ve společnosti stigmatizovány."
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-39",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-40",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "no",
-      "comment": "Pokud budou provozovatelé zpovědně přistupovat k jejich provozu a parkování, a postihovat přestupky, jako špatné parkování nebo jízdu po chodnících, mohlo by o tom město začít uvažovat."
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-41",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-42",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "yes",
-      "comment": "Už teď v Praze obrovské množství strážníků do požadovaného stavu chybí. Jak se říká, \"nejsou lidi\". Jsou městské části a oblasti, kde to je citelně znát. "
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-43",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-43",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-550372-44",
       "candidate_id": "komunalni-2022-554782-c-550372",
       "question_id": "komunalni-2022-554782-q-44",
       "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-45",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-45",
-      "answer": "no",
-      "comment": "Toto není role měst a obcí. Na podporu profesionálního sportu má své mechanismy stát a kromě toho je tento sport financován ze strany sponzorů."
     },
     {
       "id": "komunalni-2022-554782-a-550372-46",
@@ -6168,21 +4228,70 @@
       "comment": "Město potřebuje byty pro seniory, sociálně slabé, ale také pro důležité profese, jako jsou učitelé nebo třeba zdravotnický personál. Kromě toho nám vysoký podíl na trhu nemovitostí umožní příznivě pro lidi ovlivňovat ceny na trhu. "
     },
     {
+      "id": "komunalni-2022-554782-a-550372-3",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no",
+      "comment": "Křehcí senioři jsou náchylnější k nemocem a prochladnutí, je potřeba je chránit."
+    },
+    {
+      "id": "komunalni-2022-554782-a-550372-5",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-550372-17",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes",
+      "comment": "Kromě toho je ale třeba řešit příčiny: zneužívání a cílenou tvorbu dluhů na účet dětí."
+    },
+    {
+      "id": "komunalni-2022-554782-a-550372-19",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes",
+      "comment": "Participativní rozpočet dlouhodobě prosazujeme."
+    },
+    {
+      "id": "komunalni-2022-554782-a-550372-23",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "yes",
+      "comment": "Nesmí ale jít o plošné opatření. V Praze jsme zavedli na tento školní rok obědy zdarma pro rodiny v nouzi, abychom pomohli ohroženým rodinám zvládnout tvrdý náraz energetické krize. Jinak pomoc znevýhodněným pražským rodinám nabízíme přes obědová konta nebo fondy solidarity. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-550372-28",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes",
+      "comment": "Proto jsme také zavedli participaci developerů, a již se tak děje. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-550372-9",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes",
+      "comment": "Na tom již 4 roky pracujeme, otevřeli jsme výtah do stanice metra Karlovo náměstí, připravujeme výtah na náměstí Jiřího z Poděbrad, udělali jsme nájezdové rampy na nástupištích v metru, rozšiřujeme tramvajové ostrůvky a odstraňujeme bariéry ve veřejném prostoru. Máme schválenou strategii, že do roku 2025 budou všechny stanice metra plně bezbariérové."
+    },
+    {
+      "id": "komunalni-2022-554782-a-550372-31",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "dont_know",
+      "comment": "V tuto chvíli již developeři nově městu dávají takzvané kontribuce. Systém funguje krátce, je třeba jej po nějaké době vyhodnotit. Nyní je na to příliš brzy. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-550372-33",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
       "id": "komunalni-2022-554782-a-550372-49",
       "candidate_id": "komunalni-2022-554782-c-550372",
       "question_id": "komunalni-2022-554782-q-49",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-50",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-51",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-51",
       "answer": "yes"
     },
     {
@@ -6213,28 +4322,9 @@
       "comment": "Proto jsme spustili Sociální nadační fond, který rodinám a dalším lidem v nouzi pomůže s úhradou kauce  nebo  přispěje na terapie děti se zdravotním znevýhodněním."
     },
     {
-      "id": "komunalni-2022-554782-a-550372-56",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "yes",
-      "comment": "Takové služby jsme za našeho působení na Magistrátu konečně začali budovat."
-    },
-    {
       "id": "komunalni-2022-554782-a-550372-57",
       "candidate_id": "komunalni-2022-554782-c-550372",
       "question_id": "komunalni-2022-554782-q-57",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-58",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-550372-59",
-      "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-59",
       "answer": "yes"
     },
     {
@@ -6245,9 +4335,23 @@
       "comment": "Nejsou to peníze \"od státu\", ale peníze, která Praha vydělá. Hlavní město vytváří zhruba čtvrtinu HDP, ale obrovskou část v Praze vytvořených peněz stát přerozděluje jinam. Solidarita je důležitá, ale stát pak nesmí Prahu nechat třeba v tom, že bude sama financovat velké dopravní stavby, které používají lidé z celé země.  "
     },
     {
-      "id": "komunalni-2022-554782-a-550372-61",
+      "id": "komunalni-2022-554782-a-550372-56",
       "candidate_id": "komunalni-2022-554782-c-550372",
-      "question_id": "komunalni-2022-554782-q-61",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes",
+      "comment": "Takové služby jsme za našeho působení na Magistrátu konečně začali budovat."
+    },
+    {
+      "id": "komunalni-2022-554782-a-550372-42",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes",
+      "comment": "Už teď v Praze obrovské množství strážníků do požadovaného stavu chybí. Jak se říká, \"nejsou lidi\". Jsou městské části a oblasti, kde to je citelně znát. "
+    },
+    {
+      "id": "komunalni-2022-554782-a-550372-36",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-36",
       "answer": "yes"
     },
     {
@@ -6257,94 +4361,21 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-514272-1",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-1",
-      "answer": "dont_know",
-      "comment": "Nejasně formulovaná otázka."
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-2",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-2",
+      "id": "komunalni-2022-554782-a-550372-50",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-50",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-514272-3",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-3",
-      "answer": "no",
-      "comment": "V žádném případě."
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-4",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-4",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-5",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-6",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-6",
-      "answer": "dont_know",
-      "comment": "Na tuto otázku nelze odpovědět ano/ne tak jednoduše."
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-7",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-7",
+      "id": "komunalni-2022-554782-a-550372-51",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-51",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-514272-8",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-8",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-9",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-9",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-10",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "no",
-      "comment": "Požadavek na jmenovité zveřejňování odporuje principu svobodného výkonu mandátu."
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-11",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "no",
-      "comment": "Požadavek na jmenovité zveřejňování odporuje principu svobodného výkonu mandátu."
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-12",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-12",
-      "answer": "no",
-      "comment": "Je to na rozhodnutí každé obce."
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-13",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "dont_know",
-      "comment": "Město má postupovat tak, aby \"městské\" zahřívárny nebyly potřeba."
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-14",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-14",
+      "id": "komunalni-2022-554782-a-550372-43",
+      "candidate_id": "komunalni-2022-554782-c-550372",
+      "question_id": "komunalni-2022-554782-q-43",
       "answer": "yes"
     },
     {
@@ -6355,58 +4386,43 @@
       "comment": "Nejasná otázka - omezovat ve smyslu ztlumit, nebo zhasnout?"
     },
     {
-      "id": "komunalni-2022-554782-a-514272-16",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-17",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-18",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-19",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-19",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-514272-20",
       "candidate_id": "komunalni-2022-554782-c-514272",
       "question_id": "komunalni-2022-554782-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-514272-21",
+      "id": "komunalni-2022-554782-a-514272-30",
       "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-21",
+      "question_id": "komunalni-2022-554782-q-30",
+      "answer": "no",
+      "comment": "Hnutí SPD razí zásadu \"můj dům můj hrad\"."
+    },
+    {
+      "id": "komunalni-2022-554782-a-514272-1",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "dont_know",
+      "comment": "Nejasně formulovaná otázka."
+    },
+    {
+      "id": "komunalni-2022-554782-a-514272-8",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-8",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-514272-22",
+      "id": "komunalni-2022-554782-a-514272-58",
       "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-22",
-      "answer": "yes"
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "dont_know",
+      "comment": "To je otázka demografického vývoje."
     },
     {
-      "id": "komunalni-2022-554782-a-514272-23",
+      "id": "komunalni-2022-554782-a-514272-59",
       "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-23",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-24",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-24",
-      "answer": "yes"
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "dont_know"
     },
     {
       "id": "komunalni-2022-554782-a-514272-25",
@@ -6429,10 +4445,16 @@
       "comment": "Už stačilo."
     },
     {
-      "id": "komunalni-2022-554782-a-514272-28",
+      "id": "komunalni-2022-554782-a-514272-22",
       "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-28",
+      "question_id": "komunalni-2022-554782-q-22",
       "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-514272-61",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "dont_know"
     },
     {
       "id": "komunalni-2022-554782-a-514272-29",
@@ -6442,94 +4464,10 @@
       "comment": "Špatně položena otázka. MHD není totéž, co cyklistika."
     },
     {
-      "id": "komunalni-2022-554782-a-514272-30",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "no",
-      "comment": "Hnutí SPD razí zásadu \"můj dům můj hrad\"."
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-31",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-32",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-33",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-33",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-514272-34",
       "candidate_id": "komunalni-2022-554782-c-514272",
       "question_id": "komunalni-2022-554782-q-34",
       "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-35",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-36",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-37",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "no",
-      "comment": "Pirátský nesmysl."
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-38",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "no",
-      "comment": "Pirátský nesmysl."
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-39",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-40",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "dont_know",
-      "comment": "Město má být v této otázce neutrální."
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-41",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "no",
-      "comment": "Město má být v této otázce neutrální."
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-42",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "dont_know",
-      "comment": "Více strážníků do ulic ano, do kanceláří nikoliv."
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-43",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-43",
-      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-514272-44",
@@ -6537,12 +4475,6 @@
       "question_id": "komunalni-2022-554782-q-44",
       "answer": "dont_know",
       "comment": "Otázka dopravy je individuální záležitostí."
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-45",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-45",
-      "answer": "dont_know"
     },
     {
       "id": "komunalni-2022-554782-a-514272-46",
@@ -6564,22 +4496,65 @@
       "answer": "yes"
     },
     {
+      "id": "komunalni-2022-554782-a-514272-3",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no",
+      "comment": "V žádném případě."
+    },
+    {
+      "id": "komunalni-2022-554782-a-514272-5",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-514272-17",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-514272-19",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-514272-23",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-514272-28",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-514272-9",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-514272-31",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-514272-33",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
       "id": "komunalni-2022-554782-a-514272-49",
       "candidate_id": "komunalni-2022-554782-c-514272",
       "question_id": "komunalni-2022-554782-q-49",
       "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-50",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-51",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-51",
-      "answer": "dont_know"
     },
     {
       "id": "komunalni-2022-554782-a-514272-52",
@@ -6606,29 +4581,10 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-514272-56",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-514272-57",
       "candidate_id": "komunalni-2022-554782-c-514272",
       "question_id": "komunalni-2022-554782-q-57",
       "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-58",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "dont_know",
-      "comment": "To je otázka demografického vývoje."
-    },
-    {
-      "id": "komunalni-2022-554782-a-514272-59",
-      "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-59",
-      "answer": "dont_know"
     },
     {
       "id": "komunalni-2022-554782-a-514272-60",
@@ -6637,10 +4593,23 @@
       "answer": "dont_know"
     },
     {
-      "id": "komunalni-2022-554782-a-514272-61",
+      "id": "komunalni-2022-554782-a-514272-56",
       "candidate_id": "komunalni-2022-554782-c-514272",
-      "question_id": "komunalni-2022-554782-q-61",
-      "answer": "dont_know"
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-514272-42",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "dont_know",
+      "comment": "Více strážníků do ulic ano, do kanceláří nikoliv."
+    },
+    {
+      "id": "komunalni-2022-554782-a-514272-36",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-514272-62",
@@ -6649,93 +4618,22 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-856015-1",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-1",
-      "answer": "no",
-      "comment": "Praha je pro všechny Pražany"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-2",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-2",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-3",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-3",
-      "answer": "no",
-      "comment": "Problém je v tom, že Praha nebude mít plyn na vytápění obecně"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-4",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-4",
-      "answer": "no",
-      "comment": "Průjezdnost Prahy se musí řešit jinak!"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-5",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-6",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-6",
-      "answer": "yes",
-      "comment": "Bezpečnost je důležitá"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-7",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-7",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-8",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-8",
+      "id": "komunalni-2022-554782-a-514272-50",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-50",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-856015-9",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-9",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-10",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-11",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-12",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-12",
+      "id": "komunalni-2022-554782-a-514272-51",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-51",
       "answer": "dont_know"
     },
     {
-      "id": "komunalni-2022-554782-a-856015-13",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "yes",
-      "comment": "Pokud město nezajistí dostatek plynu, bude i v těchto budovách chladno"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-14",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-14",
-      "answer": "dont_know"
+      "id": "komunalni-2022-554782-a-514272-43",
+      "candidate_id": "komunalni-2022-554782-c-514272",
+      "question_id": "komunalni-2022-554782-q-43",
+      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-856015-15",
@@ -6745,30 +4643,6 @@
       "comment": "Otázka řeší následek, ne příčinu. Praha musí zajistit dostatek energie!"
     },
     {
-      "id": "komunalni-2022-554782-a-856015-16",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-17",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-18",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-19",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-19",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-856015-20",
       "candidate_id": "komunalni-2022-554782-c-856015",
       "question_id": "komunalni-2022-554782-q-20",
@@ -6776,28 +4650,34 @@
       "comment": "Praha by měla začít více stavět dostupné bydlení"
     },
     {
-      "id": "komunalni-2022-554782-a-856015-21",
+      "id": "komunalni-2022-554782-a-856015-30",
       "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-21",
-      "answer": "yes",
-      "comment": "Bude to nutnost"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-22",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-22",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-23",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-23",
+      "question_id": "komunalni-2022-554782-q-30",
       "answer": "dont_know"
     },
     {
-      "id": "komunalni-2022-554782-a-856015-24",
+      "id": "komunalni-2022-554782-a-856015-1",
       "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-24",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "no",
+      "comment": "Praha je pro všechny Pražany"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-8",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-58",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-59",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-59",
       "answer": "dont_know"
     },
     {
@@ -6820,11 +4700,16 @@
       "answer": "dont_know"
     },
     {
-      "id": "komunalni-2022-554782-a-856015-28",
+      "id": "komunalni-2022-554782-a-856015-22",
       "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-28",
-      "answer": "yes",
-      "comment": "Je to praxe velkých evropských měst, například Vídně"
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-61",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "yes"
     },
     {
       "id": "komunalni-2022-554782-a-856015-29",
@@ -6834,31 +4719,6 @@
       "comment": "Město má řešit dopravu jako celek"
     },
     {
-      "id": "komunalni-2022-554782-a-856015-30",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-31",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-32",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "dont_know",
-      "comment": "Na druhou stranu, vzhledem k trendům ve výrobě vozidel, to bude zřejmě nutnost"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-33",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-33",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-856015-34",
       "candidate_id": "komunalni-2022-554782-c-856015",
       "question_id": "komunalni-2022-554782-q-34",
@@ -6866,72 +4726,11 @@
       "comment": "Resp. děti mají mít výhody pro cestování MHD"
     },
     {
-      "id": "komunalni-2022-554782-a-856015-35",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-36",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-37",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-38",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-39",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-40",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "no",
-      "comment": "Jak to dopadá vidíme již dnes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-41",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-42",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-43",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-43",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-856015-44",
       "candidate_id": "komunalni-2022-554782-c-856015",
       "question_id": "komunalni-2022-554782-q-44",
       "answer": "no",
       "comment": "Praha nemá vhodný terénní reliéf"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-45",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-45",
-      "answer": "dont_know"
     },
     {
       "id": "komunalni-2022-554782-a-856015-46",
@@ -6953,22 +4752,66 @@
       "answer": "yes"
     },
     {
+      "id": "komunalni-2022-554782-a-856015-3",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no",
+      "comment": "Problém je v tom, že Praha nebude mít plyn na vytápění obecně"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-5",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-17",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-19",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-23",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-28",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes",
+      "comment": "Je to praxe velkých evropských měst, například Vídně"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-9",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-31",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-33",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
       "id": "komunalni-2022-554782-a-856015-49",
       "candidate_id": "komunalni-2022-554782-c-856015",
       "question_id": "komunalni-2022-554782-q-49",
       "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-50",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-51",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-51",
-      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-856015-52",
@@ -6995,27 +4838,9 @@
       "answer": "dont_know"
     },
     {
-      "id": "komunalni-2022-554782-a-856015-56",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-856015-57",
       "candidate_id": "komunalni-2022-554782-c-856015",
       "question_id": "komunalni-2022-554782-q-57",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-58",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "dont_know"
-    },
-    {
-      "id": "komunalni-2022-554782-a-856015-59",
-      "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-59",
       "answer": "dont_know"
     },
     {
@@ -7025,10 +4850,22 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-856015-61",
+      "id": "komunalni-2022-554782-a-856015-56",
       "candidate_id": "komunalni-2022-554782-c-856015",
-      "question_id": "komunalni-2022-554782-q-61",
+      "question_id": "komunalni-2022-554782-q-56",
       "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-42",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-856015-36",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "dont_know"
     },
     {
       "id": "komunalni-2022-554782-a-856015-62",
@@ -7037,87 +4874,21 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-305273-1",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-1",
+      "id": "komunalni-2022-554782-a-856015-50",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-50",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-305273-2",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-2",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-3",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-3",
+      "id": "komunalni-2022-554782-a-856015-51",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-51",
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-305273-4",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-4",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-5",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-5",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-6",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-6",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-7",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-7",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-8",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-8",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-9",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-9",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-10",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-10",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-11",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-11",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-12",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-12",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-13",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-13",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-14",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-14",
+      "id": "komunalni-2022-554782-a-856015-43",
+      "candidate_id": "komunalni-2022-554782-c-856015",
+      "question_id": "komunalni-2022-554782-q-43",
       "answer": "yes"
     },
     {
@@ -7127,57 +4898,39 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-305273-16",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-16",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-17",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-17",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-18",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-18",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-19",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-19",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-305273-20",
       "candidate_id": "komunalni-2022-554782-c-305273",
       "question_id": "komunalni-2022-554782-q-20",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-305273-21",
+      "id": "komunalni-2022-554782-a-305273-30",
       "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-21",
+      "question_id": "komunalni-2022-554782-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-1",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-8",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-58",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-58",
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-305273-22",
+      "id": "komunalni-2022-554782-a-305273-59",
       "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-22",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-23",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-23",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-24",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-24",
+      "question_id": "komunalni-2022-554782-q-59",
       "answer": "yes"
     },
     {
@@ -7199,9 +4952,15 @@
       "answer": "no"
     },
     {
-      "id": "komunalni-2022-554782-a-305273-28",
+      "id": "komunalni-2022-554782-a-305273-22",
       "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-28",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-61",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-61",
       "answer": "yes"
     },
     {
@@ -7211,87 +4970,9 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-305273-30",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-30",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-31",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-31",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-32",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-32",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-33",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-33",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-305273-34",
       "candidate_id": "komunalni-2022-554782-c-305273",
       "question_id": "komunalni-2022-554782-q-34",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-35",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-35",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-36",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-36",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-37",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-37",
-      "answer": "no"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-38",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-38",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-39",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-39",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-40",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-40",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-41",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-41",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-42",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-42",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-43",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-43",
       "answer": "yes"
     },
     {
@@ -7299,12 +4980,6 @@
       "candidate_id": "komunalni-2022-554782-c-305273",
       "question_id": "komunalni-2022-554782-q-44",
       "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-45",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-45",
-      "answer": "no"
     },
     {
       "id": "komunalni-2022-554782-a-305273-46",
@@ -7325,21 +5000,63 @@
       "answer": "yes"
     },
     {
+      "id": "komunalni-2022-554782-a-305273-3",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-5",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-17",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-19",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-23",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-28",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-9",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-31",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-33",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
       "id": "komunalni-2022-554782-a-305273-49",
       "candidate_id": "komunalni-2022-554782-c-305273",
       "question_id": "komunalni-2022-554782-q-49",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-50",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-50",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-51",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-51",
       "answer": "yes"
     },
     {
@@ -7367,27 +5084,9 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-305273-56",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-56",
-      "answer": "yes"
-    },
-    {
       "id": "komunalni-2022-554782-a-305273-57",
       "candidate_id": "komunalni-2022-554782-c-305273",
       "question_id": "komunalni-2022-554782-q-57",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-58",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-58",
-      "answer": "yes"
-    },
-    {
-      "id": "komunalni-2022-554782-a-305273-59",
-      "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-59",
       "answer": "yes"
     },
     {
@@ -7397,9 +5096,21 @@
       "answer": "yes"
     },
     {
-      "id": "komunalni-2022-554782-a-305273-61",
+      "id": "komunalni-2022-554782-a-305273-56",
       "candidate_id": "komunalni-2022-554782-c-305273",
-      "question_id": "komunalni-2022-554782-q-61",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-42",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-36",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-36",
       "answer": "yes"
     },
     {
@@ -7407,6 +5118,270 @@
       "candidate_id": "komunalni-2022-554782-c-305273",
       "question_id": "komunalni-2022-554782-q-62",
       "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-50",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-51",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-305273-43",
+      "candidate_id": "komunalni-2022-554782-c-305273",
+      "question_id": "komunalni-2022-554782-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-15",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-20",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-30",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-1",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-8",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-58",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-58",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-59",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-59",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-25",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-26",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-27",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-22",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-61",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-61",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-29",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-34",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-44",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-46",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-47",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-48",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-3",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-5",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-17",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-19",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-23",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-28",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-9",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-31",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-33",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-49",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-52",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-53",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-53",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-54",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-54",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-55",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-57",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-57",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-60",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-60",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-56",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-42",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-36",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-36",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-62",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-62",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-50",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-51",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-554782-a-917016-43",
+      "candidate_id": "komunalni-2022-554782-c-917016",
+      "question_id": "komunalni-2022-554782-q-43",
+      "answer": "no"
     }
   ]
 }

--- a/data/kalkulacka/komunalni-2022/555134.json
+++ b/data/kalkulacka/komunalni-2022/555134.json
@@ -517,7 +517,8 @@
           },
           "abbreviation": "ČSSD+PP21+NK"
         }
-      ]
+      ],
+      "motto": "Zkušenost. Odvaha. Rovnováha. Takové chceme Pardubice. Takoví jsme my. "
     },
     {
       "id": "komunalni-2022-555134-c-343643",
@@ -2859,6 +2860,320 @@
     {
       "id": "komunalni-2022-555134-a-812723-48",
       "candidate_id": "komunalni-2022-555134-c-812723",
+      "question_id": "komunalni-2022-555134-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-1",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-2",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-2",
+      "answer": "yes",
+      "comment": "Systém poplatků by měl motivovat ke třídění."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-3",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-4",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-4",
+      "answer": "dont_know",
+      "comment": "Záleží na konkrétní lokalitě, aby to nesnižovalo prostupnost daného místa."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-5",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-6",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-6",
+      "answer": "yes",
+      "comment": "Pouze v lokalitách, kde je to nezbytně nutné."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-7",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-7",
+      "answer": "no",
+      "comment": "Úplná prohibice nikdy nevyřešila problém, pouze se skryl stal ilegálním. Zákon toto dnes velmi výrazně zpřísnil a reguluje. Počet heren se v Pardubicích v posledních letech výrazně snížil. Neevidujeme problémy v lokalitách, kde jsou herní zařízení. Většina hráčů se přesunula na internet, to město regulovat nemůže."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-8",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-8",
+      "answer": "no",
+      "comment": "Pro seniory a hendikepované a bezpříspěvkové dárce krve (držitele Zlaté Jánského medaile) ano, to jsme prosadili a trváme na tom. Stejně jako zvýhodněné celoroční jízdné pro žáky základních škol, prodej celoročního jízdného se zněkolikanásobil a motivuje k využívání MHD."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-9",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-10",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-11",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-12",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-12",
+      "answer": "yes",
+      "comment": "Například při městských slavnostech v předvečer Velké Pardubické nikoliv, neboť se jedná o velmi silnou tradici. Každý ohňostroj by měl být z pohledu významu konkrétní události důkladně a individuálně posouzen."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-13",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-13",
+      "answer": "no",
+      "comment": "Existuje dostatečná kapacita azylových domů, nocleháren a nízkoprahových denních center."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-14",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-15",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-16",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-16",
+      "answer": "no",
+      "comment": "Dovedeme si představit dílčí snížení teplot na úřadech, v žádném případě však ne v městem zřizovaných základních a uměleckých školách, mateřinkách, dětských skupinách, domech dětí a mládeže, domovech pro seniory, denních stacionářích a v další klíčové občanské vybavenosti. Rizikem je větší nemocnost, chceme, aby rodiče mohli chodit normálně do práce."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-17",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-17",
+      "answer": "dont_know",
+      "comment": "Každý případ by měl být individuálně posouzen. Zpravidla už dnes na městě odpouštíme úroky z prodlení."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-18",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-19",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-19",
+      "answer": "yes",
+      "comment": "Zejména na úrovni městských obvodů, kde prosazujeme prvky participativního rozpočtu."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-20",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-21",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-22",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-22",
+      "answer": "yes",
+      "comment": "Tuto možnost umožňujeme pouze pro sociálně potřebné skrze konkrétní posouzení - adresná podpora. Tento projekt obědů zdarma již realizujeme několik let ve spolupráci s organizací Women for Women a cca dva roky v MŠ také skrze Pardubický kraj pod projektem MPSV. Pomoc je anonymní, příjemcem nejsou rodiče, ale přímo škola, je jistota účelného využití dotace. Obědy zdarma děti skutečně dostanou. "
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-23",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-23",
+      "answer": "dont_know",
+      "comment": "Je s tím schopný si poradit soukromý sektor. "
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-24",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-24",
+      "answer": "no",
+      "comment": "Jsme pro parkovací zóny v celém městě za symbolický manipulační poplatek pro rezidenty a vyšší ceny pro přespolní. Cílem je ochrana residenčního parkování."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-25",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-26",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-26",
+      "answer": "yes",
+      "comment": "Za jednotných a předem daných pravidel. Prosadili jsme proto Zásady pro investory na území města, které schválilo zastupitelstvo města."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-27",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-27",
+      "answer": "yes",
+      "comment": "Ano, ale pozitivní motivací pro pěší, cyklisty a MHD, nikoliv kladením překážek automobilové dopravě. Doprava má lidi spojovat, ne rozdělovat. Jednotlivé druhy dopravy na sebe musí navazovat."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-28",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-28",
+      "answer": "dont_know",
+      "comment": "To je zejména pražské téma AIRBNB."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-29",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-29",
+      "answer": "dont_know",
+      "comment": "Nyní máme nově schválené Zásady pro developery na území města, které jsme prosadili. Celý systém je třeba nejprve vyhodnotit a poté uvažovat o parametrických změnách. V tomto by mohl více pomoci legislativně stát skrze daňový systém."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-30",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-31",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-32",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-32",
+      "answer": "no",
+      "comment": "Dovedeme si představit MHD zdarma pro děti do ukončení povinné školní docházky."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-33",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-33",
+      "answer": "dont_know",
+      "comment": "Podpora budování fotovoltaických panelů je spíše záležitostí dotačních titulů státu. Město se primárně musí soustředit na vlastní objekty a snižování jejich energetické náročnosti."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-34",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-34",
+      "answer": "yes",
+      "comment": "Zlevněné vstupné již aplikujeme v této oblasti dlouhodobě, například Galerie města Pardubic vstupné nevybírá, za velmi výhodných podmínek nabízíme např. hrací karty do Sportovního parku Pardubice nebo zdarma otevřená hřiště pro veřejnost v areálech škol.  "
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-35",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-36",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-37",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-38",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-38",
+      "answer": "yes",
+      "comment": "V úrovni vytváření jasných pravidel a tvorby dostatečného počtu odstavných ploch pro tyto dopravní prostředky, nikoliv formou dotací."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-39",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-39",
+      "answer": "yes",
+      "comment": "S důrazem na výuku českého jazyka a přizpůsobení se kulturním zvykům České republiky. Jazyková znalost je klíčová pro úspěšnou asimilaci."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-40",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-41",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-42",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-43",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-43",
+      "answer": "yes",
+      "comment": "Pardubice jsou městem sportu. Profesionální sport si zaslouží stejnou podporu jako profesionální kultura. Děti potřebují vzory. Například Velká pardubická, Zlatá přilba, hokej, basketbal, fotbal úspěšně reprezentují město a mají přínos pro ekonomiku a podnikání ve městě včetně cestovního ruchu."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-44",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-44",
+      "answer": "no",
+      "comment": "Ale v žádném případě ji nebudeme zvyšovat."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-45",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-45",
+      "answer": "no",
+      "comment": "Systém přidělování dávek je otázkou státu, respektive jeho zřizované organizace, kterým je úřad práce. Město pomáhá financováním sítě poskytovatelů sociálních služeb, cenově dostupnými a sociálními byty v případě, že je někdo ohrožen bytovou nouzí. "
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-46",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-46",
+      "answer": "yes",
+      "comment": "Právě proto jsme prosadili Strategii bydlení města Pardubic a Program rozvoje bydlení, který garantuje, že 100% z výnosů z nájmů, město investuje zpět do bydlení. To umožní efektivnější plánování nejenom oprav a rekonstrukcí stávajícího bytového fondu, ale také jeho postupné rozšiřování včetně výstavby družstevních bytů a dalších startovacích bytů pro mladé pracující lidi například v areálu Hůrek a Masarykových kasáren."
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-47",
+      "candidate_id": "komunalni-2022-555134-c-280020",
+      "question_id": "komunalni-2022-555134-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-555134-a-280020-48",
+      "candidate_id": "komunalni-2022-555134-c-280020",
       "question_id": "komunalni-2022-555134-q-48",
       "answer": "yes"
     }

--- a/data/kalkulacka/komunalni-2022/569810.json
+++ b/data/kalkulacka/komunalni-2022/569810.json
@@ -522,7 +522,8 @@
           },
           "abbreviation": "HK"
         }
-      ]
+      ],
+      "motto": "Město lidem"
     },
     {
       "id": "komunalni-2022-569810-c-841188",
@@ -3897,6 +3898,345 @@
     {
       "id": "komunalni-2022-569810-a-515530-53",
       "candidate_id": "komunalni-2022-569810-c-515530",
+      "question_id": "komunalni-2022-569810-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-1",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-1",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-2",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-3",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-4",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-4",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-5",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-5",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-6",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-6",
+      "answer": "yes",
+      "comment": "Ale pouze na místech kde opakovaně dochází k potížím."
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-7",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-7",
+      "answer": "dont_know",
+      "comment": "Současná regulace nám přijde dostatečná"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-8",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-9",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-9",
+      "answer": "dont_know",
+      "comment": "Pokud je nám známo, většina zastávek již byla upravena na bezbariérový přístup."
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-10",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-10",
+      "answer": "dont_know",
+      "comment": "Bohužel neanonymní hlasování způsobuje větší ovlivnitelnost"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-11",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-11",
+      "answer": "dont_know",
+      "comment": "Bohužel neanonymní hlasování způsobuje větší ovlivnitelnost"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-12",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-13",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-13",
+      "answer": "no",
+      "comment": "V Hradci Králové je několik nocleháren a azylových domů."
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-14",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-14",
+      "answer": "no",
+      "comment": "Spíš instalovat úspornější svítidla"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-15",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-15",
+      "answer": "no",
+      "comment": "Spíš instalovat úspornější svítidla"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-16",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-16",
+      "answer": "no",
+      "comment": "Spíš instalovat úspornější topidla a zatelení budov"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-17",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-17",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-18",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-19",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-19",
+      "answer": "yes",
+      "comment": "Skrze komise místních samospráv"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-20",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-21",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-21",
+      "answer": "no",
+      "comment": "Spíš instalovat úspornější svítidla"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-22",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-23",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-24",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-24",
+      "answer": "no",
+      "comment": "Primárně je potřeba, aby měli kde parkovat rezidenti"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-25",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-26",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-27",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-27",
+      "answer": "dont_know",
+      "comment": "Je potřeba vybudovat adekvátní infrastrukturu než bude preferenční"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-28",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-28",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-29",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-30",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-30",
+      "answer": "yes",
+      "comment": "Není potřeba finančně, ale hlavně administrativně"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-31",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-32",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-33",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-33",
+      "answer": "yes",
+      "comment": "Není potřeba finančně, ale hlavně administrativně"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-34",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-34",
+      "answer": "dont_know",
+      "comment": "Bezplatné ne, zlevněné ano"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-35",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-36",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-37",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-37",
+      "answer": "yes",
+      "comment": "Pokud to bude dávat smysl"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-38",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-38",
+      "answer": "dont_know",
+      "comment": "Musí byt jasně daná pravidla"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-39",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-39",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-40",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-41",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-41",
+      "answer": "dont_know",
+      "comment": "Dle situace"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-42",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-43",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-44",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-45",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-45",
+      "answer": "dont_know",
+      "comment": "Záleží na okolnostech"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-46",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-47",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-48",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-49",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-49",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-50",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-51",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-51",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-52",
+      "candidate_id": "komunalni-2022-569810-c-748887",
+      "question_id": "komunalni-2022-569810-q-52",
+      "answer": "dont_know",
+      "comment": "Opravu ano, snížení parkovacích míst až za ně bude náhrada"
+    },
+    {
+      "id": "komunalni-2022-569810-a-748887-53",
+      "candidate_id": "komunalni-2022-569810-c-748887",
       "question_id": "komunalni-2022-569810-q-53",
       "answer": "yes"
     }

--- a/data/kalkulacka/komunalni-2022/590266.json
+++ b/data/kalkulacka/komunalni-2022/590266.json
@@ -485,7 +485,8 @@
           },
           "abbreviation": "ANO"
         }
-      ]
+      ],
+      "motto": "Pojďte do toho s námi, aby bylo líp."
     },
     {
       "id": "komunalni-2022-590266-c-238616",
@@ -3769,6 +3770,300 @@
     {
       "id": "komunalni-2022-590266-a-543213-48",
       "candidate_id": "komunalni-2022-590266-c-543213",
+      "question_id": "komunalni-2022-590266-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-1",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-1",
+      "answer": "yes",
+      "comment": "Město Třebíč je pro všechny slušné občany. V žádném případě nepodporujeme segregaci obyvatel v závislosti na jejich ekonomické úrovni."
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-2",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-3",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-3",
+      "answer": "no",
+      "comment": "V žádném případě. Senioři nám pomohli vybudovat naši zemi a tento krok je naprosto nepřípustný."
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-4",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-5",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-5",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-6",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-6",
+      "answer": "yes",
+      "comment": "Ve městě Třebíči se osvědčilo využívání kamerového systému pod správou městské policie a to na veřejných místech, kde je velká kumulace občanů a také šance, že dojde k trestnému činu nebo přestupku a společně s dalšími preventivními opatřeními tyto kroky pravidelně zabraňují v páchání těchto činů."
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-7",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-7",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-8",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-9",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-10",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-10",
+      "answer": "yes",
+      "comment": "Hlasování členů zastupitelstva je již nyní transparentní a výsledky hlasování jdou vidět živě při sledování jednání zastupitelstva. "
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-11",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-11",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-12",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-12",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-13",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-13",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-14",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-15",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-15",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-16",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-16",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-17",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-18",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-18",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-19",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-20",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-21",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-21",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-22",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-23",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-24",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-24",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-25",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-26",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-26",
+      "answer": "yes",
+      "comment": "Například v případě výstavby na ul. Modřínova musí soukromí developeři okrášlit okolí výsadbou keřů apod."
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-27",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-27",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-28",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-29",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-29",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-30",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-30",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-31",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-32",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-33",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-33",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-34",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-35",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-35",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-36",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-36",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-37",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-38",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-38",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-39",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-40",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-41",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-41",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-42",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-43",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-44",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-44",
+      "answer": "dont_know"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-45",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-45",
+      "answer": "yes",
+      "comment": "Město již nyní připravuje další sociální byty a zároveň startovací byty pro mladé páry."
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-46",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-47",
+      "candidate_id": "komunalni-2022-590266-c-505803",
+      "question_id": "komunalni-2022-590266-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "komunalni-2022-590266-a-505803-48",
+      "candidate_id": "komunalni-2022-590266-c-505803",
       "question_id": "komunalni-2022-590266-q-48",
       "answer": "yes"
     }

--- a/data/kalkulacka/senatni-2022/10.json
+++ b/data/kalkulacka/senatni-2022/10.json
@@ -1019,6 +1019,354 @@
       "candidate_id": "senatni-2022-10-c-974997",
       "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-1",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-2",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-2",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-3",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-4",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-4",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-5",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-6",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-6",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-7",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-8",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-8",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-9",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-9",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-10",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-11",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-12",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-13",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-14",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-15",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-15",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-16",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-17",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-18",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-18",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-19",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-19",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-20",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-20",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-21",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-21",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-22",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-22",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-23",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-23",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-24",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-25",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-26",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-27",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-28",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-29",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-30",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-31",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-32",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-33",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-33",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-34",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-35",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-35",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-36",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-37",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-38",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-39",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-40",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-41",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-41",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-42",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-43",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-44",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-45",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-46",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-47",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-48",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-48",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-49",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-50",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-50",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-51",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-52",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-53",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-54",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-55",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-55",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-56",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-56",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-57",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-10-a-908666-58",
+      "candidate_id": "senatni-2022-10-c-908666",
+      "question_id": "senatni-2022-global-q-58",
+      "answer": "yes"
     }
   ]
 }

--- a/data/kalkulacka/senatni-2022/19.json
+++ b/data/kalkulacka/senatni-2022/19.json
@@ -2608,6 +2608,366 @@
       "candidate_id": "senatni-2022-19-c-388017",
       "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-1",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-1",
+      "answer": "dont_know",
+      "comment": "Ano, ALE musí se jednat o další (a otázkou je, zda 2. nebo třeba 4.) vlastnické byty. "
+    },
+    {
+      "id": "senatni-2022-19-a-358095-2",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-2",
+      "answer": "no",
+      "comment": "ČR by se měla snažit, aby výstavba (nejen) bytů probíhala rychleji."
+    },
+    {
+      "id": "senatni-2022-19-a-358095-3",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-3",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-4",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-4",
+      "answer": "no",
+      "comment": "Dálniční infrastruktura je neméně důležitá."
+    },
+    {
+      "id": "senatni-2022-19-a-358095-5",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-5",
+      "answer": "yes",
+      "comment": "Nebude v budoucnu jiná možnost. Dnes v důchodu prožijí ženy průměrně okolo 24 let, muži 17. "
+    },
+    {
+      "id": "senatni-2022-19-a-358095-6",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-7",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-7",
+      "answer": "no",
+      "comment": "Lidé do plastů hodí 8z 10 prodaných lahví. Láhve však nesmí končit na skládkách."
+    },
+    {
+      "id": "senatni-2022-19-a-358095-8",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-8",
+      "answer": "no",
+      "comment": "V ČR je mírná daňová progrese, což je v pořádku. "
+    },
+    {
+      "id": "senatni-2022-19-a-358095-9",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-9",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-10",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-11",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-12",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-13",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-14",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-15",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-16",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-16",
+      "answer": "dont_know",
+      "comment": "Žijeme v moderní době a já nejsem zpátečníkem. Myslím si navíc, že na významu získají církevní sňatky, které se stanou vyhledávanější, právě pro dodržování striktního vymezení manželství výhradně pro muže a ženu. Oba tábory konzervativců i progresivistů tedy mohou zůstat i potom spokojeni. \n\nNa druhé straně - musím se ještě podrobněji seznámit s problematikou - dítě v dětském domově vs. adopce stejnopohlavními páry. Prozatím moje znalost říká, že dětské domovy jsou nejhorší možnou variantou pro výchovu dítěte. A druhá věc - spíše technická - je český jazyk (a tedy i trochu česká kultura). Budou se muži tedy ženit či snad mužit?"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-17",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-18",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-18",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-19",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-20",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-21",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-22",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-22",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-23",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-24",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-24",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-25",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-26",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-27",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-28",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-28",
+      "answer": "yes",
+      "comment": "Je vhodné diskutovat vhodný okamžik. Dejme tomu rok 2030."
+    },
+    {
+      "id": "senatni-2022-19-a-358095-29",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-30",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-30",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-31",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-32",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-33",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-34",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-35",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-35",
+      "answer": "yes",
+      "comment": "Zavázali jsme se ke 2%, měli bychom náš závazek dodržet."
+    },
+    {
+      "id": "senatni-2022-19-a-358095-36",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-37",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-38",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-38",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-39",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-40",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-41",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-42",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-43",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-44",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-45",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-46",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-47",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-48",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-49",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-50",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-50",
+      "answer": "yes",
+      "comment": "Musíme si stanovovat ambiciózní cíle, ale zároveň musíme být připraveni na neočekávané krizové situace (například ta dnešní). Lze obojí."
+    },
+    {
+      "id": "senatni-2022-19-a-358095-51",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-52",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-53",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-54",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-55",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-56",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-56",
+      "answer": "no",
+      "comment": "Nicméně, každá obec, resp. město, potažmo velké město, by mělo odpovědně řešit vlastní bytovou politiku. Školy a městské instituce by měli disponovat byty pro své zaměstnance, jako tomu bylo ještě za první republiky ve 20. století."
+    },
+    {
+      "id": "senatni-2022-19-a-358095-57",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-19-a-358095-58",
+      "candidate_id": "senatni-2022-19-c-358095",
+      "question_id": "senatni-2022-global-q-58",
+      "answer": "no",
+      "comment": "Právě k tomu slouží mimořádné nástroje jako např. milostivé léto."
     }
   ]
 }

--- a/data/kalkulacka/senatni-2022/22.json
+++ b/data/kalkulacka/senatni-2022/22.json
@@ -648,7 +648,8 @@
       "type": "person",
       "description": "Jiří Kobza",
       "contacts": {
-        "web": []
+        "web": [],
+        "facebook": "https://www.facebook.com/jirikobza.cz/"
       },
       "parties": [
         {
@@ -656,7 +657,8 @@
           "name": "Jiří Kobza",
           "description": "Jiří Kobza",
           "contacts": {
-            "web": []
+            "web": [],
+            "facebook": "https://www.facebook.com/jirikobza.cz/"
           },
           "abbreviation": ""
         }

--- a/data/kalkulacka/senatni-2022/31.json
+++ b/data/kalkulacka/senatni-2022/31.json
@@ -2332,6 +2332,354 @@
       "candidate_id": "senatni-2022-31-c-165219",
       "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-1",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-1",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-2",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-2",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-3",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-4",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-4",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-5",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-6",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-6",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-7",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-8",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-8",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-9",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-9",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-10",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-11",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-11",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-12",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-13",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-14",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-14",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-15",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-15",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-16",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-16",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-17",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-17",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-18",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-19",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-20",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-20",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-21",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-22",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-23",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-23",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-24",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-24",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-25",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-25",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-26",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-26",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-27",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-27",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-28",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-28",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-29",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-30",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-31",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-31",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-32",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-32",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-33",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-33",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-34",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-35",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-35",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-36",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-36",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-37",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-37",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-38",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-38",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-39",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-39",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-40",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-41",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-41",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-42",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-42",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-43",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-43",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-44",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-44",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-45",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-46",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-47",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-47",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-48",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-48",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-49",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-50",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-50",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-51",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-52",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-52",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-53",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-54",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-55",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-55",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-56",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-56",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-57",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-57",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-31-a-619365-58",
+      "candidate_id": "senatni-2022-31-c-619365",
+      "question_id": "senatni-2022-global-q-58",
+      "answer": "yes"
     }
   ]
 }

--- a/data/kalkulacka/senatni-2022/37.json
+++ b/data/kalkulacka/senatni-2022/37.json
@@ -1848,6 +1848,383 @@
       "candidate_id": "senatni-2022-37-c-116316",
       "question_id": "senatni-2022-global-q-58",
       "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-1",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-1",
+      "answer": "no",
+      "comment": "Bylo by to zasahování do vlastnických práv. "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-2",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-2",
+      "answer": "yes",
+      "comment": "Rohodně, zabránilo by se šroubování cen vlastníků bytů pro nájemce bytu."
+    },
+    {
+      "id": "senatni-2022-37-a-593846-3",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-3",
+      "answer": "yes",
+      "comment": "Názory veřejnosti by měly být pro vedení státu směrodatné. Ne naopak, jako je to nyní."
+    },
+    {
+      "id": "senatni-2022-37-a-593846-4",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-4",
+      "answer": "no",
+      "comment": "Možná by stačilo, aby se nerušily spoje. "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-5",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-5",
+      "answer": "no",
+      "comment": "Rozhodně ne! Na úkor jedné generace nelze řešit dlouhodobě špatně nastavený sociální systém. "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-6",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-6",
+      "answer": "yes",
+      "comment": "Voda je základ. "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-7",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-7",
+      "answer": "yes",
+      "comment": "Pokud je možnost zastavit zahlcení světa PET lahvemi a plechovkami, bylo by to jediné efektivní řešení. Rozhodně nemá vliv zákaz plastových brček, ten hodnotím jako plácnutí do vody, které nepomůže nikomu a ničemu. "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-8",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-9",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-9",
+      "answer": "yes",
+      "comment": "Spousta lidí ji pěstuje k léčebným účelům, má celou škálu dalšího využití - nejen jako psychotropní rostlina, jak si mnozí myslí. V prvé řadě je to bylina. Se stíháním slušných lidí, které ji využívají v léčitelství zásadně nesouhlasím. "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-10",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-11",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-11",
+      "answer": "no",
+      "comment": "Předpokládám, že by to znamenalo zpoplatnění všem uživatelům. "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-12",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-12",
+      "answer": "no",
+      "comment": "Rozhodně je zodpovědnost v kompetenci uživatele. "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-13",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-13",
+      "answer": "no",
+      "comment": "Odsuzuji cenzuru. "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-14",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-14",
+      "answer": "yes",
+      "comment": "V okamžiku, kdy prokazatelně není objektivní, by měly být zrušeny koncesionářské poplatky vůbec. "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-15",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-15",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-16",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-16",
+      "answer": "yes",
+      "comment": "Stejnopohlavní páry nechť mají shodná práva jako manželé, ale ať nenazývají sňatek \"manželstvím\", které je historicky spojením muže a ženy. "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-17",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-18",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-19",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-19",
+      "answer": "dont_know",
+      "comment": "Obecní a státní ano, soukromá rozhodně ne."
+    },
+    {
+      "id": "senatni-2022-37-a-593846-20",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-20",
+      "answer": "no",
+      "comment": "Stát má předně zjišťovat, komu dávky vyplácí... Pokud se vyplatí žít pouze ze sociálních dávek a příspěvků, povede to ke stále větším výdajům daňových poplatníků, které geometrickou řadou pororstou přesně tak, jak se budou rozrůstat rodiny, které systému zneužívají.  "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-21",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-22",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-22",
+      "answer": "no",
+      "comment": "ČR se chce zapojit do kolonizace Marsu, když si neví rady ani sama se sebou a svými (a hlavně cizími ) občany ? "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-23",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-23",
+      "answer": "no",
+      "comment": "Volby musí být ze zákona osobní."
+    },
+    {
+      "id": "senatni-2022-37-a-593846-24",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-24",
+      "answer": "no",
+      "comment": "Lidí s tituly je mnoho, ale řemeslníků málo. Podporovala bych více spíše odborné učební obory. "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-25",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-25",
+      "answer": "no",
+      "comment": "Rozhodně ne. Inkluze v nynější podobě je naprosto špatně. Největším průšvihem je zařazování dětí, které znemožní podmínky pro vzdělávání všem ostatním dětem v kolektivu. A velké kolektivy jsou pro ně naprosto nevhodné. Nevzdělává je speciální pedagog, ale zpravidla asistent pedagoga s tříměsíčním kurzem. Měli jsme speciální školství na vysoké úrovni, kterou nám záviděl celý svět a běžné školy, kde učitelé děti mohli učit. Veřejnost byla gramotná, znalá základních norem chování. Nyní předkládáme dětem od prvotní zkušenosti ve školství patologické vzory chování, nemají klid na vzdělávání a divíme se, proč do školy nechtějí chodit - tím spíše i ti nadaní, na jejichž individualitu není už ani prostor ani čas, právě díky spolužákům s těžkými psychosociálními poruchami."
+    },
+    {
+      "id": "senatni-2022-37-a-593846-26",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-26",
+      "answer": "no",
+      "comment": "Správné by bylo zařazovat děti se speciálními vzdělávacími potřebami, ale jen do té míry, dokud to není prokazatelně na úkor všech ostatních v kolektivu. Jednoznačně by měla být ukazatelem určitá úroveň prosociálního chování a intelektu inkludovaného dítěte.\n (Nepřijímat dětské brutální agresory, děti s několikahodinovými záchvaty křiku a děti, které nejsou schopny vzdělávání ve velkém kolektivu zvládnout psychicky, neboť zpravidla z toho plyne jejich nevhodné chování ve školském zařízení) "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-27",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-28",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-29",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-29",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-30",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-31",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-31",
+      "answer": "no",
+      "comment": "Myslím, že aktuálním úkolem ČR je postarat se o své vlastní občany. Humanitární pomoc a spolupráci jsme rozvíjeli až dost, nyní již dlouhodobě na úkor vlastních občanů, s čímž v zásadě nesouhlasím. "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-32",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-32",
+      "answer": "no",
+      "comment": "ČR má jediný aktuální úkol - postavit se na vlastní nohy. Všechno ostatní je nyní podružné."
+    },
+    {
+      "id": "senatni-2022-37-a-593846-33",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-33",
+      "answer": "no",
+      "comment": "Naopak. Zpřísnit."
+    },
+    {
+      "id": "senatni-2022-37-a-593846-34",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-35",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-36",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-37",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-37",
+      "answer": "no",
+      "comment": "Péče o zdraví by měla být přístupná všem a rovnocenná. ( Což jak víme všichni již dávno v praxi není) "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-38",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-39",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-40",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-40",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-41",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-42",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-43",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-44",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-45",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-45",
+      "answer": "no",
+      "comment": "Nepomohl... Když MŠ jako jediné, dle sdělení tehdejšího premiéra Babiše, z důvodu \"ekonomiky\" zůstaly v provozu v době začátku Covidu. V době, kdy se o viru nevědělo vůbec nic, všechno bylo uzavřeno ( školy, firmy, úřady, obchody), byly ohroženy ti nejmenší, bezbranní a ti, kteří se o ně celý život starají - rodiče, učitelé MŠ. Přitom je jasné, že školkové děti jsou po celý den v úzkém fyzickém kontaktu. Dvojím metrem mě velmi zklamal jak on, tak tehdejší pan premiér Babiš, který z ekonomických důvodů ohrozil to nejcennější, co máme - naše děti. Jde o princip a já nezapomínám.    "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-46",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-46",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-47",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-47",
+      "answer": "yes",
+      "comment": "Jiná cesta než jednání není. Válka není řešení. "
+    },
+    {
+      "id": "senatni-2022-37-a-593846-48",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-48",
+      "answer": "no",
+      "comment": "Myslím, že na to postačí český zákon."
+    },
+    {
+      "id": "senatni-2022-37-a-593846-49",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-49",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-50",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-50",
+      "answer": "dont_know",
+      "comment": "Podporovat mohu, ale nemyslím si, že by se to kdy povedlo. Společnost vždy bude zanechávat klimatickou stopu. A sankciovat jednotlivce je opravdu špatné řešení."
+    },
+    {
+      "id": "senatni-2022-37-a-593846-51",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-51",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-52",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-52",
+      "answer": "yes",
+      "comment": "Rozhodně !"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-53",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-53",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-54",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-55",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-56",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-56",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-57",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-57",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-37-a-593846-58",
+      "candidate_id": "senatni-2022-37-c-593846",
+      "question_id": "senatni-2022-global-q-58",
+      "answer": "dont_know"
     }
   ]
 }

--- a/data/kalkulacka/senatni-2022/61.json
+++ b/data/kalkulacka/senatni-2022/61.json
@@ -2293,6 +2293,725 @@
       "candidate_id": "senatni-2022-61-c-131643",
       "question_id": "senatni-2022-global-q-58",
       "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-1",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-2",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-3",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-4",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-5",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-6",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-6",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-7",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-7",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-8",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-9",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-9",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-10",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-11",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-12",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-13",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-13",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-14",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-15",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-15",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-16",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-17",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-18",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-18",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-19",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-20",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-20",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-21",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-21",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-22",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-23",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-23",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-24",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-25",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-26",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-27",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-27",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-28",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-29",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-30",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-30",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-31",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-32",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-33",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-34",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-35",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-36",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-37",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-38",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-38",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-39",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-39",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-40",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-40",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-41",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-42",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-43",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-44",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-44",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-45",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-46",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-46",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-47",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-47",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-48",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-48",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-49",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-50",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-50",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-51",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-51",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-52",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-53",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-53",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-54",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-55",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-56",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-56",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-57",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-57",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-290618-58",
+      "candidate_id": "senatni-2022-61-c-290618",
+      "question_id": "senatni-2022-global-q-58",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-1",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-1",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-2",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-3",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-4",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-5",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-5",
+      "answer": "yes",
+      "comment": "postupnému klouzavému zvyšování se z demografického důvodu nevyhneme, úroveň zdarvotnictví a doba dožití se také zvyšuje"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-6",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-6",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-7",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-7",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-8",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-8",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-9",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-9",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-10",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-10",
+      "answer": "no",
+      "comment": "dosavadní právní úprava je adekvátní"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-11",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-12",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-12",
+      "answer": "no",
+      "comment": "svoboda slova je důležitá, porušení zákona má řešit policie a soudy"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-13",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-13",
+      "answer": "no",
+      "comment": "jiný názor není fakenews, je to snadno zneužitelné"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-14",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-14",
+      "answer": "yes",
+      "comment": "veřejnoprávní média dlouhodobě neplní svoji zákonnou úlohu vyváženosti a nestrannosti"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-15",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-15",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-16",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-16",
+      "answer": "no",
+      "comment": "posílit práva v registrovaném partnerství"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-17",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-18",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-19",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-19",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-20",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-20",
+      "answer": "no",
+      "comment": "má utvořit jasný, přehledný a spravedlivý rámec jejich čerpání"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-21",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-21",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-22",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-23",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-23",
+      "answer": "no",
+      "comment": "papír - urna - plenta, jen tak je zachována důvěryhodnost voleb"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-24",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-24",
+      "answer": "no",
+      "comment": "mělo by být podporováno trhem, ne státem"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-25",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-25",
+      "answer": "dont_know",
+      "comment": "otázka je nekonkrétní, dítě by měli rodiče dát na školu, na kterou stačí"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-26",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-27",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-27",
+      "answer": "yes",
+      "comment": "suverenita ČR je zásadní, tudíž podporuji všechny snahy o rozvolnění vztahů s EU, v krajním případě i vystoupení"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-28",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-29",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-29",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-30",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-30",
+      "answer": "dont_know",
+      "comment": "nic jako jádro EU není, EU = převážně Německé zájmy"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-31",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-31",
+      "answer": "no",
+      "comment": "pouze tehdy, až budou vyřešeny zásadní problémy domácí a to ani zdaleka nejsou"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-32",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-32",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-33",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-34",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-34",
+      "answer": "yes",
+      "comment": "ekonomická integrace (lidi, služby, práce, kapitál) je ok, politická a ideologická se zvrhla"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-35",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-35",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-36",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-37",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-38",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-39",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-39",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-40",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-40",
+      "answer": "no",
+      "comment": "ale nemá být nadužíváno a zneužíváno pří drobném překročení limitu"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-41",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-41",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-42",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-43",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-44",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-45",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-45",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-46",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-46",
+      "answer": "dont_know",
+      "comment": "viníků konfliktu je víc, následky ponesou všichni"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-47",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-47",
+      "answer": "yes",
+      "comment": "diplomacie je důležitá vždy a všude, předchází konfliktům"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-48",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-48",
+      "answer": "no",
+      "comment": "naše právní úprava je dostatečná"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-49",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-50",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-50",
+      "answer": "no",
+      "comment": "ekologie musí jít ruku v ruce s ekonomickou a vědeckou evolucí, datum nelze byrokraticky stanovit"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-51",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-51",
+      "answer": "yes",
+      "comment": "znovunastolení míru v Evropě a obnovení diplomatické rovnováhy se bez toho neobejde"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-52",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-52",
+      "answer": "yes",
+      "comment": "jsme jediná země v regionu, která takovýto kontrakt nemá"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-53",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-53",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-54",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-54",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-55",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-56",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-57",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-57",
+      "answer": "dont_know",
+      "comment": "v případě dodržování Minských dohod by to nebylo nutné"
+    },
+    {
+      "id": "senatni-2022-61-a-202876-58",
+      "candidate_id": "senatni-2022-61-c-202876",
+      "question_id": "senatni-2022-global-q-58",
+      "answer": "no",
+      "comment": "exekuční řízení se má zjednodušit, ale dluh je pořád dluh"
     }
   ]
 }

--- a/data/kalkulacka/senatni-2022/64.json
+++ b/data/kalkulacka/senatni-2022/64.json
@@ -1761,6 +1761,354 @@
       "question_id": "senatni-2022-global-q-58",
       "answer": "no",
       "comment": "Když si každý bude dělat svou práci tak jak má, nebudou bezvýsledné."
+    },
+    {
+      "id": "senatni-2022-64-a-419952-1",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-1",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-2",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-2",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-3",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-3",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-4",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-4",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-5",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-5",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-6",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-6",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-7",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-7",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-8",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-8",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-9",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-9",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-10",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-10",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-11",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-11",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-12",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-12",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-13",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-13",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-14",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-14",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-15",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-15",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-16",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-16",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-17",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-17",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-18",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-18",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-19",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-19",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-20",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-20",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-21",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-21",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-22",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-22",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-23",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-23",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-24",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-24",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-25",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-25",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-26",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-26",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-27",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-27",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-28",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-28",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-29",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-29",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-30",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-30",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-31",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-31",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-32",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-32",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-33",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-33",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-34",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-34",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-35",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-35",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-36",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-36",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-37",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-37",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-38",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-38",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-39",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-39",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-40",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-40",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-41",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-41",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-42",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-42",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-43",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-43",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-44",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-44",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-45",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-45",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-46",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-46",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-47",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-47",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-48",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-48",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-49",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-49",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-50",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-50",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-51",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-51",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-52",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-52",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-53",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-53",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-54",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-54",
+      "answer": "yes"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-55",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-55",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-56",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-56",
+      "answer": "no"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-57",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-57",
+      "answer": "dont_know"
+    },
+    {
+      "id": "senatni-2022-64-a-419952-58",
+      "candidate_id": "senatni-2022-64-c-419952",
+      "question_id": "senatni-2022-global-q-58",
+      "answer": "no"
     }
   ]
 }


### PR DESCRIPTION
Add support for question ordering. How it works:
* searches for column name order
* checks values inside - empty string, zero, only spaces are ignored
* if there is more than one value, then ordering is used, in this situation rows with empty order are ignored
* float numbers could be used

# Examples
* `[('', 'AA'), ('', 'BB'), ('', 'CC')]` - no ordering specified => do nothing, output: `['AA', 'BB', 'CC']`
* `[('0', 'AA'), (' ', 'BB'), ('', 'CC')]` - zeroish values for ordering are used => do nothing, output: `['AA', 'BB', 'CC']`
* `[('', 'AA'), ('2', 'BB'), ('', 'CC')]` - only one none zero value is used => do nothing, output: `['AA', 'BB', 'CC']`
* `[('1.8', 'AA'), (' ', 'BB'), ('1.1', 'CC')]` - ordering is specified => apply ordering and ignore rows without ordering: `['CC', 'AA']`