### PR TITLE
Few more Volební kalkulačka (CZ) archive 2022 fixes

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,2 +1,2 @@
-PUBLIC_URL=https://www.volebnikalkulacka.cz
+PUBLIC_URL=https://archiv.volebnikalkulacka.cz
 VITE_PUBLIC_URL=${PUBLIC_URL}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,10 +7,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://archiv.volebnikalkulacka.cz" />
-    <meta property="og:title" content="Archiv volebních kalkulaček" />
+    <meta property="og:title" content="Volební kalkulačka archiv 2022–2023" />
     <meta
       property="og:description"
-      content="9 prezidentských kandidátů. Kdo z nich bude reprezentovat vaše názory?"
+      content="Archiv Volební kalkulačky pro prezidentské volby 2023, komunální a senátní volby 2022. Aktuální kalkulačku najdete na www.volebnikalkulacka.cz"
     />
     <meta
       property="og:image"
@@ -24,16 +24,16 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Archiv volebních kalkulaček" />
+    <meta name="twitter:title" content="Volební kalkulačka archiv 2022–2023" />
     <meta
       name="twitter:description"
-      content="9 prezidentských kandidátů. Kdo z nich bude reprezentovat vaše názory?"
+      content="Archiv Volební kalkulačky pro prezidentské volby 2023, komunální a senátní volby 2022. Aktuální kalkulačku najdete na www.volebnikalkulacka.cz"
     />
     <meta
       name="twitter:image"
       content="https://archiv.volebnikalkulacka.cz/images/og-image-2023.png"
     />
-    <title>Archiv volebních kalkulaček</title>
+    <title>Volební kalkulačka archiv 2022–2023</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/frontend/src/components/design-system/style/LogoComponent.vue
+++ b/frontend/src/components/design-system/style/LogoComponent.vue
@@ -73,7 +73,7 @@ const handleClick = () => {
       v-if="props.text"
       :class="['logo--text', `logo--text-${props.size}`, logoMonochromatic]"
     >
-      Archiv volebních kalkulaček
+      Volební kalkulačka archiv 2022–2023
     </div>
   </div>
 </template>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -66,7 +66,7 @@ export const appRoutes = {
     path: '/',
     component: IndexPageVue,
     meta: {
-      title: 'Archiv volebních kalkulaček',
+      title: 'Volební kalkulačka archiv 2022–2023',
     },
   },
   aboutElections: {
@@ -83,7 +83,7 @@ export const appRoutes = {
     props: true,
     component: ErrorPageVue,
     meta: {
-      title: 'Error - Archiv volebních kalkulaček',
+      title: 'Error - Volební kalkulačka archiv 2022–2023',
     },
   },
   districtSelection: {
@@ -92,7 +92,7 @@ export const appRoutes = {
     alias: '/volby/:election',
     component: DistrictSelectionPageVue,
     meta: {
-      title: 'Archiv volebních kalkulaček',
+      title: 'Volební kalkulačka archiv 2022–2023',
     },
   },
   guide: {
@@ -101,7 +101,7 @@ export const appRoutes = {
     alias: '/volby/:election/:district',
     component: GuidePageVue,
     meta: {
-      title: 'Návod - Archiv volebních kalkulaček',
+      title: 'Návod - Volební kalkulačka archiv 2022–2023',
     },
   },
   question: {
@@ -109,7 +109,7 @@ export const appRoutes = {
     path: '/volby/:election/:district/otazka/:nr?',
     component: QuestionPageVue,
     meta: {
-      title: 'Otázka $$ - Archiv volebních kalkulaček',
+      title: 'Otázka $$ - Volební kalkulačka archiv 2022–2023',
       hasNumber: true,
     },
     beforeEnter: questionGuard,
@@ -119,7 +119,7 @@ export const appRoutes = {
     path: '/volby/:election/:district/rekapitulace',
     component: RecapPageVue,
     meta: {
-      title: 'Rekapitulace - Archiv volebních kalkulaček',
+      title: 'Rekapitulace - Volební kalkulačka archiv 2022–2023',
     },
   },
   result: {
@@ -127,7 +127,7 @@ export const appRoutes = {
     path: '/volby/:election/:district/vysledek',
     component: ResultPageVue,
     meta: {
-      title: 'Výsledky - Archiv volebních kalkulaček',
+      title: 'Výsledky - Volební kalkulačka archiv 2022–2023',
     },
   },
   comparison: {
@@ -135,7 +135,7 @@ export const appRoutes = {
     path: '/volby/:election/:district/srovnani',
     component: ComparisonPageVue,
     meta: {
-      title: 'Porovnaní - Archiv volebních kalkulaček',
+      title: 'Porovnaní - Volební kalkulačka archiv 2022–2023',
     },
   },
   fallback: {


### PR DESCRIPTION
- Update .env.production URL to archiv.volebnikalkulacka.cz
- Update LogoComponent to show "Archiv volebních kalkulaček 2022–2023"
- Update all route titles in main.ts to include "2022–2023"

🤖 Generated with [Claude Code](https://claude.com/claude-code)