### PR TITLE
Store results in easily parseable form

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,5 @@ install-all-backend:
 generate-data:
 	(cd $(BACKEND_DIR); make run-converter run-add-images) && \
 	(cd $(SCHEMAS_DIR); ./validate.sh) && \
-	(cd $(FRONTENT_DIR); npm run parse-schema) && \
+	(cd $(FRONTENT_DIR); npm run parse-data-schema) && \
 	git add $(DATA_DIR);

--- a/backend/main.py
+++ b/backend/main.py
@@ -42,6 +42,7 @@ def get_table():
 class Answer(BaseModel):
     question_id: str
     answer: str
+    is_important: bool
 
 
 class Candidate(BaseModel):

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "type-check": "vue-tsc --noEmit -p tsconfig.vitest.json --composite false",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --ignore-path .gitignore",
     "lint:fix": "npm run lint -- --fix",
-    "parse-schema": "cp ../data ./public/dev -r && node ./parseSchemas.js"
+    "parse-data-schema": "cp ../data ./public/dev -r && node ./parseSchemas.js",
+    "parse-rest-schema": "node ./parseRestSchemas.js"
   },
   "dependencies": {
     "@mdi/js": "^7.0.96",

--- a/frontend/parseRestSchemas.js
+++ b/frontend/parseRestSchemas.js
@@ -6,7 +6,7 @@ const path = require('path');
 // compile from file
 
 const BASE_PATH = './src/types/rest';
-const FILE_PATH = './public/dev/volebni-kalkulacka-004-openapi.json';
+const FILE_PATH = './public/dev/volebni-kalkulacka-005-openapi.json';
 const REPLACE_PATTERN = '#/components/schemas/';
 const SUFFIX = '.schema.json';
 

--- a/frontend/src/common/restApi.ts
+++ b/frontend/src/common/restApi.ts
@@ -1,4 +1,8 @@
-import { useElectionStore, convertAnswerToStr } from '@/stores/electionStore';
+import {
+  useElectionStore,
+  convertAnswerToStr,
+  convertStrToAnswer,
+} from '@/stores/electionStore';
 import type { AnswerRest } from '@/types/rest/Answer';
 import type { CalculatorRest } from '@/types/rest/Calculator';
 import type { ElectionRest } from '@/types/rest/Election';
@@ -41,7 +45,7 @@ export const getResults = async (resultUuid: string) => {
     return {
       id: x.question_id,
       flag: x.is_important,
-      answer: x.answer,
+      answer: convertStrToAnswer(x.answer),
     };
   });
 };

--- a/frontend/src/common/restApi.ts
+++ b/frontend/src/common/restApi.ts
@@ -1,4 +1,4 @@
-import { useElectionStore } from '@/stores/electionStore';
+import { useElectionStore, convertAnswerToStr } from '@/stores/electionStore';
 import type { AnswerRest } from '@/types/rest/Answer';
 import type { CalculatorRest } from '@/types/rest/Calculator';
 import type { ElectionRest } from '@/types/rest/Election';
@@ -38,11 +38,10 @@ export const getResults = async (resultUuid: string) => {
     result.calculator.district_code
   );
   electionStore.answers = result.answers.map((x) => {
-    const answer = x.answer.split('|');
     return {
       id: x.question_id,
-      flag: answer[0] === '1',
-      answer: parseInt(answer[1]),
+      flag: x.is_important,
+      answer: x.answer,
     };
   });
 };
@@ -61,7 +60,8 @@ export const postResults = async () => {
     const answers: AnswerRest[] = electionStore.answers.map((x) => {
       return {
         question_id: x.id,
-        answer: `${x.flag ? 1 : 0}|${x.answer}`,
+        answer: convertAnswerToStr(x.answer),
+        is_important: x.flag,
       };
     });
     const ra = calculateRelativeAgreement(

--- a/frontend/src/stores/electionStore.ts
+++ b/frontend/src/stores/electionStore.ts
@@ -12,6 +12,30 @@ export enum UserAnswerEnum {
   skip = 3,
 }
 
+export const convertAnswerToStr = (answer: UserAnswerEnum): string => {
+  switch (answer) {
+    case UserAnswerEnum.yes:
+      return 'yes';
+    case UserAnswerEnum.no:
+      return 'no';
+    case UserAnswerEnum.skip:
+      return 'dont_know';
+    default:
+      return 'dont_know';
+  }
+};
+
+export const convertStrToAnswer = (answer: string): UserAnswerEnum => {
+  switch (answer) {
+    case 'yes':
+      return UserAnswerEnum.yes;
+    case 'no':
+      return UserAnswerEnum.no;
+    default:
+      return UserAnswerEnum.skip;
+  }
+};
+
 export interface UserAnswer {
   id: string;
   answer: UserAnswerEnum;

--- a/frontend/src/types/rest/Answer.d.ts
+++ b/frontend/src/types/rest/Answer.d.ts
@@ -7,9 +7,11 @@
 
 export type QuestionId = string;
 export type Answer = string;
+export type IsImportant = boolean;
 
 export interface AnswerRest {
   question_id: QuestionId;
   answer: Answer;
+  is_important: IsImportant;
   [k: string]: unknown;
 }

--- a/frontend/src/types/rest/Answer.schema.json
+++ b/frontend/src/types/rest/Answer.schema.json
@@ -1,9 +1,10 @@
 {
   "title": "AnswerRest",
-  "required": ["question_id", "answer"],
+  "required": ["question_id", "answer", "is_important"],
   "type": "object",
   "properties": {
     "question_id": { "title": "Question Id", "type": "string" },
-    "answer": { "title": "Answer", "type": "string" }
+    "answer": { "title": "Answer", "type": "string" },
+    "is_important": { "title": "Is Important", "type": "boolean" }
   }
 }

--- a/frontend/src/types/rest/ResultIn.d.ts
+++ b/frontend/src/types/rest/ResultIn.d.ts
@@ -7,6 +7,7 @@
 
 export type QuestionId = string;
 export type Answer = string;
+export type IsImportant = boolean;
 export type Answers = AnswerRest[];
 export type CandidateId = string;
 export type Name = string;
@@ -45,6 +46,7 @@ export interface ResultInRest {
 export interface AnswerRest {
   question_id: QuestionId;
   answer: Answer;
+  is_important: IsImportant;
   [k: string]: unknown;
 }
 export interface MatchRest {

--- a/frontend/src/types/rest/ResultOut.d.ts
+++ b/frontend/src/types/rest/ResultOut.d.ts
@@ -9,6 +9,7 @@ export type ResultId = string;
 export type CreatedAt = string;
 export type QuestionId = string;
 export type Answer = string;
+export type IsImportant = boolean;
 export type Answers = AnswerRest[];
 export type CandidateId = string;
 export type Name = string;
@@ -49,6 +50,7 @@ export interface ResultOutRest {
 export interface AnswerRest {
   question_id: QuestionId;
   answer: Answer;
+  is_important: IsImportant;
   [k: string]: unknown;
 }
 export interface MatchRest {


### PR DESCRIPTION
Storing results as `int|int` is confusing. Lets store them in less confusing way.

# Testing:

Storing results works - 

https://volebni-kalkulacka-2022-git-send-results-im-698be2-ceskodigital.vercel.app/volby/komunalni-2022/555134/vysledek

![image](https://user-images.githubusercontent.com/152821/189836995-47f8fc7d-d87e-4039-8072-088d270b9992.png)

