### PR TITLE
Add Images: Include path to already downloaded images

### DIFF
--- a/data/kalkulacka/senatni-2022/1.json
+++ b/data/kalkulacka/senatni-2022/1.json
@@ -450,7 +450,8 @@
             "twitter": "https://twitter.com/BohdanVanek"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/1/senatni-2022-1-c-107987-original.jpg"
     },
     {
       "id": "senatni-2022-1-c-578851",
@@ -500,7 +501,8 @@
             "instagram": "https://www.instagram.com/prochazkova548/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/1/senatni-2022-1-c-128673-face.jpg"
     },
     {
       "id": "senatni-2022-1-c-329053",
@@ -538,7 +540,8 @@
             "instagram": "https://www.instagram.com/petr.cool.hanek/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/1/senatni-2022-1-c-329053-original.jpg"
     },
     {
       "id": "senatni-2022-1-c-200693",
@@ -676,7 +679,8 @@
             "instagram": "https://www.instagram.com/vaclav.slavik/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/1/senatni-2022-1-c-306348-face.jpg"
     },
     {
       "id": "senatni-2022-1-c-742303",
@@ -722,7 +726,8 @@
             "instagram": "https://www.instagram.com/janhornik/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/1/senatni-2022-1-c-742303-face.jpg"
     }
   ],
   "answers": [

--- a/data/kalkulacka/senatni-2022/10.json
+++ b/data/kalkulacka/senatni-2022/10.json
@@ -452,7 +452,8 @@
             "instagram": "https://www.instagram.com/senator_tomasjirsa/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/10/senatni-2022-10-c-593117-face.jpg"
     },
     {
       "id": "senatni-2022-10-c-974997",

--- a/data/kalkulacka/senatni-2022/13.json
+++ b/data/kalkulacka/senatni-2022/13.json
@@ -450,7 +450,8 @@
             ]
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/13/senatni-2022-13-c-941147-face.jpg"
     },
     {
       "id": "senatni-2022-13-c-420091",
@@ -496,7 +497,8 @@
             "instagram": "https://instagram.com/jirimachac_"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/13/senatni-2022-13-c-420091-original.jpg"
     },
     {
       "id": "senatni-2022-13-c-940838",
@@ -576,7 +578,8 @@
             "facebook": "http://facebook.com/evzenzadrazil.cz/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/13/senatni-2022-13-c-459651-face.jpg"
     },
     {
       "id": "senatni-2022-13-c-267821",
@@ -600,7 +603,8 @@
             "facebook": "https://www.facebook.com/olga.bastlova"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/13/senatni-2022-13-c-267821-original.jpg"
     },
     {
       "id": "senatni-2022-13-c-545048",

--- a/data/kalkulacka/senatni-2022/16.json
+++ b/data/kalkulacka/senatni-2022/16.json
@@ -380,7 +380,8 @@
             "twitter": "https://twitter.com/MichalAurednik"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/16/senatni-2022-16-c-875643-face.jpg"
     },
     {
       "id": "senatni-2022-16-c-219251",
@@ -434,7 +435,8 @@
             "instagram": "https://www.instagram.com/janissid/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/16/senatni-2022-16-c-219251-original.jpg"
     },
     {
       "id": "senatni-2022-16-c-728249",
@@ -470,7 +472,8 @@
             "twitter": "https://twitter.com/JiriOberfalzer"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/16/senatni-2022-16-c-728249-face.jpg"
     },
     {
       "id": "senatni-2022-16-c-244153",
@@ -532,7 +535,8 @@
             "instagram": "https://www.instagram.com/martinkarim8/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/16/senatni-2022-16-c-244153-face.jpg"
     }
   ],
   "answers": [

--- a/data/kalkulacka/senatni-2022/19.json
+++ b/data/kalkulacka/senatni-2022/19.json
@@ -400,7 +400,8 @@
             "instagram": "https://www.instagram.com/bohbot_david/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/19/senatni-2022-19-c-420727-original.jpg"
     },
     {
       "id": "senatni-2022-19-c-746291",
@@ -486,7 +487,8 @@
             "twitter": "https://twitter.com/vladimir_spidla"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/19/senatni-2022-19-c-325120-face.jpg"
     },
     {
       "id": "senatni-2022-19-c-107153",
@@ -520,7 +522,8 @@
             "facebook": "https://www.facebook.com/ladislav.kos.senat/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/19/senatni-2022-19-c-107153-face.jpg"
     },
     {
       "id": "senatni-2022-19-c-517013",
@@ -546,7 +549,8 @@
             "twitter": "https://twitter.com/robertvasicek79"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/19/senatni-2022-19-c-517013-face.jpg"
     },
     {
       "id": "senatni-2022-19-c-358095",
@@ -638,7 +642,8 @@
             "instagram": "https://www.instagram.com/hanak_marvanova/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/19/senatni-2022-19-c-388017-face.jpg"
     }
   ],
   "answers": [

--- a/data/kalkulacka/senatni-2022/22.json
+++ b/data/kalkulacka/senatni-2022/22.json
@@ -434,7 +434,8 @@
             "instagram": "https://www.instagram.com/senatorkarenata/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/22/senatni-2022-22-c-371682-original.jpg"
     },
     {
       "id": "senatni-2022-22-c-549994",

--- a/data/kalkulacka/senatni-2022/25.json
+++ b/data/kalkulacka/senatni-2022/25.json
@@ -476,7 +476,8 @@
             "instagram": "https://www.instagram.com/ruzicka_jiri/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/25/senatni-2022-25-c-813666-face.jpg"
     },
     {
       "id": "senatni-2022-25-c-426167",
@@ -498,7 +499,8 @@
             "web": []
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/25/senatni-2022-25-c-426167-original.jpg"
     },
     {
       "id": "senatni-2022-25-c-630845",
@@ -552,7 +554,8 @@
             "instagram": "https://www.instagram.com/maxmilion_and_me/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/25/senatni-2022-25-c-630845-face.jpg"
     },
     {
       "id": "senatni-2022-25-c-188521",
@@ -620,7 +623,8 @@
             "instagram": "https://www.instagram.com/dana_balcarova/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/25/senatni-2022-25-c-290001-face.jpg"
     }
   ],
   "answers": [

--- a/data/kalkulacka/senatni-2022/28.json
+++ b/data/kalkulacka/senatni-2022/28.json
@@ -408,7 +408,8 @@
             "twitter": "https://twitter.com/zdeneksarapatka"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/28/senatni-2022-28-c-454822-face.jpg"
     },
     {
       "id": "senatni-2022-28-c-553512",
@@ -446,7 +447,8 @@
             "instagram": "https://www.instagram.com/brzobohataandrea/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/28/senatni-2022-28-c-553512-face.jpg"
     },
     {
       "id": "senatni-2022-28-c-720036",

--- a/data/kalkulacka/senatni-2022/31.json
+++ b/data/kalkulacka/senatni-2022/31.json
@@ -410,7 +410,8 @@
             "instagram": "https://www.instagram.com/veranechybovasenatorkou/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/31/senatni-2022-31-c-665893-face.jpg"
     },
     {
       "id": "senatni-2022-31-c-165219",
@@ -454,7 +455,8 @@
             "instagram": "https://www.instagram.com/echtkrsek/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/31/senatni-2022-31-c-165219-original.jpg"
     },
     {
       "id": "senatni-2022-31-c-619365",
@@ -514,7 +516,8 @@
             "facebook": "https://www.facebook.com/jan.beer.39"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/31/senatni-2022-31-c-246453-face.jpg"
     },
     {
       "id": "senatni-2022-31-c-699892",
@@ -604,7 +607,8 @@
             "instagram": "https://www.instagram.com/jaroslav_telecky/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/31/senatni-2022-31-c-800949-face.jpg"
     },
     {
       "id": "senatni-2022-31-c-163515",
@@ -660,7 +664,8 @@
             ]
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/31/senatni-2022-31-c-570575-face.jpg"
     },
     {
       "id": "senatni-2022-31-c-392644",

--- a/data/kalkulacka/senatni-2022/34.json
+++ b/data/kalkulacka/senatni-2022/34.json
@@ -380,7 +380,8 @@
             "facebook": "https://www.facebook.com/spdliberecky"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/34/senatni-2022-34-c-879839-face.jpg"
     },
     {
       "id": "senatni-2022-34-c-936940",
@@ -426,7 +427,8 @@
             "instagram": "https://www.instagram.com/martinamot/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/34/senatni-2022-34-c-936940-face.jpg"
     },
     {
       "id": "senatni-2022-34-c-474514",
@@ -480,7 +482,8 @@
             "instagram": "https://www.instagram.com/canovmichael/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/34/senatni-2022-34-c-474514-face.jpg"
     },
     {
       "id": "senatni-2022-34-c-990991",

--- a/data/kalkulacka/senatni-2022/37.json
+++ b/data/kalkulacka/senatni-2022/37.json
@@ -394,7 +394,8 @@
             "instagram": "https://www.instagram.com/tomas_czernin/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/37/senatni-2022-37-c-828456-face.jpg"
     },
     {
       "id": "senatni-2022-37-c-844780",
@@ -440,7 +441,8 @@
             "instagram": "https://www.instagram.com/renefranek_cz/?hl=cs"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/37/senatni-2022-37-c-844780-face.jpg"
     },
     {
       "id": "senatni-2022-37-c-383315",
@@ -528,7 +530,8 @@
             "instagram": "https://www.instagram.com/martinova_marta/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/37/senatni-2022-37-c-664833-original.jpg"
     },
     {
       "id": "senatni-2022-37-c-957667",
@@ -562,7 +565,8 @@
             "facebook": "https://www.facebook.com/jaromirdedecek2022"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/37/senatni-2022-37-c-957667-original.jpg"
     },
     {
       "id": "senatni-2022-37-c-593846",
@@ -598,7 +602,8 @@
             "instagram": "https://www.instagram.com/ekotyzova/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/37/senatni-2022-37-c-593846-face.jpg"
     },
     {
       "id": "senatni-2022-37-c-116316",

--- a/data/kalkulacka/senatni-2022/4.json
+++ b/data/kalkulacka/senatni-2022/4.json
@@ -392,7 +392,8 @@
             "twitter": "https://twitter.com/DernerovaAlena"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/4/senatni-2022-4-c-871435-face.jpg"
     },
     {
       "id": "senatni-2022-4-c-737193",
@@ -454,7 +455,8 @@
             "facebook": "https://www.facebook.com/Ivana-Turkov%C3%A1-SPD-102412049180933"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/4/senatni-2022-4-c-248303-face.jpg"
     },
     {
       "id": "senatni-2022-4-c-729274",

--- a/data/kalkulacka/senatni-2022/40.json
+++ b/data/kalkulacka/senatni-2022/40.json
@@ -606,7 +606,8 @@
             "instagram": "https://www.instagram.com/jiri.strachota/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/40/senatni-2022-40-c-353870-face.jpg"
     }
   ],
   "answers": [

--- a/data/kalkulacka/senatni-2022/43.json
+++ b/data/kalkulacka/senatni-2022/43.json
@@ -420,7 +420,8 @@
             "facebook": "https://www.facebook.com/MartinCharvatPCE"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/43/senatni-2022-43-c-143881-face.jpg"
     },
     {
       "id": "senatni-2022-43-c-849519",
@@ -494,7 +495,8 @@
             "instagram": "https://www.instagram.com/miluse_horska/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/43/senatni-2022-43-c-742106-face.jpg"
     },
     {
       "id": "senatni-2022-43-c-191858",

--- a/data/kalkulacka/senatni-2022/46.json
+++ b/data/kalkulacka/senatni-2022/46.json
@@ -400,7 +400,8 @@
             "twitter": "https://twitter.com/petrfiala68"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/46/senatni-2022-46-c-367047-face.jpg"
     },
     {
       "id": "senatni-2022-46-c-835047",

--- a/data/kalkulacka/senatni-2022/49.json
+++ b/data/kalkulacka/senatni-2022/49.json
@@ -462,7 +462,8 @@
             "twitter": "https://twitter.com/filipeskamoter"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/49/senatni-2022-49-c-229934-face.jpg"
     },
     {
       "id": "senatni-2022-49-c-439462",
@@ -544,7 +545,8 @@
             "facebook": "https://www.facebook.com/jaromiravitkovasenatorka.cz/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/49/senatni-2022-49-c-744028-face.jpg"
     },
     {
       "id": "senatni-2022-49-c-882688",

--- a/data/kalkulacka/senatni-2022/52.json
+++ b/data/kalkulacka/senatni-2022/52.json
@@ -440,7 +440,8 @@
             "twitter": "https://twitter.com/vystrcil_milos/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/52/senatni-2022-52-c-406075-face.jpg"
     },
     {
       "id": "senatni-2022-52-c-520609",

--- a/data/kalkulacka/senatni-2022/55.json
+++ b/data/kalkulacka/senatni-2022/55.json
@@ -400,7 +400,8 @@
             "instagram": "https://instagram.com/petra_redova_fajmonova"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/55/senatni-2022-55-c-716101-face.jpg"
     },
     {
       "id": "senatni-2022-55-c-429934",
@@ -436,7 +437,8 @@
             "instagram": "https://www.instagram.com/radomirpavlicek/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/55/senatni-2022-55-c-429934-face.jpg"
     },
     {
       "id": "senatni-2022-55-c-323222",

--- a/data/kalkulacka/senatni-2022/58.json
+++ b/data/kalkulacka/senatni-2022/58.json
@@ -408,7 +408,8 @@
             "twitter": "https://twitter.com/JiDusek"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/58/senatni-2022-58-c-381319-face.jpg"
     },
     {
       "id": "senatni-2022-58-c-296693",
@@ -462,7 +463,8 @@
             "instagram": "https://instagram.com/petrkunc.cz"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/58/senatni-2022-58-c-296693-face.jpg"
     },
     {
       "id": "senatni-2022-58-c-663420",
@@ -484,7 +486,8 @@
             "web": []
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/58/senatni-2022-58-c-663420-face.jpg"
     },
     {
       "id": "senatni-2022-58-c-995955",
@@ -534,7 +537,8 @@
             "facebook": "https://www.facebook.com/rektor.zdenekkoudelka/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/58/senatni-2022-58-c-995955-face.jpg"
     },
     {
       "id": "senatni-2022-58-c-630883",

--- a/data/kalkulacka/senatni-2022/61.json
+++ b/data/kalkulacka/senatni-2022/61.json
@@ -398,7 +398,8 @@
             "facebook": "https://www.facebook.com/ctirad.musil"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/61/senatni-2022-61-c-131643-face.jpg"
     },
     {
       "id": "senatni-2022-61-c-504062",
@@ -478,7 +479,8 @@
             "facebook": "https://www.facebook.com/michal.malacka/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/61/senatni-2022-61-c-330603-face.jpg"
     },
     {
       "id": "senatni-2022-61-c-290618",
@@ -556,7 +558,8 @@
             "twitter": "https://twitter.com/KantorLumir"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/61/senatni-2022-61-c-836627-face.jpg"
     },
     {
       "id": "senatni-2022-61-c-146752",
@@ -598,7 +601,8 @@
             "facebook": "https://www.facebook.com/vaclav.ranc.75"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/61/senatni-2022-61-c-146752-face.jpg"
     },
     {
       "id": "senatni-2022-61-c-405277",
@@ -696,7 +700,8 @@
             "instagram": "https://www.instagram.com/zuzana_majerova_trikolora/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/61/senatni-2022-61-c-202876-face.jpg"
     }
   ],
   "answers": [

--- a/data/kalkulacka/senatni-2022/64.json
+++ b/data/kalkulacka/senatni-2022/64.json
@@ -438,7 +438,8 @@
             "facebook": "https://www.facebook.com/ludek.sarman.7"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/64/senatni-2022-64-c-419952-face.jpg"
     },
     {
       "id": "senatni-2022-64-c-542456",
@@ -472,7 +473,8 @@
             "facebook": "https://www.facebook.com/profile.php?id=100083011057007"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/64/senatni-2022-64-c-542456-face.jpg"
     },
     {
       "id": "senatni-2022-64-c-298500",
@@ -514,7 +516,8 @@
             "facebook": "https://www.facebook.com/ladavaclavec"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/64/senatni-2022-64-c-298500-face.jpg"
     },
     {
       "id": "senatni-2022-64-c-419215",
@@ -556,7 +559,8 @@
             "facebook": "https://m.facebook.com/stanek.antonin/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/64/senatni-2022-64-c-419215-face.jpg"
     }
   ],
   "answers": [

--- a/data/kalkulacka/senatni-2022/67.json
+++ b/data/kalkulacka/senatni-2022/67.json
@@ -436,7 +436,8 @@
             "instagram": "https://www.instagram.com/mgr_jan_muzik/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/67/senatni-2022-67-c-301471-face.jpg"
     },
     {
       "id": "senatni-2022-67-c-775013",
@@ -478,7 +479,8 @@
             "facebook": "https://www.facebook.com/orelsenator"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/67/senatni-2022-67-c-775013-face.jpg"
     },
     {
       "id": "senatni-2022-67-c-405244",
@@ -522,7 +524,8 @@
             "twitter": "https://twitter.com/VanovaVova1"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/67/senatni-2022-67-c-405244-face.jpg"
     },
     {
       "id": "senatni-2022-67-c-745404",
@@ -592,7 +595,8 @@
             "facebook": "https://www.facebook.com/leo.luzar"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/67/senatni-2022-67-c-129902-face.jpg"
     }
   ],
   "answers": [

--- a/data/kalkulacka/senatni-2022/7.json
+++ b/data/kalkulacka/senatni-2022/7.json
@@ -410,7 +410,8 @@
             "instagram": "https://www.instagram.com/valenta1965/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/7/senatni-2022-7-c-883400-face.jpg"
     },
     {
       "id": "senatni-2022-7-c-401024",
@@ -526,7 +527,8 @@
             "twitter": "https://twitter.com/VaclavChaloupek"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/7/senatni-2022-7-c-801538-face.jpg"
     },
     {
       "id": "senatni-2022-7-c-582714",
@@ -578,7 +580,8 @@
             "twitter": "https://twitter.com/DanielaKovarova"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/7/senatni-2022-7-c-582714-original.jpg"
     },
     {
       "id": "senatni-2022-7-c-161426",

--- a/data/kalkulacka/senatni-2022/70.json
+++ b/data/kalkulacka/senatni-2022/70.json
@@ -422,7 +422,8 @@
             "twitter": "https://twitter.com/ZdenekNytra"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/70/senatni-2022-70-c-894640-face.jpg"
     },
     {
       "id": "senatni-2022-70-c-397158",
@@ -446,7 +447,8 @@
             "facebook": "https://www.facebook.com/liana.janackova.1"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/70/senatni-2022-70-c-397158-face.jpg"
     },
     {
       "id": "senatni-2022-70-c-550066",
@@ -510,7 +512,8 @@
             "facebook": "https://www.facebook.com/pharvanek"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/70/senatni-2022-70-c-254017-face.jpg"
     },
     {
       "id": "senatni-2022-70-c-635788",

--- a/data/kalkulacka/senatni-2022/73.json
+++ b/data/kalkulacka/senatni-2022/73.json
@@ -406,7 +406,8 @@
             "twitter": "https://twitter.com/folfik62"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/73/senatni-2022-73-c-245847-face.jpg"
     },
     {
       "id": "senatni-2022-73-c-817015",
@@ -498,7 +499,8 @@
             "instagram": "https://www.instagram.com/petrhamrozi/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/73/senatni-2022-73-c-866259-face.jpg"
     },
     {
       "id": "senatni-2022-73-c-795375",
@@ -534,7 +536,8 @@
             "instagram": "https://www.instagram.com/petrgawlas/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/73/senatni-2022-73-c-795375-face.jpg"
     }
   ],
   "answers": [

--- a/data/kalkulacka/senatni-2022/76.json
+++ b/data/kalkulacka/senatni-2022/76.json
@@ -390,7 +390,8 @@
             "facebook": "https://www.facebook.com/StarostaSeifert/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/76/senatni-2022-76-c-132112-face.jpg"
     },
     {
       "id": "senatni-2022-76-c-592201",
@@ -532,7 +533,8 @@
             "twitter": "https://twitter.com/jelinkovakdu?lang=cs"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/76/senatni-2022-76-c-651961-face.jpg"
     },
     {
       "id": "senatni-2022-76-c-161118",

--- a/data/kalkulacka/senatni-2022/79.json
+++ b/data/kalkulacka/senatni-2022/79.json
@@ -378,7 +378,8 @@
             "web": []
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/79/senatni-2022-79-c-228951-original.jpg"
     },
     {
       "id": "senatni-2022-79-c-231466",
@@ -518,7 +519,8 @@
             "facebook": "https://www.facebook.com/ivovasicekpolitik"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/79/senatni-2022-79-c-771797-face.jpg"
     },
     {
       "id": "senatni-2022-79-c-266442",
@@ -576,7 +578,8 @@
             "facebook": "https://www.facebook.com/zbynekdosenatu/"
           }
         }
-      ]
+      ],
+      "img_url": "data/avatars/senatni-2022/79/senatni-2022-79-c-811606-original.jpg"
     }
   ],
   "answers": [


### PR DESCRIPTION
There was a bug that we have not included path to already downloaded images, therefore they were being lost. This PR is fixing this.

`make run-add-images` - now adds all the already downloaded images

PR generating the data: #187